### PR TITLE
Ani depthplot fix

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -4201,7 +4201,7 @@ def ani_depthplot(spec_file='specimens.txt', samp_file='samples.txt',
             ax6 = plt.subplot(1, pcol, 5)
             Axs.append(ax6)
             ax6.plot(Bulks, BulkDepths, 'bo')
-            #ax6.axis([bmin - 1, 1.1 * bmax, dmax, dmin])
+            ax6.set_ylim(dmax, dmin)
             ax6.set_xlabel('Bulk Susc. (uSI)')
             ax6.yaxis.set_major_locator(plt.NullLocator())
             if sum_file:

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -4201,7 +4201,7 @@ def ani_depthplot(spec_file='specimens.txt', samp_file='samples.txt',
             ax6 = plt.subplot(1, pcol, 5)
             Axs.append(ax6)
             ax6.plot(Bulks, BulkDepths, 'bo')
-            ax6.axis([bmin - 1, 1.1 * bmax, dmax, dmin])
+            #ax6.axis([bmin - 1, 1.1 * bmax, dmax, dmin])
             ax6.set_xlabel('Bulk Susc. (uSI)')
             ax6.yaxis.set_major_locator(plt.NullLocator())
             if sum_file:


### PR DESCRIPTION
As discussed in the issue https://github.com/PmagPy/PmagPy/issues/681, the code

```
ipmag.ani_depthplot(dir_path='data_files/ani_depthplot') 

```

gives the error:

```
ValueError: Axis limits cannot be NaN or Inf
```

due to this line: 

```
ax6.axis([bmin - 1, 1.1 * bmax, dmax, dmin])
```

the fix done here is to have the y axis be specified with dmax, dmin, while letting the x-axis be set automatically by matplotlib.