### PR TITLE
Get reload from importlib rather than imp

### DIFF
--- a/pmagpy/find_pmag_dir.py
+++ b/pmagpy/find_pmag_dir.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-from imp import reload
+from importlib import reload
 import os
 import sys
 


### PR DESCRIPTION
When installing PmagPy on a new computer, I ran into an error related to the command:

`from imp import reload` 

in the file find_pmag_dir.py

Looks like this is an issue related to Python 3.12, see https://docs.python.org/3/whatsnew/3.12.html#imp. Looking around in the code, looks like most other usages are:

`from importlib import reload`

Must have been the last holdout. Switched it to the correct line. Easy peasy.