### PR TITLE
Demag GUI sample / specimen bug

### DIFF
--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4814,11 +4814,19 @@ def dolnp(data, direction_type_key):
     inc_key = 'dir_inc' if dec_key == 'dir_dec' else 'inc'
     meth_key = 'method_codes' if dec_key == 'dir_dec' else 'magic_method_codes'
     if len(data) == 1:
+        tilt_key = 'dir_tilt_correction' if dec_key == 'dir_dec' else 'tilt_correction'
+        tc = str(data[0][tilt_key]) if tilt_key in data[0] else '-1'
         ReturnData = {
-            "dec": data[0][dec_key], "inc": data[0][inc_key],
-            "n_total": '1', "alpha95": "", "R": "", "K": ""
+            "dec": '%7.1f ' % float(data[0][dec_key]),
+            "inc": '%7.1f ' % float(data[0][inc_key]),
+            "n_total": '1', "alpha95": "", "R": "", "K": "",
+            "tilt_correction": tc
         }
-        if "DE-BFP" in data[0].get(meth_key, ''):
+        rec = data[0]
+        if direction_type_key in rec and rec[direction_type_key] == 'p':
+            ReturnData["n_lines"] = '0'
+            ReturnData["n_planes"] = '1'
+        elif "DE-BFP" in rec.get(meth_key, ''):
             ReturnData["n_lines"] = '0'
             ReturnData["n_planes"] = '1'
         else:

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4786,106 +4786,45 @@ def fisher_by_pol(data):
     return FisherByPoles
 
 
-def dolnp3_0(Data):
+def dolnp(data, direction_type_key):
     """
-    Compute the Fisher mean for a list of dicts using data-model 3.0 keys.
-    Translates 3.0-style records (with `dir_dec`, `dir_inc`, `dir_tilt_correction`,
-    and `method_codes` containing `DE-BFP` for planes) into the 2.5-style format
-    that dolnp() expects, then calls dolnp() and returns the result.
-
-    Used by demag_gui.py for computing sample- and site-level Fisher means
-    when saving MagIC tables.
+    Returns fisher mean, a95 for data using the method of McFadden and McElhinny 1988 for lines and planes.
+    Handles both data-model 3.0 (dir_dec, dir_inc, method_codes) and 2.5 (dec, inc, magic_method_codes) records.
 
     Parameters
     ----------
-    Data : nested list of dictionaries with keys
-        dir_dec
-        dir_inc
-        dir_tilt_correction
-        method_codes
+    data : list of dicts with keys:
+        Data model 3.0: dir_dec, dir_inc, dir_tilt_correction, method_codes
+        Data model 2.5: dec, inc, tilt_correction, magic_method_codes
+    direction_type_key : key for line/plane classification ('direction_type', 'dir_type', etc.).
+        If absent from records, classification falls back to checking method_codes for DE-BFP.
 
     Returns
     -------
-        ReturnData : dictionary with keys
-            dec : fisher mean dec of data in Data
-            inc : fisher mean inc of data in Data
-            n_lines : number of directed lines [method_code = DE-BFL or DE-FM]
-            n_planes : number of best fit planes [method_code = DE-BFP]
-            alpha95  : fisher confidence circle from Data
-            R : fisher R value of Data
-            K : fisher k value of Data
+    dict with keys: dec, inc, n_total, n_lines, n_planes, alpha95, R, K
+
     Effects
-        prints to screen in case of no data
+    -------
+    prints to screen in case of no data
     """
-    if len(Data) == 0:
+    if len(data) == 0:
         print("This function requires input Data have at least 1 entry")
         return {}
-    if len(Data) == 1:
-        ReturnData = {}
-        ReturnData["dec"] = Data[0]['dir_dec']
-        ReturnData["inc"] = Data[0]['dir_inc']
-        ReturnData["n_total"] = '1'
-        if "DE-BFP" in Data[0]['method_codes']:
+    dec_key = 'dir_dec' if 'dir_dec' in data[0] else 'dec'
+    inc_key = 'dir_inc' if dec_key == 'dir_dec' else 'inc'
+    meth_key = 'method_codes' if dec_key == 'dir_dec' else 'magic_method_codes'
+    if len(data) == 1:
+        ReturnData = {
+            "dec": data[0][dec_key], "inc": data[0][inc_key],
+            "n_total": '1', "alpha95": "", "R": "", "K": ""
+        }
+        if "DE-BFP" in data[0].get(meth_key, ''):
             ReturnData["n_lines"] = '0'
             ReturnData["n_planes"] = '1'
         else:
             ReturnData["n_planes"] = '0'
             ReturnData["n_lines"] = '1'
-        ReturnData["alpha95"] = ""
-        ReturnData["R"] = ""
-        ReturnData["K"] = ""
         return ReturnData
-    else:
-        LnpData = []
-        for n, d in enumerate(Data):
-            LnpData.append({})
-            LnpData[n]['dec'] = d['dir_dec']
-            LnpData[n]['inc'] = d['dir_inc']
-            LnpData[n]['tilt_correction'] = d['dir_tilt_correction']
-            if 'method_codes' in list(d.keys()):
-                if "DE-BFP" in d['method_codes']:
-                    LnpData[n]['dir_type'] = 'p'
-                else:
-                    LnpData[n]['dir_type'] = 'l'
-        # get a sample average from all specimens
-        ReturnData = dolnp(LnpData, 'dir_type')
-        return ReturnData
-
-
-def dolnp(data, direction_type_key):
-    """
-    Returns fisher mean, a95 for data using the method of McFadden and McElhinny 1988 for lines and planes.
-
-    Parameters
-    ----------
-    Data : nested list of dictionaries with keys
-        Data model 3.0:
-            dir_dec
-            dir_inc
-            dir_tilt_correction
-            method_codes
-        Data model 2.5:
-            dec
-            inc
-            tilt_correction
-            magic_method_codes
-    direction_type_key :  ['specimen_direction_type']
-    
-    Returns
-    -------
-    ReturnData : dictionary with keys
-        dec : fisher mean dec of data in Data
-        inc : fisher mean inc of data in Data
-        n_lines : number of directed lines [method_code = DE-BFL or DE-FM]
-        n_planes : number of best fit planes [method_code = DE-BFP]
-        alpha95  : fisher confidence circle from Data
-        R : fisher R value of Data
-        K : fisher k value of Data
-        
-    Effects
-    -------
-    prints to screen in case of no data
-    """
     if 'dir_dec' in data[0].keys():
         tilt_key = 'dir_tilt_correction'  # this is data model 3.0
     else:

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4815,24 +4815,25 @@ def dolnp(data, direction_type_key):
     meth_key = 'method_codes' if dec_key == 'dir_dec' else 'magic_method_codes'
     if len(data) == 1:
         tilt_key = 'dir_tilt_correction' if dec_key == 'dir_dec' else 'tilt_correction'
-        tc = str(data[0][tilt_key]) if tilt_key in data[0] else '-1'
-        ReturnData = {
-            "dec": '%7.1f ' % float(data[0][dec_key]),
-            "inc": '%7.1f ' % float(data[0][inc_key]),
-            "n_total": '1', "alpha95": "", "R": "", "K": "",
-            "tilt_correction": tc
-        }
         rec = data[0]
-        if direction_type_key in rec and rec[direction_type_key] == 'p':
-            ReturnData["n_lines"] = '0'
-            ReturnData["n_planes"] = '1'
-        elif "DE-BFP" in rec.get(meth_key, ''):
-            ReturnData["n_lines"] = '0'
-            ReturnData["n_planes"] = '1'
+        tc = str(rec[tilt_key]) if tilt_key in rec else '-1'
+        # Line/plane classification mirrors process_data_for_mean: when
+        # direction_type_key is present it is authoritative; only otherwise do we
+        # fall back to checking method_codes for DE-BFP.
+        if direction_type_key in rec:
+            is_plane = rec[direction_type_key] == 'p'
         else:
-            ReturnData["n_planes"] = '0'
-            ReturnData["n_lines"] = '1'
-        return ReturnData
+            is_plane = "DE-BFP" in rec.get(meth_key, '')
+        n_lines, n_planes = (0, 1) if is_plane else (1, 0)
+        return {
+            "dec": '%7.1f ' % float(rec[dec_key]),
+            "inc": '%7.1f ' % float(rec[inc_key]),
+            "n_total": '%i ' % 1,
+            "n_lines": '%i ' % n_lines,
+            "n_planes": '%i ' % n_planes,
+            "alpha95": "", "R": "", "K": "",
+            "tilt_correction": tc,
+        }
     if 'dir_dec' in data[0].keys():
         tilt_key = 'dir_tilt_correction'  # this is data model 3.0
     else:

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -4786,6 +4786,72 @@ def fisher_by_pol(data):
     return FisherByPoles
 
 
+def dolnp3_0(Data):
+    """
+    Compute the Fisher mean for a list of dicts using data-model 3.0 keys.
+    Translates 3.0-style records (with `dir_dec`, `dir_inc`, `dir_tilt_correction`,
+    and `method_codes` containing `DE-BFP` for planes) into the 2.5-style format
+    that dolnp() expects, then calls dolnp() and returns the result.
+
+    Used by demag_gui.py for computing sample- and site-level Fisher means
+    when saving MagIC tables.
+
+    Parameters
+    ----------
+    Data : nested list of dictionaries with keys
+        dir_dec
+        dir_inc
+        dir_tilt_correction
+        method_codes
+
+    Returns
+    -------
+        ReturnData : dictionary with keys
+            dec : fisher mean dec of data in Data
+            inc : fisher mean inc of data in Data
+            n_lines : number of directed lines [method_code = DE-BFL or DE-FM]
+            n_planes : number of best fit planes [method_code = DE-BFP]
+            alpha95  : fisher confidence circle from Data
+            R : fisher R value of Data
+            K : fisher k value of Data
+    Effects
+        prints to screen in case of no data
+    """
+    if len(Data) == 0:
+        print("This function requires input Data have at least 1 entry")
+        return {}
+    if len(Data) == 1:
+        ReturnData = {}
+        ReturnData["dec"] = Data[0]['dir_dec']
+        ReturnData["inc"] = Data[0]['dir_inc']
+        ReturnData["n_total"] = '1'
+        if "DE-BFP" in Data[0]['method_codes']:
+            ReturnData["n_lines"] = '0'
+            ReturnData["n_planes"] = '1'
+        else:
+            ReturnData["n_planes"] = '0'
+            ReturnData["n_lines"] = '1'
+        ReturnData["alpha95"] = ""
+        ReturnData["R"] = ""
+        ReturnData["K"] = ""
+        return ReturnData
+    else:
+        LnpData = []
+        for n, d in enumerate(Data):
+            LnpData.append({})
+            LnpData[n]['dec'] = d['dir_dec']
+            LnpData[n]['inc'] = d['dir_inc']
+            LnpData[n]['tilt_correction'] = d['dir_tilt_correction']
+            if 'method_codes' in list(d.keys()):
+                if "DE-BFP" in d['method_codes']:
+                    LnpData[n]['dir_type'] = 'p'
+                else:
+                    LnpData[n]['dir_type'] = 'l'
+        # get a sample average from all specimens
+        ReturnData = dolnp(LnpData, 'dir_type')
+        return ReturnData
+
+
 def dolnp(data, direction_type_key):
     """
     Returns fisher mean, a95 for data using the method of McFadden and McElhinny 1988 for lines and planes.

--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -5583,8 +5583,16 @@ class Demag_GUI(wx.Frame):
             PmagSamps, SampDirs = [], []
             PmagSites = []  # list of all site data
             SampInts = []
-            renamelnp = {'R': 'dir_r', 'n': 'dir_n_samples', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
-                         'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec', 'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
+            # rename map for sample-level means: n_total = number of specimens averaged
+            renamelnp_samp = {'R': 'dir_r', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
+                              'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
+                              'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
+            # rename map for site-level means: n_total = number of samples averaged
+            renamelnp_site = {'R': 'dir_r', 'n_total': 'dir_n_samples', 'alpha95': 'dir_alpha95',
+                              'n_lines': 'dir_n_samples_lines', 'K': 'dir_k', 'dec': 'dir_dec',
+                              'n_planes': 'dir_n_samples_planes', 'inc': 'dir_inc'}
+            # keep renamelnp as site-level map for backward compatibility with site loop below
+            renamelnp = renamelnp_site
             for samp in samples:  # run through the sample names
                 if not avg_directions_by_sample:
                     break
@@ -5607,7 +5615,7 @@ class Demag_GUI(wx.Frame):
                         if len(CompDir) <= 0:
                             continue  # no data for comp
                         PmagSampRec = pmag.dolnp3_0(CompDir)
-                        for k, v in list(renamelnp.items()):
+                        for k, v in list(renamelnp_samp.items()):
                             if k in PmagSampRec:
                                 PmagSampRec[v] = PmagSampRec[k]
                                 del PmagSampRec[k]
@@ -5719,10 +5727,10 @@ class Demag_GUI(wx.Frame):
                         if len(siteD) <= 0:
                             # print("no data for comp %s in site %s. skipping"%(comp,site))
                             continue
-                        PmagSiteRec = PmagSampRec = pmag.dolnp3_0(
-                            siteD)  # get an average for this site
+                        PmagSiteRec = pmag.dolnp3_0(siteD)  # get an average for this site
                         for k, v in list(renamelnp.items()):
                             if k in PmagSiteRec:
+
                                 PmagSiteRec[v] = PmagSiteRec[k]
                                 del PmagSiteRec[k]
                         # decorate the site record

--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -5614,7 +5614,7 @@ class Demag_GUI(wx.Frame):
                             x for x in CompDir if 'result_quality' in x and x['result_quality'] == 'g']
                         if len(CompDir) <= 0:
                             continue  # no data for comp
-                        PmagSampRec = pmag.dolnp3_0(CompDir)
+                        PmagSampRec = pmag.dolnp(CompDir, 'direction_type')
                         for k, v in list(renamelnp_samp.items()):
                             if k in PmagSampRec:
                                 PmagSampRec[v] = PmagSampRec[k]
@@ -5730,13 +5730,13 @@ class Demag_GUI(wx.Frame):
                         if dia.combo_site_mean.GetValue() == 'samples' and avg_directions_by_sample:
                             # At the site level, sample means are usually directed lines,
                             # so DE-BFP should be stripped from method_codes to prevent
-                            # dolnp3_0 from misclassifying the sample as a pole to a plane.
+                            # dolnp from misclassifying the sample as a pole to a plane.
                             #
                             # Exception: when a sample has exactly 1 BFP specimen and no
-                            # line specimens, dolnp3_0's single-record path stored the raw
-                            # pole (dir_dec/dir_inc = pole to great circle) in the sample
+                            # line specimens, dolnp's N=1 path stored the raw pole
+                            # (dir_dec/dir_inc = pole to great circle) in the sample
                             # record unchanged.  In that case DE-BFP must be kept so that
-                            # dolnp3_0 at the site level correctly treats dir_dec/dir_inc
+                            # dolnp at the site level correctly treats dir_dec/dir_inc
                             # as a plane normal and applies McFadden-McElhinny rather than
                             # using the pole as a directed line.
                             siteD_for_mean = []
@@ -5754,9 +5754,9 @@ class Demag_GUI(wx.Frame):
                                         c for c in d.get('method_codes', '').split(':')
                                         if c != 'DE-BFP'
                                     )})
-                            PmagSiteRec = pmag.dolnp3_0(siteD_for_mean)  # get an average for this site
+                            PmagSiteRec = pmag.dolnp(siteD_for_mean, 'direction_type')  # get an average for this site
                         else:
-                            PmagSiteRec = pmag.dolnp3_0(siteD)  # get an average for this site
+                            PmagSiteRec = pmag.dolnp(siteD, 'direction_type')  # get an average for this site
                         for k, v in list(renamelnp.items()):
                             if k in PmagSiteRec:
 

--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -5727,7 +5727,36 @@ class Demag_GUI(wx.Frame):
                         if len(siteD) <= 0:
                             # print("no data for comp %s in site %s. skipping"%(comp,site))
                             continue
-                        PmagSiteRec = pmag.dolnp3_0(siteD)  # get an average for this site
+                        if dia.combo_site_mean.GetValue() == 'samples' and avg_directions_by_sample:
+                            # At the site level, sample means are usually directed lines,
+                            # so DE-BFP should be stripped from method_codes to prevent
+                            # dolnp3_0 from misclassifying the sample as a pole to a plane.
+                            #
+                            # Exception: when a sample has exactly 1 BFP specimen and no
+                            # line specimens, dolnp3_0's single-record path stored the raw
+                            # pole (dir_dec/dir_inc = pole to great circle) in the sample
+                            # record unchanged.  In that case DE-BFP must be kept so that
+                            # dolnp3_0 at the site level correctly treats dir_dec/dir_inc
+                            # as a plane normal and applies McFadden-McElhinny rather than
+                            # using the pole as a directed line.
+                            siteD_for_mean = []
+                            for d in siteD:
+                                try:
+                                    n_lines = int(float(d.get('dir_n_specimens_lines', 0) or 0))
+                                    n_planes = int(float(d.get('dir_n_specimens_planes', 0) or 0))
+                                except (ValueError, TypeError):
+                                    n_lines, n_planes = 0, 0
+                                # single-BFP-only sample: dir_dec/dir_inc is the raw pole — keep DE-BFP
+                                if n_lines == 0 and n_planes == 1:
+                                    siteD_for_mean.append(d)
+                                else:
+                                    siteD_for_mean.append({**d, 'method_codes': ':'.join(
+                                        c for c in d.get('method_codes', '').split(':')
+                                        if c != 'DE-BFP'
+                                    )})
+                            PmagSiteRec = pmag.dolnp3_0(siteD_for_mean)  # get an average for this site
+                        else:
+                            PmagSiteRec = pmag.dolnp3_0(siteD)  # get an average for this site
                         for k, v in list(renamelnp.items()):
                             if k in PmagSiteRec:
 

--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -5587,12 +5587,19 @@ class Demag_GUI(wx.Frame):
             renamelnp_samp = {'R': 'dir_r', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
                               'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
                               'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
-            # rename map for site-level means: n_total = number of samples averaged
+            # rename map for site-level means when averaging samples: n_total = number of samples averaged
             renamelnp_site = {'R': 'dir_r', 'n_total': 'dir_n_samples', 'alpha95': 'dir_alpha95',
                               'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
                               'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
-            # keep renamelnp as site-level map for backward compatibility with site loop below
-            renamelnp = renamelnp_site
+            # rename map for site-level means when averaging specimens: n_total = number of specimens averaged
+            renamelnp_site_specimens = {'R': 'dir_r', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
+                                         'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
+                                         'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
+             # keep renamelnp as the site-level map used by the site loop below
+            if dia.combo_site_mean.GetValue() == 'samples':
+                renamelnp = renamelnp_site
+            else:
+                renamelnp = renamelnp_site_specimens
             for samp in samples:  # run through the sample names
                 if not avg_directions_by_sample:
                     break

--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -5589,8 +5589,8 @@ class Demag_GUI(wx.Frame):
                               'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
             # rename map for site-level means: n_total = number of samples averaged
             renamelnp_site = {'R': 'dir_r', 'n_total': 'dir_n_samples', 'alpha95': 'dir_alpha95',
-                              'n_lines': 'dir_n_samples_lines', 'K': 'dir_k', 'dec': 'dir_dec',
-                              'n_planes': 'dir_n_samples_planes', 'inc': 'dir_inc'}
+                              'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
+                              'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
             # keep renamelnp as site-level map for backward compatibility with site loop below
             renamelnp = renamelnp_site
             for samp in samples:  # run through the sample names

--- a/programs/demag_gui.py
+++ b/programs/demag_gui.py
@@ -5583,23 +5583,27 @@ class Demag_GUI(wx.Frame):
             PmagSamps, SampDirs = [], []
             PmagSites = []  # list of all site data
             SampInts = []
-            # rename map for sample-level means: n_total = number of specimens averaged
-            renamelnp_samp = {'R': 'dir_r', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
-                              'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
-                              'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
-            # rename map for site-level means when averaging samples: n_total = number of samples averaged
-            renamelnp_site = {'R': 'dir_r', 'n_total': 'dir_n_samples', 'alpha95': 'dir_alpha95',
-                              'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
-                              'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
-            # rename map for site-level means when averaging specimens: n_total = number of specimens averaged
-            renamelnp_site_specimens = {'R': 'dir_r', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
-                                         'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
-                                         'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
-             # keep renamelnp as the site-level map used by the site loop below
-            if dia.combo_site_mean.GetValue() == 'samples':
-                renamelnp = renamelnp_site
+            # n_total = number of specimens averaged.  Used for sample means and
+            # for site means computed directly over specimens.
+            renamelnp_specimens = {'R': 'dir_r', 'n_total': 'dir_n_specimens', 'alpha95': 'dir_alpha95',
+                                   'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
+                                   'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
+            # n_total = number of samples averaged.  Used for site means computed over
+            # sample means.  The *_lines/_planes columns retain the dir_n_specimens_*
+            # names because the MagIC 3.0 controlled vocabulary has no dir_n_samples_*
+            # counterparts.
+            renamelnp_samples = {'R': 'dir_r', 'n_total': 'dir_n_samples', 'alpha95': 'dir_alpha95',
+                                 'n_lines': 'dir_n_specimens_lines', 'K': 'dir_k', 'dec': 'dir_dec',
+                                 'n_planes': 'dir_n_specimens_planes', 'inc': 'dir_inc'}
+            # renamelnp is applied in the site loop below.  The condition must mirror
+            # the dirlist selection at the top of the site loop: only when both
+            # combo_site_mean == 'samples' *and* avg_directions_by_sample is True does
+            # the site loop iterate over sample means; otherwise it iterates over
+            # specimens and n_total is a specimen count.
+            if dia.combo_site_mean.GetValue() == 'samples' and avg_directions_by_sample:
+                renamelnp = renamelnp_samples
             else:
-                renamelnp = renamelnp_site_specimens
+                renamelnp = renamelnp_specimens
             for samp in samples:  # run through the sample names
                 if not avg_directions_by_sample:
                     break
@@ -5622,7 +5626,7 @@ class Demag_GUI(wx.Frame):
                         if len(CompDir) <= 0:
                             continue  # no data for comp
                         PmagSampRec = pmag.dolnp(CompDir, 'direction_type')
-                        for k, v in list(renamelnp_samp.items()):
+                        for k, v in list(renamelnp_specimens.items()):
                             if k in PmagSampRec:
                                 PmagSampRec[v] = PmagSampRec[k]
                                 del PmagSampRec[k]
@@ -5766,7 +5770,6 @@ class Demag_GUI(wx.Frame):
                             PmagSiteRec = pmag.dolnp(siteD, 'direction_type')  # get an average for this site
                         for k, v in list(renamelnp.items()):
                             if k in PmagSiteRec:
-
                                 PmagSiteRec[v] = PmagSiteRec[k]
                                 del PmagSiteRec[k]
                         # decorate the site record


### PR DESCRIPTION
There was a little bug in Demag GUI wherein when MagIC tables were saved and sites were averaged by samples which had multiple specimens, the `dir_n_specimens` column was given the value for the `dir_n_samples` column.

Also found a little odd edge-case wherein a sample with two specimens which each had a different fit method (i.e., BFL and BFP) would propagate weirdly into the site mean.

Also, re-removed `dolnp3_0` by folding it into `dolnp`. Whew. Probably seen the last of that?

Tested this on some uploaded data and the specimen / sample number bug seems to be fixed and it runs fine with just the `dolnp` call (now unified).