### PR TITLE
fix aniso_magic KeyError on multi-row sites tables in pandas 2.x

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -11232,8 +11232,8 @@ def aniso_magic(infile='specimens.txt', samp_file='samples.txt', site_file='site
             if 'sites' in con.tables:
                 if 'location' in con.tables['sites'].df.columns:
                     locs = con.tables['sites'].df.loc[site, 'location']
-                    if len(con.tables['sites'].df)>1:
-                        loc=locs[0]
+                    if isinstance(locs, pd.Series):
+                        loc=locs.iloc[0]
                     else:
                         loc=locs
 


### PR DESCRIPTION
The isite branch used len(sites_df) > 1 to decide whether df.loc[site, 'location'] returned a Series, then indexed with locs[0]. The length check is unrelated to whether locs is a Series, and label-based locs[0] raises KeyError: 0 in pandas 2.x when the index has no label 0. Check isinstance(locs, pd.Series) and use .iloc[0] for positional access. Fixes #843.