### PR TITLE
Efficient implementation of Fisher samples + Test suite using PyTest

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -488,7 +488,7 @@ def print_kent_mean(mean_dictionary):
 def fishrot(k=20, n=100, dec=0, inc=90, di_block=True):
     """
     Generates Fisher distributed unit vectors from a specified distribution
-    using the pmag.py function pmag.fshdev() and pmag.dodirot() functions.
+    using the pmag.py function pmag.fshdev() and pmag.dodirot_V() functions.
 
     Parameters:
         k : kappa precision parameter (default is 20)
@@ -504,28 +504,24 @@ def fishrot(k=20, n=100, dec=0, inc=90, di_block=True):
 
     Examples:
         >>> ipmag.fishrot(k=20, n=5, dec=40, inc=60)
-        [[44.766285502555775, 37.440866867657235, 1.0],
-        [33.866315796883725, 64.732532250463436, 1.0],
-        [47.002912770597163, 54.317853800896977, 1.0],
-        [36.762165614432547, 56.857240672884252, 1.0],
-        [71.43950604474395, 59.825830945715431, 1.0]]
+        array([[55.30451720381376 , 56.186057037482435,  1.               ],
+               [25.593998008087908, 63.544360587984784,  1.               ],
+               [29.263675539971246, 54.58964868129066 ,  1.               ],
+               [61.28572459596148 , 51.5004074156194  ,  1.               ],
+               [55.20784339888985 , 54.186746152272484,  1.               ]])
     """
-    directions = []
-    declinations = []
-    inclinations = []
-    if di_block == True:
-        for data in range(n):
-            d, i = pmag.fshdev(k)
-            drot, irot = pmag.dodirot(d, i, dec, inc)
-            directions.append([drot, irot, 1.])
-        return directions
+    
+    # Generation of samples
+    declinations, inclinations = pmag.fshdev(np.repeat(k, n))
+
+    # Rotation to have desired mean direction
+    resampled_di = np.array([declinations, inclinations, np.repeat(1, n)]).T
+    resampled_di_rotated = pmag.dodirot_V(resampled_di, np.repeat(dec, n), np.repeat(inc, n))    
+
+    if di_block: 
+        return np.insert(resampled_di_rotated, 2, np.ones(n), axis=1) 
     else:
-        for data in range(n):
-            d, i = pmag.fshdev(k)
-            drot, irot = pmag.dodirot(d, i, dec, inc)
-            declinations.append(drot)
-            inclinations.append(irot)
-        return declinations, inclinations
+        return resampled_di_rotated[:,0], resampled_di_rotated[:,1]
     
     
 def fisher_mean_resample(alpha95=20, n=100, dec=0, inc=90, di_block=True):

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -515,7 +515,7 @@ def fishrot(k=20, n=100, dec=0, inc=90, di_block=True):
     declinations, inclinations = pmag.fshdev(np.repeat(k, n))
 
     # Rotation to have desired mean direction
-    resampled_di = np.array([declinations, inclinations, np.repeat(1, n)]).T
+    resampled_di = np.vstack([declinations, inclinations]).T
     resampled_di_rotated = pmag.dodirot_V(resampled_di, np.repeat(dec, n), np.repeat(inc, n))    
 
     if di_block: 

--- a/pmagpy/test/test_fisher_sample.py
+++ b/pmagpy/test/test_fisher_sample.py
@@ -1,0 +1,20 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from pmagpy.ipmag import fishrot
+
+def test_fishrot_type_1():
+    res = fishrot(k=10, n=1, di_block=False)
+    assert len(res)==2 and res[0].shape == (1,)
+    
+def test_fishrot_type_1_diblock():
+    res = fishrot(k=10, n=1, di_block=True)
+    assert res.shape == (1,3)
+    
+def test_fishrot_type_n():
+    res = fishrot(k=10, n=5, di_block=False)
+    assert len(res)==2 and res[0].shape == (5,)
+    
+def test_fishrot_type_n_diblock():
+    res = fishrot(k=10, n=5, di_block=True)
+    assert res.shape == (5,3)

--- a/pmagpy/test/test_igrf.py
+++ b/pmagpy/test/test_igrf.py
@@ -1,0 +1,14 @@
+from pmagpy import ipmag
+from numpy.testing import assert_allclose
+
+
+def test_IGRF():
+    
+    result = ipmag.igrf([1999, 30, 20, 50])
+    reference = [1.20288657e+00, 2.82331112e+01, 3.9782338913649881e+04]
+
+    print(result, reference)
+    
+    assert_allclose(result, reference, rtol=.1)
+
+

--- a/pmagpy/test/test_rotations.py
+++ b/pmagpy/test/test_rotations.py
@@ -1,0 +1,21 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from pmagpy.pmag import dodirot, dodirot_V
+
+def test_dodirot_type():
+    assert isinstance(dodirot(0,90,5,85), tuple)
+
+def test_dodirot_1():
+    assert_allclose(dodirot(0,90,5,85), (5.0, 85.0), rtol=10e-4)
+    
+def test_dodirot_V_type():
+    di_array = np.array([[0,90],[0,90],[0,90]])
+    assert isinstance(dodirot_V(di_array,5,15), np.ndarray)
+
+def test_dodirot_V_1():
+    di_array = np.array([[0,90],[0,90],[0,90]])
+    result = np.array([[ 5., 15.],
+                       [ 5., 15.],
+                       [ 5., 15.]])
+    assert_allclose(dodirot_V(di_array,5,15), result, rtol=10e-4)


### PR DESCRIPTION
This PR implements:
- Changes in the function `fishrot` used to sample from a Fisher distribution. See this [issue](https://github.com/PolarWandering/PaleoSampling/issues/9) for more information about changes. 
- Test suite using Pytest. The folder `pmagpy/test` has a series of tests that can be automatically executed by entering `pytest` in a terminal inside the folder `pmagpy`. We can also automatize this by adding it to CI with GH Actions (see [here](https://ucb-stat-159-s23.github.io/site/lectures/testing/workflow.html) for information of how to do this). 