### PR TITLE
Fix rec index in plot_mag and plot_zed 

### DIFF
--- a/pmagpy/pmagplotlib.py
+++ b/pmagpy/pmagplotlib.py
@@ -703,11 +703,11 @@ def plot_zij(fignum, datablock, angle, s, norm=True):
     gXYZ = pd.DataFrame(pmag.dir2cart(forVDS))
     gXYZ.columns = ['X', 'Y', 'Z']
     amax = np.maximum(gXYZ.X.max(), gXYZ.Z.max())
+    amax = np.maximum(amax, gXYZ.Y.max())
     amin = np.minimum(gXYZ.X.min(), gXYZ.Z.min())
-    amax = np.maximum(amax, gXYZ.Y.max())#DEBUG
-    amin = np.minimum(gXYZ.X.min(), gXYZ.Z.min())#DEBUG
-    if amin > 0: 
-        amin = 0 
+    amin = np.minimum(amin, gXYZ.Y.min())
+    if amin > 0:
+        amin = 0
     bXYZ = pmag.dir2cart(bdata[['dec', 'inc', 'int']].values).transpose()
 # plotting stuff
     if angle != 0:
@@ -778,7 +778,7 @@ def plot_mag(fignum, datablock, s, num, units, norm):
     Mex, Tex, Vdif = [], [], []
     recbak = []
     for rec in datablock:
-        if rec[4] == 'g':
+        if rec[5] == 'g':
             if units == "T":
                 T.append(rec[0] * 1e3)
                 Tv.append(rec[0] * 1e3)
@@ -882,7 +882,7 @@ def plot_zed(ZED, datablock, angle, s, units):
         eqarea : figure number for equal area projection
         zijd   : figure number for  zijderveld plot
         demag :  figure number for magnetization against demag step
-        datablock : nested list of [step, dec, inc, M (Am2), quality]
+        datablock : nested list of [step, dec, inc, M (Am2), type, quality]
         step : units assumed in SI
         M    : units assumed Am2
         quality : [g,b], good or bad measurement; if bad will be marked as such
@@ -908,7 +908,7 @@ def plot_zed(ZED, datablock, angle, s, units):
         if cb.is_null(rec[2],zero_as_null=False):
             print('-W- You are missing an inclination for specimen', s, ', skipping this row')
             continue
-        if rec[4] == 'b':
+        if rec[5] == 'b':
             DIbad.append((rec[1], rec[2]))
         else:
             DIgood.append((rec[1], rec[2]))


### PR DESCRIPTION
## Summary

Commit 81a4339d (2026-04-16) included a useful `plot_zij` pandas/matplotlib compatibility fix. However it seems like it also included changes that are problematic for `plot_mag` and `plot_zed`.

- In `plot_mag` and `plot_zed`, revert `rec[4]` back to `rec[5]` for the quality-flag check. Every datablock built in the codebase puts the quality flag at index 5 (index 4 is the `type`/`blank` column), so with `rec[4]` the check was never true — `plot_mag` was dropping every point from the demag curve and `plot_zed` was classifying every record as "good" by accident.
- In `plot_zij`, extend `amin` to include `gXYZ.Y.min()`. The `amax` line was correctly updated to include Y, but the parallel `amin` line in the commit ended up as a duplicate of the X/Z-only `amin` above it, so I think extending it to Y as well matches the intent. Also stripped a couple of `#DEBUG` comments left over from that session.
- Updated the `plot_zed` docstring from the old 5-column signature to the actual 6-column form `[step, dec, inc, M, type, quality]`. The stale docstring may have been what prompted the index shift in the first place, so worth fixing at the same time.

## Context

Every place in the codebase that builds a datablock and hands it to one of these functions puts the quality flag at index 5:

| Where the datablock is built | Datablock |
|---|---|
| `programs/zeq.py` | `[step, dec, inc, int, '', 'g']` |
| `ipmag.zeq` | `[treatment, declination, inclination, intensity, type, quality]` |
| `ipmag.zeq_magic` | `[treat, dec, inc, moment, blank, quality]` |
| `ipmag.plot_dmag` / `dmag_magic` | `[dmag, 0, 0, int, 1, quality]` |
| `pmag.find_dmag_rec` (7-col) | `[tr, dec, inc, int, ZI, flag, inst]` |
| `programs/demag_gui.py`, `programs/thellier_gui.py` | `[tr, dec, inc, int, ZI, flag, inst]` |

`pmag.domean` also reads the quality flag from index 5, so keeping the plotting functions consistent with index 5 avoids it drifting out of step with the rest of the pipeline.