### PR TITLE
make datablock more clear in plot_zij and plot_zed docstrings

### DIFF
--- a/pmagpy/pmagplotlib.py
+++ b/pmagpy/pmagplotlib.py
@@ -663,7 +663,8 @@ def plot_zij(fignum, datablock, angle, s, norm=True):
     __________
     fignum : matplotlib figure number
     datablock : nested list of [step, dec, inc, M (Am2), type, quality]
-                where type is a string, either 'ZI' or 'IZ' for IZZI experiments
+                (type indicates the IZZI step for paleointensity experiments —
+                'ZI'/'IZ' or 1/0; empty string for pure demagnetization data)
     angle : desired rotation in the horizontal plane (0 puts X on X axis)
     s : specimen name
     norm : if True, normalize to initial magnetization = unity
@@ -883,6 +884,8 @@ def plot_zed(ZED, datablock, angle, s, units):
         zijd   : figure number for  zijderveld plot
         demag :  figure number for magnetization against demag step
         datablock : nested list of [step, dec, inc, M (Am2), type, quality]
+            (type indicates the IZZI step for paleointensity experiments —
+            'ZI'/'IZ' or 1/0; empty string for pure demagnetization data)
         step : units assumed in SI
         M    : units assumed Am2
         quality : [g,b], good or bad measurement; if bad will be marked as such


### PR DESCRIPTION
## Summary

Clarifies what the `type` entry means in the `datablock` parameter documented for `plot_zij` and `plot_zed` in `pmagpy/pmagplotlib.py`. Addresses the review comment on #847 suggesting that we document what the `type` field represents.

The `type` slot at index 4 of the datablock encodes the IZZI step indicator from Thellier-style paleointensity experiments. Across the codebase it appears in three forms:

- `'ZI'` / `'IZ'` strings (as previously documented in `plot_zij`)
- integers `1` / `0` (used by `pmag.find_dmag_rec` and consumed by Thellier code in `pmag.py`)
- empty string `''` for pure demagnetization data (e.g. `ipmag.zeq`, `ipmag.zeq_magic`)

The previous `plot_zij` docstring mentioned only the string form, and `plot_zed` did not explain the field at all. Both are now updated to a consistent parenthetical that covers all three encodings.

## Changes

- `plot_zij` docstring: replace the partial "string, either 'ZI' or 'IZ'" description with a parenthetical covering all encodings.
- `plot_zed` docstring: add the same parenthetical under the datablock entry, alongside the existing per-field notes.

No code behavior is changed.