### PR TITLE
Fix colorbar error and update mode calculation in find_ei_kent

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -9692,6 +9692,7 @@ def find_ei_kent(data, site_latitude, site_longitude, kent_color='k', nb=1000, s
     
     plt.figure(figsize=(4,4))
     plot_net()
+    net_ax = plt.gca()
     cNorm  = colors.Normalize(vmin=min(F), vmax=max(F))
     f_scalarMap = cm.ScalarMappable(norm=cNorm, cmap=cmap)
     
@@ -9718,7 +9719,7 @@ def find_ei_kent(data, site_latitude, site_longitude, kent_color='k', nb=1000, s
         hex_color = colors.rgb2hex(rgba)
 
         plot_di(decs, unsquish_incs, color = hex_color, alpha=0.02)
-    cb = plt.colorbar(f_scalarMap,orientation='horizontal',fraction=0.05, pad=0.05)
+    cb = plt.colorbar(f_scalarMap, ax=net_ax, orientation='horizontal', fraction=0.05, pad=0.05)
     cb.ax.tick_params(labelsize=14)
     cb.ax.set_title(label='$f$ values', fontsize=14)
 
@@ -9727,7 +9728,7 @@ def find_ei_kent(data, site_latitude, site_longitude, kent_color='k', nb=1000, s
 
     # plot paleolatitudes distribution
     EI_plats = np.degrees(np.arctan(np.tan(np.radians(I))/2))
-    plat_mode = stats.mode(np.round(EI_plats, 1))[0][0]
+    plat_mode = stats.mode(np.round(EI_plats, 1)).mode
     plat_lower, plat_upper = np.round(np.percentile(EI_plats, [2.5, 97.5]), 1)
     mu, std = stats.norm.fit(EI_plats)
     x = np.linspace(min(EI_plats), max(EI_plats), 100)


### PR DESCRIPTION
`plt.colorbar()` is called with a ScalarMappable that isn't attached to any Axes. Newer matplotlib (3.7+) requires an explicit `ax` or `cax` argument in this case. The fix is to pass the current axes (from the equal-area plot created by `plot_net()` at line 9694). This fix closes #867.

Also fixed a scipy issue given that sciPy ≥1.9 changed scipy.stats.mode to return ModeResult(mode=<scalar>, count=<scalar>) rather than length-1 arrays. The old [0][0] indexing reached into a 0-d scalar and raised IndexError. Accessing .mode directly is the future-proof form and works on both old and new SciPy.

**Plotting improvements:**

* Assigned the current axes to `net_ax` using `plt.gca()` and specified `ax=net_ax` when creating the colorbar, ensuring the colorbar is correctly associated with the plot and improving figure layout. [[1]](diffhunk://#diff-1880d832ee3c65857bad94da95e2403f5b85ae47a955b5cda2d08dfaeab19464R9695) [[2]](diffhunk://#diff-1880d832ee3c65857bad94da95e2403f5b85ae47a955b5cda2d08dfaeab19464L9721-R9722)

**Library compatibility:**

* Updated the usage of `stats.mode` to use the `.mode` attribute instead of indexing, aligning with recent SciPy changes and preventing deprecation warnings