### PR TITLE
Bug in dealing with files without dec_corr assigned

### DIFF
--- a/pmagpy/convert_2_magic.py
+++ b/pmagpy/convert_2_magic.py
@@ -257,9 +257,9 @@ def _2g_bin(dir_path=".", mag_file="", dec_corr=True,meas_file='measurements.txt
             if dec_corr: # ADDED 3/3/21
                 if rec[el].isdigit(): 
                     deccorr=float(rec[el])
+                el+=1
             else:
                 deccorr=0
-            el+=1
             while rec[el] == "":
                 el += 1
             az = float(rec[el])


### PR DESCRIPTION
For 2G binary files where dec_corr is not provided, the present behavior (modified in 2021) skips the azimuth value and assigns the plunge value to the azimuth variable. 