### PR TITLE
Removing deprecated API calls #798

### DIFF
--- a/pmagpy_tests/test_programs.py
+++ b/pmagpy_tests/test_programs.py
@@ -5,12 +5,15 @@ import os
 import unittest
 import shutil
 import sys
-from pkg_resources import resource_filename
+try:
+    import importlib.resources as importlib_resources
+except ImportError:
+    import importlib_resources # if Python < 3.7
 import programs
 
 # set constants
-fname = resource_filename(programs.__name__, 'angle.py')
-programs_WD = os.path.split(fname)[0]
+fname = importlib_resources.files(programs.__name__) / 'angle.py'
+programs_WD = os.path.split(str(fname))[0]
 #env = TestFileEnvironment('./new-test-output')
 
 

--- a/programs/__init__.py
+++ b/programs/__init__.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env pythonw
 
 import sys
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata # if Python < 3.7
 from os import path
-import pkg_resources
-command = path.split(sys.argv[0])[-1]
-
+import matplotlib
 from .program_envs import prog_env
+
+command = path.split(sys.argv[0])[-1]
 
 if command.endswith(".py"):
     mpl_env = prog_env.get(command[:-3])
@@ -13,8 +17,6 @@ elif command.endswith("_a"):
     mpl_env = prog_env.get(command[:-2])
 else:
     mpl_env = prog_env.get(command)
-
-import matplotlib
 
 # if backend was already set, skip this step
 if matplotlib.get_backend() in ('WXAgg', 'TKAgg'):
@@ -28,33 +30,9 @@ else:
 
 if "-v" in sys.argv:
     print("You are running:")
-    try:
-        print(pkg_resources.get_distribution('pmagpy'))
-    except pkg_resources.DistributionNotFound:
-        pass
-    try:
-        print(pkg_resources.get_distribution('pmagpy-cli'))
-    except pkg_resources.DistributionNotFound:
-        pass
-
-#from . import generic_magic
-#from . import sio_magic
-#from . import cit_magic
-#from . import _2g_bin_magic
-#from . import huji_magic
-#from . import huji_magic_new
-#from . import ldeo_magic
-#from . import iodp_srm_magic
-#from . import iodp_dscr_magic
-#from . import iodp_samples_magic
-#from . import pmd_magic
-#from . import tdt_magic
-#from . import jr6_jr6_magic
-#from . import jr6_txt_magic
-#from . import bgc_magic
-
-
-#__all__ = [generic_magic, sio_magic, cit_magic, _2g_bin_magic, huji_magic,
-#           huji_magic_new, ldeo_magic, iodp_srm_magic, iodp_dscr_magic,
-#           pmd_magic, tdt_magic, jr6_jr6_magic, jr6_txt_magic, bgc_magic,
-#           iodp_samples_magic]
+    for package in ['pmagpy', 'pmagpy-cli']:
+        try:
+            version = importlib_metadata.version(package)
+            print(f"{package} version: {version}")
+        except importlib_metadata.version.PackageNotFoundError:
+            pass


### PR DESCRIPTION
This should fix #798, whererein the deprecated API `pkg_resources` was being used. Since this may be removed by November, and it seemed more difficult to pin to an older version of `Setuptools`, I rewrote using the most up-to-date API as discussed here: https://importlib-resources.readthedocs.io/en/latest/migration.html. The only slight oddity was that `importlib_resources` is itself a backport of `importlib.resources`, but that's something currently handled in the imports that could be fixed later.

I tested this by running the command:
`import pmagpy.pmag as pmag`
in the python interpreter, which used to raise the error, and the error is no longer raised.