### PR TITLE
fix gausspars docstring and simplify function with numpy

### DIFF
--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4593,7 +4593,7 @@ def gausspars(data):
     Standard deviation: 2.072409225997607
     """
     data = np.asarray(data)
-    N = data.size
+    N = len(data)
 
     if N < 1:
         return "", ""


### PR DESCRIPTION
This pull request fixes the typo in the `pmag.gausspars()` docstring. It also addresses an issue where the example made it seem like this function was appropriate to apply to paleomagnetic directional data. Instead it should be applied solely to 1D arrays. 

Additionally, the function was previously set-up to manually make the calculations. It might as well be updated to use `numpy`. I have tested the previous pmagpy function vs this update with them giving identical results:
```
data = np.random.normal(loc=50, scale=2, size=5)
mean, stdev = pmag.gausspars(data)
print("Mean:", mean)
print("Standard deviation:", stdev)
mean, stdev = gausspars_new(data)
print("Mean:", mean)
print("Standard deviation:", stdev)
```
giving
```
Mean: 49.83027776124487
Standard deviation: 1.9714168655001911
Mean: 49.83027776124487
Standard deviation: 1.9714168655001911
```
and then:
```
Mean: 49.73263939007033
Standard deviation: 1.727135598819502
Mean: 49.73263939007033
Standard deviation: 1.727135598819502
```
and then:
```
Mean: 50.28679501613689
Standard deviation: 2.2144149402000974
Mean: 50.2867950161369
Standard deviation: 2.2144149402000974
```
