### PR TITLE
Adding Curie temperature estimation functionality to rockmagpy

### DIFF
--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -3503,6 +3503,39 @@ def estimate_curie_temperature(
     inverse_method=False,
     print_estimates=True
 ):
+    """
+    Estimate the Curie temperature from high temperature susceptibility curves in multiple ways. Automatically calculates first derivative minimum, second derivative maximum, and
+    second derivative zero-crossing. Also has option to estimate Curie temperature from inverse susceptibility (Petrovsky and A. Kapicka, 2006). Uses Bokeh for the interactive plot.
+
+    Parameters:
+        experiment (pandas.DataFrame): MagIC-formatted experiment DataFrame.
+        temperature_column (str): Name of temperature column.
+        magnetic_column (str): Name of susceptibility column.
+        temp_unit (str): "C" for Celsius.
+        smooth_window (int): Window for smoothing.
+        remove_holder (bool): Subtract holder signal.
+        figsize (tuple): (width, height) in inches.
+        inverse_method (bool): Use inverse susceptibility method.
+        print_estimates (bool): Print estimated Curie temperatures.
+    
+    Returns
+    -------
+
+    temp_of_first_derivative_min_heating : float
+        temperature of first derivative minimum for heating cycle
+    temp_of_first_derivative_min_cooling : float
+        temperature of first derivative minimum for cooling cycle
+    temp_of_second_derivative_max_heating : float
+        temperature of second derivative maximum for heating cycle
+    temp_of_second_derivative_max_cooling : float
+        temperature of second derivative maximum for cooling cycle
+    heating_zero : list[float] or None
+        temperatures of second derivative zero-crossings for heating cycle, or None if none found
+    cooling_zero : list[float] or None
+        temperatures of second derivative zero-crossings for cooling cycle, or None if none found
+       
+    """
+
     warm_T, warm_X, cool_T, cool_X = split_warm_cool(
         experiment,
         temperature_column=temperature_column,

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -3646,7 +3646,6 @@ def estimate_curie_temperature(
         print(f'Second derivative maximum is at T={int(temp_of_second_derivative_max_cooling)} for cooling')
         print(f'The second derivative of the heating curve crosses zero at T = {int(temp_of_zero_crossing_heating[0])}')
         print(f'The second derivative of the cooling curve crosses zero at T = {int(temp_of_zero_crossing_cooling[0])}')
-       
 
     heating_zero = temp_of_zero_crossing_heating[0] if temp_of_zero_crossing_heating else None
     cooling_zero = temp_of_zero_crossing_cooling[0] if temp_of_zero_crossing_cooling else None


### PR DESCRIPTION
This PR is me porting over to `rockmag.py` my attempt ( #726 ) at addressing #709 in `ipmag.py`. Since the X-T plotting functionality in `rockmag.py` looks pretty robust and uses the same `np.gradient` logic for the derivatives I put in that PR, I figured that the useful thing I could do would be to add the Curie temperature estimation.

I've not only done it but added a significantly better version of the inverse temperature estimation, wherein the user can do it interactively by dragging a line in a Bokeh plot. *pats self and Copilot on the back...*

The derivative-based estimates are easy and automatic.

Additional thought: If this passes muster, I can make one more commit in in #726 by simply **removing(!)** the `curie.py` function from `ipmag.py`, and close that loop. Then, the rock magnetic functions live in `rockmag.py` and there isn't duplication.