### PR TITLE
switch order of SPD.lib and SPD.spd imports

### DIFF
--- a/SPD/__init__.py
+++ b/SPD/__init__.py
@@ -8,7 +8,7 @@
 #print "initialized in SPD_project directory"
 #import os
 #print 'cwd', os.getcwd()
-import SPD.spd
 import SPD.lib
+import SPD.spd
 SPD.magic_file = 'SPD/magic_measurements.txt'
 


### PR DESCRIPTION
This commit implements the suggestion of @tmchaffee associated with this issue https://github.com/PmagPy/PmagPy/issues/710
@tmchaffee wrote:
> Hello, I had the same issue and was able to fix the circular import by changing the import order in the SPD module **init**.py file
> 
> The original order was
> 
> import SPD.spd import SPD.lib
> 
> Switching these so SPD.spd is imported second allows the module to successfullly import SPD.lib.
> 
> Cheers, Thom Chaffee
This switch is made to the SPD imports in the commit associated with this pull request.