### PR TITLE
delete ipmag.plot_XY() as not used anywhere

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -1926,10 +1926,6 @@ def plot_net(fignum=None):
     plt.axis((-1.05, 1.05, -1.05, 1.05))
 
 
-def plot_XY(X=None, Y=None, sym='ro'):
-    plt.plot(X, Y, sym)
-
-
 def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize=20, legend='no', label='', title=None, edge=None,alpha=1):
     """
     Plot declination, inclination data on an equal area plot.


### PR DESCRIPTION
The function ipmag.plot_XY is a very limited wrapper around ```plt.plot()``` that is not used anywhere in our codebase nor anywhere else that I can find. I think it makes sense to delete from ipmag.py

```
def plot_XY(X=None, Y=None, sym='ro'):
    plt.plot(X, Y, sym)
```

