### PR TITLE
requested changes to great circle plotting

### DIFF
--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -1721,14 +1721,14 @@ class Demag_GUI(wx.Frame):
                         X_c_d.append(XY[0])
                         Y_c_d.append(XY[1])
 
-                if self.plane_display_box.GetValue() == "u. hemisphere" or \
-                   self.plane_display_box.GetValue() == "whole plane" or \
-                   "wp" in self.plane_display_box.GetValue():
-                    self.specimen_eqarea.plot(X_c_d, Y_c_d, 'b')
                 if self.plane_display_box.GetValue() == "l. hemisphere" or \
                    self.plane_display_box.GetValue() == "whole plane" or \
                    "wp" in self.plane_display_box.GetValue():
-                    self.specimen_eqarea.plot(X_c_up, Y_c_up, 'c')
+                    self.specimen_eqarea.plot(X_c_d, Y_c_d, c='b', lw=0.75)
+                if self.plane_display_box.GetValue() == "u. hemisphere" or \
+                   self.plane_display_box.GetValue() == "whole plane" or \
+                   "wp" in self.plane_display_box.GetValue():
+                    self.specimen_eqarea.plot(X_c_up, Y_c_up, ls='dotted', c='c', lw=0.75)
                 eqarea_x = XY[0]
                 eqarea_y = XY[1]
                 z = 1
@@ -2166,16 +2166,16 @@ class Demag_GUI(wx.Frame):
                                 X_c_d.append(XY[0])
                                 Y_c_d.append(XY[1])
 
-                        if self.plane_display_box.GetValue() == "u. hemisphere" or \
-                           self.plane_display_box.GetValue() == "whole plane" or \
-                           self.plane_display_box.GetValue() == "wp + bfv":
-                            fig.plot(X_c_d, Y_c_d, 'b')
-                            if self.ie_open:
-                                self.ie.plot(X_c_d, Y_c_d, 'b')
                         if self.plane_display_box.GetValue() == "l. hemisphere" or \
                            self.plane_display_box.GetValue() == "whole plane" or \
                            self.plane_display_box.GetValue() == "wp + bfv":
-                            fig.plot(X_c_up, Y_c_up, 'c')
+                            fig.plot(X_c_d, Y_c_d, c='b', lw=0.75)
+                            if self.ie_open:
+                                self.ie.plot(X_c_d, Y_c_d, 'b')
+                        if self.plane_display_box.GetValue() == "u. hemisphere" or \
+                           self.plane_display_box.GetValue() == "whole plane" or \
+                           self.plane_display_box.GetValue() == "wp + bfv":
+                            fig.plot(X_c_up, Y_c_up, ls='dotted', c='c', lw=0.75)
                             if self.ie_open:
                                 self.ie.plot(X_c_up, Y_c_up, 'c')
 


### PR DESCRIPTION
As requested by L. Zielinski and J. Glen, minor adjustments to the plotting of great-circles in demag_gui.py.

1. Fixed bug where selecting lower hemisphere instead showed upper hemisphere segment of great-circle, and vice-versa.
2. Plotted upper hemisphere as dotted line, lower hemisphere remains as solid line. Colors remain the same. Made lines slightly narrower which makes plots a little cleaner.