### PR TITLE
Adding ability to save plots to specified directory

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -12346,7 +12346,7 @@ def zeq_magic(meas_file='measurements.txt', spec_file='',crd='s', dir_path = "."
     dir_path : str
         output directory for plots, default "."
     input_dir_path : str
-        input directory, if different from dir_path, default "."
+        input directory, if different from dir_path, default ""
     angle : float
         angle of X direction with respect to specimen X
     n_plots : int, default 5

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -12327,7 +12327,7 @@ def atrm_magic(meas_file, dir_path=".", input_dir_path="",
 
 
 
-def zeq_magic(meas_file='measurements.txt', spec_file='',crd='s',input_dir_path='.', angle=0,
+def zeq_magic(meas_file='measurements.txt', spec_file='',crd='s', dir_path = ".", input_dir_path="", angle=0,
               n_plots=5, save_plots=True, fmt="svg", interactive=False, specimen="",
               samp_file='samples.txt', contribution=None,fignum=1, image_records=False):
     """
@@ -12343,8 +12343,10 @@ def zeq_magic(meas_file='measurements.txt', spec_file='',crd='s',input_dir_path=
     crd : str
         coordinate system [s,g,t] for specimen, geographic, tilt corrected
         g,t options require a sample file with specimen and bedding orientation
+    dir_path : str
+        output directory for plots, default "."
     input_dir_path : str
-        input directory of meas_file, default "."
+        input directory, if different from dir_path, default "."
     angle : float
         angle of X direction with respect to specimen X
     n_plots : int, default 5
@@ -12682,7 +12684,7 @@ def zeq_magic(meas_file='measurements.txt', spec_file='',crd='s',input_dir_path=
                               'software_packages': version.version}
                 image_recs.append(image_rec)
         if save_plots:
-            saved.extend(pmagplotlib.save_plots(ZED, titles))
+            saved.extend(pmagplotlib.save_plots(ZED, titles, dir_path=dir_path))
         elif interactive:
             pmagplotlib.draw_figs(ZED)
             ans = pmagplotlib.save_or_quit()
@@ -14065,7 +14067,7 @@ def eqarea_magic(in_file='sites.txt', dir_path=".", input_dir_path="",
             FIG = pmagplotlib.add_borders(FIG, titles, con_id=con_id)
             saved_figs = pmagplotlib.save_plots(FIG, files)
         elif save_plots:
-            saved_figs = pmagplotlib.save_plots(FIG, files, incl_directory=True)
+            saved_figs = pmagplotlib.save_plots(FIG, files, dir_path = dir_path, incl_directory=True)
             #continue
         elif interactive:
             pmagplotlib.draw_figs(FIG)

--- a/pmagpy/pmagplotlib.py
+++ b/pmagpy/pmagplotlib.py
@@ -31,7 +31,7 @@ if has_cartopy:
     from cartopy.feature import NaturalEarthFeature, LAND, COASTLINE, OCEAN, LAKES, BORDERS
 has_basemap, Basemap = pmag.import_basemap()
 
-
+import os
 import matplotlib
 from matplotlib import cm as color_map
 from matplotlib import pyplot as plt
@@ -1597,7 +1597,7 @@ def plot_teq(fignum, araiblock, s, pars):
     plt.text(-1.1, 1.15, s)
 
 
-def save_plots(Figs, filenames, **kwargs):
+def save_plots(Figs, filenames, dir_path=None, **kwargs):
     """
     Parameters
     ----------
@@ -1606,6 +1606,9 @@ def save_plots(Figs, filenames, **kwargs):
     filenames : dict
         dictionary of filenames, e.g. {'eqarea': 'mc01a_eqarea.svg', ...}
         dict keys should correspond with Figs
+    dir_path : str
+        string of directory name where plots will be saved to
+    kwargs: other keyword arguments
     """
     saved = []
     for key in list(Figs.keys()):
@@ -1628,7 +1631,7 @@ def save_plots(Figs, filenames, **kwargs):
             elif isServer:
                 plt.savefig(fname, dpi=240)
             else:
-                plt.savefig(fname)
+                plt.savefig(os.path.join(dir_path, fname))
             if verbose:
                 print(Figs[key], " saved in ", fname)
             saved.append(fname)

--- a/pmagpy/pmagplotlib.py
+++ b/pmagpy/pmagplotlib.py
@@ -1627,7 +1627,7 @@ def save_plots(Figs, filenames, dir_path=None, **kwargs):
             else:
                 fname = fname.replace('/', '-') # flatten file name
             if 'dpi' in list(kwargs.keys()):
-                plt.savefig(fname, dpi=kwargs['dpi'])
+                plt.savefig(os.path.join(dir_path, fname), dpi=kwargs['dpi'])
             elif isServer:
                 plt.savefig(fname, dpi=240)
             else:
@@ -1641,7 +1641,6 @@ def save_plots(Figs, filenames, dir_path=None, **kwargs):
             print('could not save: ', Figs[key], filenames[key])
             print("output file format not supported ")
     return saved
-#
 
 
 def plot_evec(fignum, Vs, symsize, title):


### PR DESCRIPTION
Dealing with issue #705. I tracked this down to pmagplotlib.py, the function `pmagplotlib.save_plots`. No directory was specified in that function so it would just save to local. I have now added the ability for both `ipmag.eq_area_magic` and `ipmag.zeq_magic` to send the dir_path to pmagplotlib and the files get saved to the correct directory.

I tested it in the Inspecting_MagIC_directional_data.ipynb pmagpy-docs notebook*, and it worked.

*The Inspecting_MagIC_directional_data.ipynb pmagpy-docs notebook does not run very well in its present state. The function `ipmag.download_magic_from_doi()` does not have the correct parameters, and I don't think there is a function `ipmag.list_MagIC_names()`. I had to change the initial function to `ipmag.download_magic_from_id()` which seemed to better match the relevant inputs and outputs. The MagIC ID in question is "19640".