### PR TITLE
Changes in pmag.fisher_mean()

### DIFF
--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4367,13 +4367,13 @@ def fillkeys(Recs):
     return OutRecs, keylist
 
 
-def fisher_mean(di_block):
+def fisher_mean(data):
     """
     Calculates the Fisher mean and associated parameter from a di_block.
 
     Parameters
     ----------
-    di_block : nested list of [dec,inc] or [dec,inc,intensity]
+    data : nested list of [dec,inc] or [dec,inc,intensity]
 
     Returns
     -------
@@ -4407,7 +4407,7 @@ def fisher_mean(di_block):
     X = np.array(dir2cart(di_block))
     Xbar = X.sum(axis=0)
     R = np.linalg.norm(Xbar)
-    Xbar /= R
+    Xbar = Xbar/R
     dir = cart2dir(Xbar)
 
     fpars["dec"] = dir[0]

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4398,13 +4398,13 @@ def fisher_mean(data):
      'alpha95': 6.414731246264079,
      'csd': 4.20876891770567}    
     """
-    N, fpars = len(di_block), {}
+    N, fpars = len(data), {}
     
     if N < 2: 
-        return {'dec': di_block[0][0], 
-                'inc': di_block[0][1]}
+        return {'dec': data[0][0], 
+                'inc': data[0][1]}
     
-    X = np.array(dir2cart(di_block))
+    X = np.array(dir2cart(data))
     Xbar = X.sum(axis=0)
     R = np.linalg.norm(Xbar)
     Xbar = Xbar/R

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -1,4 +1,3 @@
-
 import codecs
 import math
 import os
@@ -4399,24 +4398,23 @@ def fisher_mean(di_block):
      'alpha95': 6.414731246264079,
      'csd': 4.20876891770567}    
     """
-    R, Xbar, X, fpars = 0, [0, 0, 0], [], {}
-    N = len(data)
-    if N < 2:
-        return fpars
-    X = dir2cart(data)
-    for i in range(len(X)):
-        for c in range(3):
-            Xbar[c] += X[i][c]
-    for c in range(3):
-        R += Xbar[c]**2
-    R = np.sqrt(R)
-    for c in range(3):
-        Xbar[c] = Xbar[c]/R
+    N, fpars = len(di_block), {}
+    
+    if N < 2: 
+        return {'dec': di_block[0][0], 
+                'inc': di_block[0][1]}
+    
+    X = np.array(dir2cart(di_block))
+    Xbar = X.sum(axis=0)
+    R = np.linalg.norm(Xbar)
+    Xbar /= R
     dir = cart2dir(Xbar)
+
     fpars["dec"] = dir[0]
     fpars["inc"] = dir[1]
     fpars["n"] = N
     fpars["r"] = R
+    
     if N != R:
         k = (N - 1.) / (N - R)
         fpars["k"] = k


### PR DESCRIPTION
I made a few changes to the `pmag.fisher_mean()` functions: 

1. Change the computation of the mean value by using NumPy function instead of native for loops in Python. This shows a speedup of around x2/x3 in computations of the Fisher mean for ~100 points. This is important in simulations where Fisher means are computed multiple times and sometimes calls of the functions are nested. 
2. Added a default return when computing the fisher mean of a sample with one single point. For this case, it returns the inclination and declination of the single sample without computing the rest of the information. 
3. The original function has as argument `di_block`, but the function inside was making calls to a variable called `data`. I am not sure if this was a bug or if it was intentional, but the argument of the function seems not to be used inside the function.  

Since this is a core function of the package, it will be good to perform some tests to know this doesn't break any other part of the library. I made a few tests and it returns the same output that the original function but faster and accounting for exceptions 2 and 3. I tried to run the `python -m unittest discover` command suggested in the [testing README](https://github.com/PmagPy/PmagPy/blob/master/pmagpy_tests/README.md) but it returns errors, which I assume could be just for floating number approximations. For example,

<img width="555" alt="Screen Shot 2022-08-30 at 2 26 50 PM" src="https://user-images.githubusercontent.com/39526081/187436270-d05323ee-64ed-4a8f-b60d-865125bb6549.png">

seems to be comparing float numbers. Maybe by using [numpy.testing](https://numpy.org/doc/stable/reference/routines.testing.html) this won't give this error. 

Happy to continue working and exploring this if this seems to be a useful contribution to the project :) 