### PR TITLE
restore dolnp3_0 and rewrite its docstring

### DIFF
--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4786,6 +4786,72 @@ def fisher_by_pol(data):
     return FisherByPoles
 
 
+def dolnp3_0(Data):
+    """
+    Compute the Fisher mean for a list of dicts using data-model 3.0 keys.
+    Translates 3.0-style records (with `dir_dec`, `dir_inc`, `dir_tilt_correction`,
+    and `method_codes` containing `DE-BFP` for planes) into the 2.5-style format
+    that dolnp() expects, then calls dolnp() and returns the result.
+
+    Used by demag_gui.py for computing sample- and site-level Fisher means
+    when saving MagIC tables.
+
+    Parameters
+    ----------
+    Data : nested list of dictionaries with keys
+        dir_dec
+        dir_inc
+        dir_tilt_correction
+        method_codes
+
+    Returns
+    -------
+        ReturnData : dictionary with keys
+            dec : fisher mean dec of data in Data
+            inc : fisher mean inc of data in Data
+            n_lines : number of directed lines [method_code = DE-BFL or DE-FM]
+            n_planes : number of best fit planes [method_code = DE-BFP]
+            alpha95  : fisher confidence circle from Data
+            R : fisher R value of Data
+            K : fisher k value of Data
+    Effects
+        prints to screen in case of no data
+    """
+    if len(Data) == 0:
+        print("This function requires input Data have at least 1 entry")
+        return {}
+    if len(Data) == 1:
+        ReturnData = {}
+        ReturnData["dec"] = Data[0]['dir_dec']
+        ReturnData["inc"] = Data[0]['dir_inc']
+        ReturnData["n_total"] = '1'
+        if "DE-BFP" in Data[0]['method_codes']:
+            ReturnData["n_lines"] = '0'
+            ReturnData["n_planes"] = '1'
+        else:
+            ReturnData["n_planes"] = '0'
+            ReturnData["n_lines"] = '1'
+        ReturnData["alpha95"] = ""
+        ReturnData["R"] = ""
+        ReturnData["K"] = ""
+        return ReturnData
+    else:
+        LnpData = []
+        for n, d in enumerate(Data):
+            LnpData.append({})
+            LnpData[n]['dec'] = d['dir_dec']
+            LnpData[n]['inc'] = d['dir_inc']
+            LnpData[n]['tilt_correction'] = d['dir_tilt_correction']
+            if 'method_codes' in list(d.keys()):
+                if "DE-BFP" in d['method_codes']:
+                    LnpData[n]['dir_type'] = 'p'
+                else:
+                    LnpData[n]['dir_type'] = 'l'
+        # get a sample average from all specimens
+        ReturnData = dolnp(LnpData, 'dir_type')
+        return ReturnData
+
+
 def dolnp(data, direction_type_key):
     """
     Returns fisher mean, a95 for data using the method of McFadden and McElhinny 1988 for lines and planes.


### PR DESCRIPTION
PR #780 removed dolnp3_0 based on its "DEPRECATED" notice, but the function is still called twice from demag_gui.py and is not substitutable by dolnp() — it does per-record translation of 3.0-style method_codes (DE-BFP) into dir_type='p' that dolnp() and process_data_for_mean() do not perform on their own.

Restore the function as it was prior to e6be2d59, and replace the deprecation notice in the docstring with a description of what it does and where it is used (demag_gui.py for sample- and site-level Fisher means when saving MagIC tables).