### PR TITLE
added the 'random' probability test of Bogue and Coe 1981

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15265,7 +15265,7 @@ def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     for probabilistic correlation, evaluating the probability that the similarity between 
     two paleomagnetic directions is due to simultaneous sampling of the ancient magnetic 
     field. This can be compared with the probability that the two directions were sampled 
-    at random times with the companion function (ipmag.random_correlation_prob). 
+    at random times with the companion function (ipmag.random_correlation_prob; to come). 
     k1 and k2 can be estimated the kappa of the  directions, or one can use the companion 
     function (ipmag.full_kappa; to come) as in the original publication. 
     

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15269,7 +15269,7 @@ def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     to PmagPy functionality by A. Pivarunas
     
     Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical
-    Research, v. 86, p. 11883–11897.
+    Research, v. 86, p. 11883ï¿½11897.
     
     Parameters
     ----------
@@ -15320,7 +15320,7 @@ def rand_correlation_prob(sec_var, delta1, delta2, alpha, trials=10000, print_re
     to PmagPy functionality by A. Pivarunas
     
     Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical
-    Research, v. 86, p. 11883–11897.
+    Research, v. 86, p. 11883ï¿½11897.
     
     Parameters
     ----------
@@ -15372,5 +15372,5 @@ def rand_correlation_prob(sec_var, delta1, delta2, alpha, trials=10000, print_re
    
     if print_result == True:
         print ('The probability (average of P1 and P2) that directions represent random samples of the geomagnetic field is: {0:5.3f}'.format((prand1+prand2)/2))
-    else:
-        return rand_prob
+    
+    return rand_prob

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15308,3 +15308,69 @@ def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
         print ('The probability that directions represent simultaneous samples of the geomagnetic field is: {0:5.3f}'.format(simul_prob))
     else:
         return simul_prob
+
+def rand_correlation_prob(sec_var, delta1, delta2, alpha, trials=10000, print_result=False):
+
+    """
+    This function does a brute force numerical simulation of the 'random' hypothesis of Bogue + Coe (1981). Basically asks and answers
+    the question: if we randomly sampled the ancient field, how frequently would we get two VGPs that are both this far from the time-averaged pole and this
+    close together?  Approach is, assume VGP1 observed first, pull a random direction from Fisher distribution about mean pole with k. If it is within alpha
+    of VGP1, hit. If not, miss. Repeat many (10,000?) times. P(Hr)1 = hit/(trials). Then, repeat this process with VGP2, getting
+    P(Hr)2. The returned probability is the average of the two. A version of this function was written in Python by S. Bogue, translated
+    to PmagPy functionality by A. Pivarunas
+    
+    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical
+    Research, v. 86, p. 11883–11897.
+    
+    Parameters
+    ----------
+    
+    sec_var: kappa estimate of regional secular variation (probably 30 or 40)
+    alpha: angle between paleomagnetic directions (or poles)
+    delta1: distance of direction 1 from mean direction
+    delta2: distance of direction 2 from mean direction
+    trials: the number of simulations, default=10,000
+    print_result: the probability value returned in a sentence, default=False 
+    
+    Returns
+    --------------------------
+    
+    rand_prob
+    
+    """
+
+    #calc probability of getting vgp within alpha of vgp1
+    i = 0
+    miss = 0
+    hit = 0
+    for i in range(trials):
+        dec,inc = ipmag.fishrot(sec_var, 1, 0, 0, di_block=False)
+        angle = pmag.angle([dec[0], inc[0]], [0, delta1])
+        if (angle <= alpha):
+            hit = hit + 1
+        else:
+            miss = miss + 1 
+
+    prand1=(1.0 * hit) / trials
+    #print ('P1(Hr): ',prand1);
+
+    #calc probability of getting vgp within alpha of vgp2
+    i = 0
+    hit = 0
+    miss = 0
+    for i in range(trials):
+        dec, inc = ipmag.fishrot(sec_var, 1, 0, 0, di_block=False)
+        angle = pmag.angle([dec[0], inc[0]], [0,delta2])
+        if (angle <= alpha):
+            hit = hit + 1
+        else:
+            miss = miss + 1
+
+    prand2=(1.0 * hit) / trials
+    #the average of the two trials is the probability of the "random" hypothesis
+    rand_prob = np.round((prand1 + prand2) / 2, 4)
+   
+    if print_result == True:
+        print ('The probability (average of P1 and P2) that directions represent random samples of the geomagnetic field is: {0:5.3f}'.format((prand1+prand2)/2))
+    else:
+        return rand_prob

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15261,32 +15261,24 @@ def validate_magic(top_dir,doi=False,private_key=False,contribution_id=False):
 
 def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     """
-    The function ipmag.simul_correlation_prob runs an algorithm from Bogue and
-    Coe (1981) for probabilistic correlation, evaluating the probability that
-    the similarity between two paleomagnetic directions is due to simultaneous 
-    sampling of the ancient magnetic field. This can be compared with the 
-    probability that the two directions were sampled at random times with the 
-    companion function (ipmag.random_correlation_prob). k1 and k2 can be 
-    estimated the kappa of the directions, or one can use the companion 
+    The function runs an algorithm from Bogue and Coe (1981; doi: 10.1029/JB086iB12p11883) 
+    for probabilistic correlation, evaluating the probability that the similarity between 
+    two paleomagnetic directions is due to simultaneous sampling of the ancient magnetic 
+    field. This can be compared with the probability that the two directions were sampled 
+    at random times with the companion function (ipmag.random_correlation_prob). 
+    k1 and k2 can be estimated the kappa of the  directions, or one can use the companion 
     function (ipmag.full_kappa; to come) as in the original publication. 
-    A version of this function was written in Python by S. Bogue, translated
-    to PmagPy functionality by A. Pivarunas
     
-    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia 
-    River basalt flows using secular variation. Journal of Geophysical
-    Research, v. 86, p. 11883-11897.
+    Parameters:
+        alpha : angle between paleomagnetic directions (site means)
+        k1 (float): kappa estimate for first direction
+        k2 (float): kappa estimate for second direction
+        trials (int): the number of simulations [default = 10,000]
+        print_result (boolean): the probability value returned in a sentence [default = False]
     
-    Parameters
-    ----------
-    alpha: angle between paleomagnetic directions (site means)
-    k1: kappa estimate for first direction
-    k2: kappa estimate for second direction
-    trials: the number of simulations, default=10,000
-    print_result: the probability value returned in a sentence, default=False
-    
-    Returns
-    --------------------------
-    simul_prob
+    Returns:
+        float 
+            number indicating probability value
     """
     #sets initial value for counters
     hit = 0

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -15261,19 +15261,23 @@ def validate_magic(top_dir,doi=False,private_key=False,contribution_id=False):
 
 def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     """
-    The function ipmag.simul_correlation_prob runs an algorithm from Bogue and Coe (1981) for probabilistic correlation, evaluating
-    the probability that the similarity between two paleomagnetic directions is due to simultaneous sampling of the ancient magnetic field. 
-    This can be compared with the probability that the two directions were sampled at random times with the companion function
-    (ipmag.random_correlation_prob; to come). k1 and k2 can be estimated the kappa of the directions, or one can use the companion function 
-    (ipmag.full_kappa; to come) as in the original publication. A version of this function was written in Python by S. Bogue, translated
+    The function ipmag.simul_correlation_prob runs an algorithm from Bogue and
+    Coe (1981) for probabilistic correlation, evaluating the probability that
+    the similarity between two paleomagnetic directions is due to simultaneous 
+    sampling of the ancient magnetic field. This can be compared with the 
+    probability that the two directions were sampled at random times with the 
+    companion function (ipmag.random_correlation_prob). k1 and k2 can be 
+    estimated the kappa of the directions, or one can use the companion 
+    function (ipmag.full_kappa; to come) as in the original publication. 
+    A version of this function was written in Python by S. Bogue, translated
     to PmagPy functionality by A. Pivarunas
     
-    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical
-    Research, v. 86, p. 11883�11897.
+    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia 
+    River basalt flows using secular variation. Journal of Geophysical
+    Research, v. 86, p. 11883-11897.
     
     Parameters
     ----------
-    
     alpha: angle between paleomagnetic directions (site means)
     k1: kappa estimate for first direction
     k2: kappa estimate for second direction
@@ -15282,7 +15286,6 @@ def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
     
     Returns
     --------------------------
-    
     simul_prob
     """
     #sets initial value for counters
@@ -15312,30 +15315,35 @@ def simul_correlation_prob(alpha, k1, k2, trials=10000, print_result=False):
 def rand_correlation_prob(sec_var, delta1, delta2, alpha, trials=10000, print_result=False):
 
     """
-    This function does a brute force numerical simulation of the 'random' hypothesis of Bogue + Coe (1981). Basically asks and answers
-    the question: if we randomly sampled the ancient field, how frequently would we get two VGPs that are both this far from the time-averaged pole and this
-    close together?  Approach is, assume VGP1 observed first, pull a random direction from Fisher distribution about mean pole with k. If it is within alpha
-    of VGP1, hit. If not, miss. Repeat many (10,000?) times. P(Hr)1 = hit/(trials). Then, repeat this process with VGP2, getting
-    P(Hr)2. The returned probability is the average of the two. A version of this function was written in Python by S. Bogue, translated
+    This function does a brute force numerical simulation of the 'random' 
+    hypothesis of Bogue + Coe (1981). Basically asks and answers the question:
+    if we randomly sampled the ancient field, how frequently would we get two
+    VGPs that are both this far from the time-averaged pole and this close 
+    together?  Approach is, assume VGP1 observed first, pull a random 
+    direction from Fisher distribution about mean pole with k. If it is within
+    alpha of VGP1, hit. If not, miss. Repeat many (10,000?) times. 
+    P(Hr)1 = hit/(trials). Then, repeat this process with VGP2, getting
+    P(Hr)2. The returned probability is the average of the two.
+    
+    A version of this function was written in Python by S. Bogue, translated
     to PmagPy functionality by A. Pivarunas
     
-    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia River basalt flows using secular variation. Journal of Geophysical
-    Research, v. 86, p. 11883�11897.
+    Bogue, S.W., and Coe, R.S., 1981, Paleomagnetic correlation of Columbia 
+    River basalt flows using secular variation. Journal of Geophysical
+    Research, v. 86, p. 11883-11897.
     
     Parameters
     ----------
-    
     sec_var: kappa estimate of regional secular variation (probably 30 or 40)
     alpha: angle between paleomagnetic directions (or poles)
     delta1: distance of direction 1 from mean direction
     delta2: distance of direction 2 from mean direction
     trials: the number of simulations, default=10,000
-    print_result: the probability value returned in a sentence, default=False 
+    print_result: the probability value printed as a sentence, default=False 
     
     Returns
     --------------------------
-    
-    rand_prob
+    rand_prob 
     
     """
 


### PR DESCRIPTION
Have now added the 'random' algorithm of Bogue and Coe (1981). This tests the alternative scenario to the 'simul' algorithm (i.e., the probability of the directions being acquired at different times).

function is named 'rand_correlation_prob' in order to mirror 'simul_correlation_prob'

Next plan is to improve docstrings for both with examples.