### PR TITLE
Replace deprecated np.matrix with ndarray in H23 functions

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -430,6 +430,11 @@ def mean_bootstrap_confidence(dec=None,inc=None,di_block=None,num_sims=10000,alp
         T_b[i] = pmag.find_T(mhat,n,Mhat_b,Ghat_b) #T for bootstrap sample
 
     T_b = T_b[np.isfinite(T_b)] #discard degenerate bootstrap samples
+    if T_b.size == 0:
+        raise ValueError(
+            "No finite bootstrap T values were obtained; the input directions may be too "
+            "few or too degenerate for mean_bootstrap_confidence to compute a confidence region."
+        )
     Tc = np.quantile(T_b,1-alpha) #find 1-alpha quantile of T
     pars["T_critical"] = Tc
 

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -13746,6 +13746,8 @@ def find_T(m,n,Mhat,Ghat):
     
     m = m[:,np.newaxis].astype(float)
 
+    if not np.isfinite(Ghat).all():
+        return np.inf
     if np.linalg.cond(Ghat) > 1e12:
         return np.inf
     return (n * m.T @ Mhat.T @ np.linalg.inv(Ghat) @ Mhat @ m).item()


### PR DESCRIPTION
## Summary

- Replace all `np.matrix` usage in the Heslop et al. (2023) common mean direction test functions (`form_Mhat`, `form_Ghat`, `form_Q`, `find_CMDT_CR`, `find_T`, `find_CR`) with standard ndarray operations (`np.asarray`, `.T`, `.conj().T`, `@` operator)
- Fix `'%.1f' % array` formatting bug in `common_mean_watson()` and `float()` on 1-element array in `lat_from_pole()`
- Add numerical stability guard in `find_T` for singular covariance matrices from degenerate bootstrap samples

## Context

`np.matrix` is deprecated and broken in modern numpy, causing `ValueError: setting an array element with a sequence` in `form_Ghat`. This broke `common_mean_bootstrap_H23`, `mean_bootstrap_confidence`, and `reversal_test_bootstrap_H23`. The `common_mean_watson` and `lat_from_pole` fixes address separate but related numpy array/scalar handling issues.