### PR TITLE
Add Bogue+Coe 1981 simul algo

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15257,3 +15257,42 @@ def validate_magic(top_dir,doi=False,private_key=False,contribution_id=False):
 
 
     return magic_dir,upload_file
+
+def prob_simul(alpha,k1,k2,wordy=False):
+    """
+    the function ipmag.prob_simul runs the Bogue + Coe (1981) algorithm for probabilistic correlation. k1 and k2 can be naively estimated from kappa
+    or one can use the function ipmag.full_kappa to get a better estimate as in the original publication
+    
+    Parameters
+    ----------
+    
+    alpha: angle between paleomagnetic directions (site means)
+    k1: kappa estimate for first direction
+    k2: kappa estimate for second direction
+    
+    Returns
+    --------------------------
+    
+    simul_prob
+    """
+    trials=10000
+
+    hit=0
+    miss=0
+
+    for i in range(trials):
+        #FakeFish returns a list of [dec,inc]s, in this case just 1.
+        lontp1,lattp1 = ipmag.fishrot(k1,1,0,90,di_block=False)
+        lontp2,lattp2 = ipmag.fishrot(k2,1,0,90,di_block=False)
+        angle=pmag.angle([lontp1[0],lattp1[0]],[lontp2[0],lattp2[0]])
+        if (angle>=alpha):
+            hit=hit+1
+        else:
+            miss=miss+1
+
+    p1=1.0*hit/trials
+    simul_prob=p1;
+    
+    if wordy == True:
+        print ('Probability of simultaneous directions is: {0:5.3f}'.format(p1))
+    return p1

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env/pythonw
+# -*- coding: cp1252 -*-
 
 import codecs
 import copy
@@ -15260,8 +15261,15 @@ def validate_magic(top_dir,doi=False,private_key=False,contribution_id=False):
 
 def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     """
-    the function ipmag.simul_correlation_prob runs the Bogue + Coe (1981) algorithm for probabilistic correlation. k1 and k2 can be estimated from typical kappa
-    or one can use the function ipmag.full_kappa [to come] to get a better estimate as in the original publication
+    The function ipmag.simul_correlation_prob runs an algorithm from Bogue and Coe (1981) for probabilistic correlation, evaluating
+    the probability that the similarity between two paleomagnetic directions is due to simultaneous sampling of the ancient magnetic field. 
+    This can be compared with the probability that the two directions were sampled at random times with the companion function
+    (ipmag.random_correlation_prob; to come). k1 and k2 can be estimated the kappa of the directions, or one can use the companion function 
+    (ipmag.full_kappa; to come) as in the original publication. A version of this function was written in Python by S. Bogue, translated
+    to PmagPy functionality by A. Pivarunas
+    
+    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical
+    Research, v. 86, p. 11883–11897.
     
     Parameters
     ----------
@@ -15277,24 +15285,26 @@ def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     
     simul_prob
     """
-    num_trials=trials
-
-    hit=0
-    miss=0
-
-    for i in range(num_trials):
-        #FakeFish returns a list of [dec,inc]s, in this case just 1.
+    #sets initial value for counters
+    hit = 0
+    miss = 0
+    
+    #trial loop
+    for i in range(trials):
+        #generates two synthetic directions, using the estimated kappas
         lontp1,lattp1 = ipmag.fishrot(k1, 1, 0, 90, di_block=False)
         lontp2,lattp2 = ipmag.fishrot(k2, 1, 0, 90, di_block=False)
+        #determines the angle between the generated directions 
         angle=pmag.angle([lontp1[0], lattp1[0]], [lontp2[0], lattp2[0]])
-        if (angle>=alpha):
-            hit=hit+1
+        #checks if angle between synthetic directions meets or exceeds 'known' angle from directions to be tested
+        if (angle >= alpha):
+            hit = hit + 1
         else:
-            miss=miss+1
-
-    p1=1.0*hit/num_trials
-    simul_prob=p1;
+            miss = miss + 1
+    #calculates probability based on how often the angle between the 'real' datasets is met or exceeded
+    simul_prob = 1.0 * hit / trials
     
     if print_result == True:
-        print ('Probability of simultaneous directions is: {0:5.3f}'.format(p1))
-    return p1
+        print ('The probability that directions represent simultaneous samples of the geomagnetic field is: {0:5.3f}'.format(simul_prob))
+    else:
+        return simul_prob

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15258,10 +15258,10 @@ def validate_magic(top_dir,doi=False,private_key=False,contribution_id=False):
 
     return magic_dir,upload_file
 
-def prob_simul(alpha,k1,k2,wordy=False):
+def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     """
-    the function ipmag.prob_simul runs the Bogue + Coe (1981) algorithm for probabilistic correlation. k1 and k2 can be naively estimated from kappa
-    or one can use the function ipmag.full_kappa to get a better estimate as in the original publication
+    the function ipmag.simul_correlation_prob runs the Bogue + Coe (1981) algorithm for probabilistic correlation. k1 and k2 can be estimated from typical kappa
+    or one can use the function ipmag.full_kappa [to come] to get a better estimate as in the original publication
     
     Parameters
     ----------
@@ -15269,30 +15269,32 @@ def prob_simul(alpha,k1,k2,wordy=False):
     alpha: angle between paleomagnetic directions (site means)
     k1: kappa estimate for first direction
     k2: kappa estimate for second direction
+    trials: the number of simulations, default=10,000
+    print_result: the probability value returned in a sentence, default=False
     
     Returns
     --------------------------
     
     simul_prob
     """
-    trials=10000
+    num_trials=trials
 
     hit=0
     miss=0
 
-    for i in range(trials):
+    for i in range(num_trials):
         #FakeFish returns a list of [dec,inc]s, in this case just 1.
-        lontp1,lattp1 = ipmag.fishrot(k1,1,0,90,di_block=False)
-        lontp2,lattp2 = ipmag.fishrot(k2,1,0,90,di_block=False)
-        angle=pmag.angle([lontp1[0],lattp1[0]],[lontp2[0],lattp2[0]])
+        lontp1,lattp1 = ipmag.fishrot(k1, 1, 0, 90, di_block=False)
+        lontp2,lattp2 = ipmag.fishrot(k2, 1, 0, 90, di_block=False)
+        angle=pmag.angle([lontp1[0], lattp1[0]], [lontp2[0], lattp2[0]])
         if (angle>=alpha):
             hit=hit+1
         else:
             miss=miss+1
 
-    p1=1.0*hit/trials
+    p1=1.0*hit/num_trials
     simul_prob=p1;
     
-    if wordy == True:
+    if print_result == True:
         print ('Probability of simultaneous directions is: {0:5.3f}'.format(p1))
     return p1


### PR DESCRIPTION
This adds the Bogue and Coe (1981) simultaneous algorithm functionality. This allows users to check the probability of correlating two directions with known precision parameter estimates and a known angle between them. This was written in Python by Scott Bogue, and I translated it into PmagPy functionality to hopefully make it more widely available.

This is my first time doing a commit. I'd like to start helping with this project more in the future.

Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical Research, v. 86, p. 11883–11897.