### PR TITLE
Resolving issue #668 connect points

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -2211,12 +2211,12 @@ def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize
 
     if len(X_up) > 0:
         if connect_points == True:
-            plt.plot(X_up, Y_up, ls = '-', linewidth=0.5, color ='k', alpha = alpha, zorder=1)
+            plt.plot(X_up, Y_up, ls = '-', linewidth=0.25, color ='k', alpha = alpha, zorder=1)
         plt.scatter(X_up, Y_up, facecolors='none', edgecolors=color_up,
                     s=markersize, marker=marker, label=label,alpha=alpha, zorder=zorder)
     if len(X_down) > 0:
         if connect_points == True:
-            plt.plot(X_down, Y_down, ls = '-', linewidth=0.5, color ='k', alpha = alpha, zorder=1)
+            plt.plot(X_down, Y_down, ls = '-', linewidth=0.25, color ='k', alpha = alpha, zorder=1)
         plt.scatter(X_down, Y_down, facecolors=color_down, edgecolors=edge,
                     s=markersize, marker=marker, label=label,alpha=alpha, zorder=zorder)
     if legend == 'yes':

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -2142,7 +2142,7 @@ def plot_net(fignum=None,tick_spacing=10):
     plt.axis((-1.05, 1.05, -1.05, 1.05))
 
 
-def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize=20, legend='no', label='', title=None, edge=None,alpha=1, zorder=2):
+def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize=20, legend='no', label='', connect_points=False, title=None, edge=None, alpha=1, zorder=2):
     """
     Plot declination, inclination data on an equal area plot.
 
@@ -2159,8 +2159,10 @@ def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize
         color : the default color is black. Other colors can be chosen (e.g. 'r')
         marker : the default marker is a circle ('o')
         markersize : default size is 20
-        label : the default label is blank ('')
         legend : the default is no legend ('no'). Putting 'yes' will plot a legend.
+        label : the default label is blank ('')
+        connect_points : option to connect points in order of plotting, default is False
+        title : the default title is False
         edge : marker edge color - if blank, is color of marker
         alpha : opacity
         zorder : zorder of marker
@@ -2208,10 +2210,13 @@ def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize
             color_up.append(color)
 
     if len(X_up) > 0:
+        if connect_points == True:
+            plt.plot(X_up, Y_up, ls = '-', linewidth=0.5, color ='k', alpha = alpha, zorder=1)
         plt.scatter(X_up, Y_up, facecolors='none', edgecolors=color_up,
                     s=markersize, marker=marker, label=label,alpha=alpha, zorder=zorder)
-
     if len(X_down) > 0:
+        if connect_points == True:
+            plt.plot(X_down, Y_down, ls = '-', linewidth=0.5, color ='k', alpha = alpha, zorder=1)
         plt.scatter(X_down, Y_down, facecolors=color_down, edgecolors=edge,
                     s=markersize, marker=marker, label=label,alpha=alpha, zorder=zorder)
     if legend == 'yes':

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -2142,7 +2142,7 @@ def plot_net(fignum=None,tick_spacing=10):
     plt.axis((-1.05, 1.05, -1.05, 1.05))
 
 
-def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize=20, legend='no', label='', connect_points=False, title=None, edge=None, alpha=1, zorder=2):
+def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize=20, legend='no', label='', connect_points=False, lw=0.25, lc='k', la=0.5, title=None, edge=None, alpha=1, zorder=2):
     """
     Plot declination, inclination data on an equal area plot.
 
@@ -2162,6 +2162,9 @@ def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize
         legend : the default is no legend ('no'). Putting 'yes' will plot a legend.
         label : the default label is blank ('')
         connect_points : option to connect points in order of plotting, default is False
+        lw : linewidth of connecting lines
+        lc : color of connecting lines
+        la : alpha of connecting lines
         title : the default title is False
         edge : marker edge color - if blank, is color of marker
         alpha : opacity
@@ -2211,12 +2214,12 @@ def plot_di(dec=None, inc=None, di_block=None, color='k', marker='o', markersize
 
     if len(X_up) > 0:
         if connect_points == True:
-            plt.plot(X_up, Y_up, ls = '-', linewidth=0.25, color ='k', alpha = alpha, zorder=1)
+            plt.plot(X_up, Y_up, ls = '-', linewidth=lw, color =lc, alpha = la, zorder=1)
         plt.scatter(X_up, Y_up, facecolors='none', edgecolors=color_up,
                     s=markersize, marker=marker, label=label,alpha=alpha, zorder=zorder)
     if len(X_down) > 0:
         if connect_points == True:
-            plt.plot(X_down, Y_down, ls = '-', linewidth=0.25, color ='k', alpha = alpha, zorder=1)
+            plt.plot(X_down, Y_down, ls = '-', linewidth=lw, color =lc, alpha = la, zorder=1)
         plt.scatter(X_down, Y_down, facecolors=color_down, edgecolors=edge,
                     s=markersize, marker=marker, label=label,alpha=alpha, zorder=zorder)
     if legend == 'yes':


### PR DESCRIPTION
This pull request fixes issue #668. Added capability to ipmag.plot_di to be able to connect points by using a "connect_points" flag in the function call. Flag is set to False, so the capability is an opt-in. Works for normal directions and reverse directions but does not connect normal directions _to_ reverse directions. I think that's fine.

Linewidth is 0.25 pt, and color is black for the most neutrality. Linewidth was thinned after feedback. 