### PR TITLE
Fix ipmag.fishqq plot=False path; add data_type='poles' labels; add u…

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -2004,7 +2004,7 @@ def conglomerate_test_Watson(R, n):
     return result
 
 
-def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save_folder='.'):
+def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save_folder='.',data_type='directions'):
     """
     Test whether a distribution is Fisherian and make a corresponding Q-Q plot.
     The Q-Q plot shows the data plotted against the value expected from a
@@ -2029,6 +2029,15 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
         save_folder : relative directory where plots will be saved
             (default is current directory, '.')
         fmt : format of saved plot (default is 'png')
+        data_type : 'directions' (default) or 'poles'. Controls the axis/plot
+            labels only: 'directions' labels the components 'Declinations' and
+            'Inclinations'; 'poles' labels them 'Longitudes' and 'Latitudes'
+            (appropriate when the input di_block is a set of VGPs/poles).
+
+    Note:
+        The Mu and Me test statistics are computed whether or not ``plot`` is
+        True (when ``plot`` is False they are calculated on a temporary figure
+        that is closed without display).
 
     Returns:
         dictionary 
@@ -2080,6 +2089,10 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
     QQ_dict2 = {}
     QQ = {'unf': 1, 'exp': 2}
     fignum=1
+    if data_type == 'poles':
+        dec_label, inc_label = 'Longitudes', 'Latitudes'
+    else:
+        dec_label, inc_label = 'Declinations', 'Inclinations'
     di=np.array(all_dirs).transpose()
     decs=di[0]
     incs=di[1]
@@ -2096,18 +2109,25 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
         ndata=np.column_stack((Ds,Is,az,pl))
         D1,I1=pmag.dotilt_V(ndata)
         D1=(D1-180.)%360 # Somehow this got lost
-        Dtit = 'Mode 1 Declinations'
-        Itit = 'Mode 1 Inclinations'
+        Dtit = 'Mode 1 ' + dec_label
+        Itit = 'Mode 1 ' + inc_label
         if plot:
             plt.figure(fignum,figsize=(6, 3))
             fignum+=1
-            Mu_n, Mu_ncr = pmagplotlib.plot_qq_unf(
-                QQ['unf'], D1, Dtit, subplot=True)  # make plot
-            Me_n, Me_ncr = pmagplotlib.plot_qq_exp(
-                QQ['exp'], I1, Itit, subplot=True)  # make plot
+        else:
+            tmp_fig = plt.figure(figsize=(6, 3))
+        # the Mu/Me statistics are computed within the plotting functions, so
+        # they are called whether or not the plot is retained
+        Mu_n, Mu_ncr = pmagplotlib.plot_qq_unf(
+            QQ['unf'], D1, Dtit, subplot=True)  # make plot
+        Me_n, Me_ncr = pmagplotlib.plot_qq_exp(
+            QQ['exp'], I1, Itit, subplot=True)  # make plot
+        if plot:
             plt.tight_layout()
             if save:
                 plt.savefig(os.path.join(save_folder, 'QQ_mode1')+'.'+fmt, dpi=450)
+        else:
+            plt.close(tmp_fig)
         if Mu_n <= Mu_ncr and Me_n <= Me_ncr:
             F_n = 'Consistent with Fisher distribution'
         else:
@@ -2134,22 +2154,27 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
         rdata=np.column_stack((Ds,Is,az,pl))
         D2,I2=pmag.dotilt_V(rdata)
         D2=(D2-180.)%360 # Somehow this got lost
-        Dtit = 'Mode 2 Declinations'
-        Itit = 'Mode 2 Inclinations'
+        Dtit = 'Mode 2 ' + dec_label
+        Itit = 'Mode 2 ' + inc_label
         ppars = pmag.doprinc(rDIs)  # get principal directions
         if ppars['dec']>90 and ppars['dec']<270:
             Drbar = ppars['dec'] - 180.
         if ppars['inc']<0:
-            Irbar['inc']=-ppars['inc']
+            Irbar=-ppars['inc']
         if plot:
             plt.figure(fignum,figsize=(6, 3))
-            Mu_r, Mu_rcr = pmagplotlib.plot_qq_unf(
-                QQ['unf'], D2, Dtit, subplot=True)  # make plot
-            Me_r, Me_rcr = pmagplotlib.plot_qq_exp(
-                QQ['exp'], I2, Itit, subplot=True)  # make plot
+        else:
+            tmp_fig = plt.figure(figsize=(6, 3))
+        Mu_r, Mu_rcr = pmagplotlib.plot_qq_unf(
+            QQ['unf'], D2, Dtit, subplot=True)  # make plot
+        Me_r, Me_rcr = pmagplotlib.plot_qq_exp(
+            QQ['exp'], I2, Itit, subplot=True)  # make plot
+        if plot:
             plt.tight_layout()
             if save:
                 plt.savefig(os.path.join(save_folder, 'QQ_mode2')+'.'+fmt, dpi=450)
+        else:
+            plt.close(tmp_fig)
 
         if Mu_r <= Mu_rcr and Me_r <= Me_rcr:
             F_r = 'Consistent with Fisher distribution'
@@ -2165,10 +2190,11 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
         QQ_dict2['Me_critical'] = Me_rcr
         QQ_dict2['Test_result'] = F_r
 
-    if QQ_dict2:
-        return QQ_dict1, QQ_dict2
-    elif QQ_dict1:
-        return QQ_dict1
+    populated = [d for d in (QQ_dict1, QQ_dict2) if d]
+    if len(populated) == 2:
+        return populated[0], populated[1]
+    elif len(populated) == 1:
+        return populated[0]
     else:
         print('you need N> 10 for at least one mode')
 

--- a/pmagpy/test/test_ipmag_plotting.py
+++ b/pmagpy/test/test_ipmag_plotting.py
@@ -251,6 +251,33 @@ class TestFishqq:
         assert summary.get('N', 0) > 10
         plt.close('all')
 
+    def test_stats_computed_without_plot(self):
+        """fishqq returns the same statistics with plot=False as plot=True."""
+        directions = ipmag.fishrot(k=40, n=20, dec=200, inc=50,
+                                    random_seed=33).tolist()
+        with_plot = ipmag.fishqq(di_block=directions, plot=True, save=False)
+        no_plot = ipmag.fishqq(di_block=directions, plot=False, save=False)
+        assert isinstance(no_plot, dict)
+        for key in ('Mu', 'Mu_critical', 'Me', 'Me_critical'):
+            assert abs(no_plot[key] - with_plot[key]) < 1e-9
+        assert no_plot['Test_result'] == with_plot['Test_result']
+        plt.close('all')
+
+    def test_data_type_poles_labels(self):
+        """data_type='poles' labels the QQ subplots Longitudes/Latitudes."""
+        vgps = ipmag.fishrot(k=40, n=20, dec=200, inc=50,
+                             random_seed=33).tolist()
+        ipmag.fishqq(di_block=vgps, plot=True, save=False, data_type='poles')
+        titles = [ax.get_title() for ax in plt.gcf().get_axes()]
+        assert 'Mode 1 Longitudes' in titles
+        assert 'Mode 1 Latitudes' in titles
+        plt.close('all')
+        ipmag.fishqq(di_block=vgps, plot=True, save=False)
+        titles = [ax.get_title() for ax in plt.gcf().get_axes()]
+        assert 'Mode 1 Declinations' in titles
+        assert 'Mode 1 Inclinations' in titles
+        plt.close('all')
+
 
 # ---------------------------------------------------------------------------
 # igrf_print: IGRF output formatting

--- a/pmagpy/test/test_ipmag_upload.py
+++ b/pmagpy/test/test_ipmag_upload.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for ipmag.upload_magic.
+
+Guards against a bug where integer "count" columns matching ``*_n*``
+(e.g. ``pole_n_sites``, ``dir_n_samples``) were corrupted by
+``str.strip('.0')`` — which strips the characters ``.`` and ``0`` from both
+ends of the string (so ``'50' -> '5'``, ``'10' -> '1'``, ``'100' -> '1'``)
+instead of removing a trailing ``.0`` decimal. The fix removes only a trailing
+``.0`` so integer counts are preserved while ``'50.0' -> '50'`` still works.
+"""
+import os
+
+from pmagpy import ipmag
+
+
+def _write_table(path, table_type, cols, rows):
+    with open(path, 'w') as f:
+        f.write('tab delimited\t{}\n'.format(table_type))
+        f.write('\t'.join(cols) + '\n')
+        for r in rows:
+            f.write('\t'.join(str(r[c]) for c in cols) + '\n')
+
+
+def _parse_tables(path):
+    tables = {}
+    for block in open(path).read().split('>>>>>>>>>>'):
+        lines = [ln for ln in block.split('\n') if ln.strip()]
+        if not lines:
+            continue
+        ttype = lines[0].split('\t')[-1].strip()
+        hdr = lines[1].split('\t')
+        tables[ttype] = [dict(zip(hdr, ln.split('\t'))) for ln in lines[2:]]
+    return tables
+
+
+class TestUploadMagicCountColumns:
+    """Integer count columns must survive upload_magic unchanged."""
+
+    def test_counts_not_corrupted(self, tmp_path):
+        d = str(tmp_path)
+        site_cols = ['site', 'location', 'method_codes', 'citations',
+                     'lat', 'lon', 'dir_tilt_correction',
+                     'dir_dec', 'dir_inc', 'dir_n_samples']
+        sites = [
+            {'site': 'S1', 'location': 'Loc', 'method_codes': 'LP-DIR-T',
+             'citations': '10.0000/x', 'lat': '47.0', 'lon': '272.0',
+             'dir_tilt_correction': '100', 'dir_dec': '10', 'dir_inc': '5',
+             'dir_n_samples': '10'},   # ends in 0 -> was corrupted to '1'
+            {'site': 'S2', 'location': 'Loc', 'method_codes': 'LP-DIR-T',
+             'citations': '10.0000/x', 'lat': '47.0', 'lon': '272.0',
+             'dir_tilt_correction': '100', 'dir_dec': '12', 'dir_inc': '6',
+             'dir_n_samples': '6'},
+        ]
+        _write_table(os.path.join(d, 'sites.txt'), 'sites', site_cols, sites)
+
+        loc_cols = ['location', 'location_type', 'lat_s', 'lat_n',
+                    'lon_w', 'lon_e', 'pole_n_sites']
+        locs = [{'location': 'Loc', 'location_type': 'Outcrop',
+                 'lat_s': '47.0', 'lat_n': '47.5', 'lon_w': '272.0',
+                 'lon_e': '272.0', 'pole_n_sites': '50'}]  # was corrupted to '5'
+        _write_table(os.path.join(d, 'locations.txt'), 'locations',
+                     loc_cols, locs)
+
+        result = ipmag.upload_magic(dir_path=d, input_dir_path=d,
+                                    validate=False, verbose=False)
+        outfile = result[0]
+        assert outfile and os.path.isfile(outfile)
+
+        tables = _parse_tables(outfile)
+        assert tables['locations'][0]['pole_n_sites'] == '50'
+        # lat_n is a latitude, not a count, and must be left intact
+        assert tables['locations'][0]['lat_n'] == '47.5'
+        assert sorted(r['dir_n_samples'] for r in tables['sites']) == ['10', '6']
+
+    def test_trailing_decimal_zero_still_stripped(self, tmp_path):
+        """A genuine '.0' decimal on a count column is still removed."""
+        d = str(tmp_path)
+        loc_cols = ['location', 'location_type', 'lat_s', 'lat_n',
+                    'lon_w', 'lon_e', 'pole_n_sites']
+        locs = [{'location': 'Loc', 'location_type': 'Outcrop',
+                 'lat_s': '47.0', 'lat_n': '47.5', 'lon_w': '272.0',
+                 'lon_e': '272.0', 'pole_n_sites': '50.0'}]
+        _write_table(os.path.join(d, 'locations.txt'), 'locations',
+                     loc_cols, locs)
+        result = ipmag.upload_magic(dir_path=d, input_dir_path=d,
+                                    validate=False, verbose=False)
+        tables = _parse_tables(result[0])
+        assert tables['locations'][0]['pole_n_sites'] == '50'


### PR DESCRIPTION
…pload_magic regression test

fishqq computed its Mu/Me statistics only inside the plot branch, so plot=False raised UnboundLocalError. Compute them on a temporary (closed) figure when not plotting. Add a data_type='poles' option to label the Q-Q axes Longitudes/ Latitudes for VGP/pole inputs, and make the Mode-2 path and return robust.

Add test_ipmag_upload.py covering that integer count columns (pole_n_sites, dir_n_samples) survive upload_magic, guarding the existing _drop_trailing_dot_zero fix