### PR TITLE
remove Linux standalone references from documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ The `dialogs` directory contains GUI components that are used to build the graph
 
 - `help_files` contains html help that is used in the GUIs.
 
-- `setup_scripts` contains scripts that are used in created standalone releases of the GUIs for Mac, Windows, and Linux.
+- `setup_scripts` contains scripts that are used in creating standalone releases of the GUIs for Mac and Windows.
 
 - `bin` contains some scripts that are used in creating the Anaconda part of a pip release.
 
@@ -122,7 +122,7 @@ PmagPy ships in two forms, released on different cadences:
 
 - __pip packages__ (`pmagpy` and `pmagpy-cli`) — released several times per year. The full process is documented in [pip_README.md](pip_README.md): prerequisites, pre-release testing on Colab from a feature branch, the build/upload commands for both packages, the optional TestPyPI rehearsal, and tagging plus GitHub release.
 
-- __Standalone GUI executables__ (Windows, Mac, Linux) — released less frequently. See the [setup_scripts README](https://github.com/PmagPy/PmagPy/tree/master/setup_scripts) for the build process.
+- __Standalone GUI executables__ (macOS and Windows) — released less frequently. See the [setup_scripts README](https://github.com/PmagPy/PmagPy/tree/master/setup_scripts) for the build process.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,7 @@ You’ll find the latest stable release here: [Mac PmagPy Executable Application
 
 You’ll find the latest stable release here: [Windows PmagPy Executable Application](https://github.com/PmagPy/PmagPy-Standalone-Windows/releases/latest)
 
-####  Linux Standalone download
-
-This binary has only been tested on a Ubuntu 14.04 (Trusty) distribution and might experience problems on other distributions.
-You’ll find the latest stable release here: [Linux PmagPy Executable Application](https://github.com/PmagPy/PmagPy-Standalone-Linux/releases)
+Note: standalone GUI binaries are available only for macOS and Windows. Linux users should use the [pip install](https://pmagpy.github.io/PmagPy-docs/installation/pip_install.html) instead — it works smoothly on Linux when combined with conda for the GUI dependencies.
 
 ### Full PmagPy install
 

--- a/setup_scripts/README.md
+++ b/setup_scripts/README.md
@@ -159,27 +159,6 @@ If you need to install this way, but you get a weird error, you might have a pep
 
 
 
-## Compiling on Linux
-
-The Linux binary is generated very similar to the Windows binary. Again you must have all PmagPy dependencies and pyinstaller on your machine all of which can be found in the standard repositories or pypi. Then you should modify and run this script from the PmagPy main directory to make the .spec file:
-
-```bash
-pyi-makespec --onefile --windowed --icon=./programs/images/PmagPy.ico
---name=PmagGUI -p=$PATH_TO_ANY_DEPENDENCIES_NOT_ALREADY_IN_ENV
-./programs/pmag_gui.py
-```
-
-Then just like above you should open the PmagGUI.spec file and edit the line `datas=None` so it reads `datas=[('./pmagpy/data_model/*','./data_model')]`. Once you've fixed the datas line you should run the same code as above to finish the compiling process.
-
-```bash
-pyinstaller --clean PmagGUI.spec
-```
-
-The executable will be in the dist directory. If it does not run when you double click it or enter its name in the terminal you may have to change execution permissions to make it runnable by running `chmod a+x $EXENAME`. Also due to the way Pyinstaller is constructed when bundling as one-file you should note that it can take 5-30 seconds for the program to run so check with an activity manager (like top) before assuming the executable did not compile correctly.
-
-**Note:** if compiling this document to pdf using pandoc the command used is `pandoc devguide.md -o devguide.pdf --highlight-style tango -V geometry:margin=.7in`
-
-
 ## Troubleshooting
 
 You can run the executable with output to Terminal (this is particularly useful when your build is refusing to launch):


### PR DESCRIPTION
This pull request updates documentation to clarify that standalone GUI executables are now only available for macOS and Windows, and removes outdated instructions and references to Linux standalone binaries. The changes help set clearer expectations for Linux users and streamline the documentation.

Documentation updates:

* Updated `CONTRIBUTING.md` to state that standalone GUI executables are only created for macOS and Windows, removing references to Linux. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L67-R67) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L125-R125)
* Revised `README.md` to remove the Linux standalone binary section, instead recommending Linux users install via pip and conda for GUI dependencies.
* Removed the "Compiling on Linux" section from `setup_scripts/README.md`, eliminating instructions for building Linux standalone binaries.