### PR TITLE
enforcing M/M0 plot ylim at 0

### DIFF
--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -1535,6 +1535,7 @@ class Demag_GUI(wx.Frame):
         self.mplot.get_xaxis().tick_bottom()
         self.mplot.get_yaxis().tick_left()
         self.mplot.set_ylabel("M / NRM0", fontsize=8*self.GUI_RESOLUTION)
+        self.mplot.set_ylim(0)
 
         self.canvas3.draw()
 
@@ -1626,7 +1627,7 @@ class Demag_GUI(wx.Frame):
             self.selected_meas_artists.append(self.mplot.scatter(
                 T_x, T_y, facecolor=red_cover, edgecolor="#000000", marker='o', s=30, lw=1, clip_on=False, zorder=3))
         self.mplot.set_xlim([xmin, xmax])
-        self.mplot.set_ylim([ymin, ymax])
+        self.mplot.set_ylim([0, ymax])
 
         xmin, xmax = self.mplot_af.get_xlim()
         ymin, ymax = self.mplot_af.get_ylim()
@@ -1634,7 +1635,7 @@ class Demag_GUI(wx.Frame):
             self.selected_meas_artists.append(self.mplot_af.scatter(
                 af_x, af_y, facecolor=blue_cover, edgecolor="#000000", marker='o', s=30, lw=1, clip_on=False, zorder=3))
         self.mplot_af.set_xlim([xmin, xmax])
-        self.mplot_af.set_ylim([ymin, ymax])
+        self.mplot_af.set_ylim([0, ymax])
 
         self.canvas1.draw()
         self.canvas2.draw()


### PR DESCRIPTION
The M/M0 plot in the Demag Gui used to auto-set y-limits. If something is not fully demagnetized, however, the lower y-limit might be something like 0.5. Or 0.3. Or, sure, 0. Therefore, the generated M/M0 plots are not 1:1 comparable with each other. This fix enforces the lower y-limit to 0 (i.e., total demagnetization), so that M/M0 plots can be better compared and total amount of demagnetization assessed.