### PR TITLE
Add common_mean_bootstrap_H23() and reversal_test_bootstrap_H23()

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -409,6 +409,7 @@ def mean_bootstrap_confidence(dec=None,inc=None,di_block=None,num_sims=10000,alp
     References:
         Heslop, D., Scealy, J. L., Wood, A. T. A., Tauxe, L., & Roberts, A. P. (2023). 
         A bootstrap common mean direction test. Journal of Geophysical Research: Solid Earth, 128, e2023JB026983.
+        https://doi.org/10.1029/2023JB026983
     """
     
     if di_block is None:


### PR DESCRIPTION
This pull request brings in functions to ipmag that enable ready access to the new advance of @dave-heslop74 that enables the bootstrap common mean test to be put within a null hypothesis significance testing framework. It utilizes the functions within pmag.py that were also used in #703 and wraps the code of https://github.com/dave-heslop74/Bootstrap-CMDT/tree/v.1.0.0 within ipmag.py style functions. 