### PR TITLE
add recursive-include pmagpy/field_models *.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include pmagpy/data_model *.*
+recursive-include pmagpy/field_models *.txt
 recursive-include images *.txt *.ico
 recursive-include programs/images *.txt *.ico
 recursive-include dialogs/help_files *.html


### PR DESCRIPTION
Fixes #850 (I think). `pip install pmagpy` was missing `pmagpy/field_models/igrf14coeffs.txt`, causing `ipmag.igrf()` to raise `FileNotFoundError` for any IGRF14-based call.

PR #819 moved the IGRF14 coefficients into an external data file but did not add the new `pmagpy/field_models/` directory to `MANIFEST.in`. With `include_package_data=True` in `setup.py`, `setuptools` only bundles non-`.py` files that `MANIFEST.in` picks up, so the file was excluded from both the sdist and the wheel uploaded to PyPI. This adds the missing `recursive-include` line, mirroring the existing entry for `pmagpy/data_model/`.