### PR TITLE
progress on new coercivity spectra code and hysteresis processing updates

### DIFF
--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -3,6 +3,7 @@ import numpy as np
 import copy
 import json
 import ast
+import warnings
 
 from scipy.optimize import minimize, brent, least_squares, minimize_scalar, brentq
 from scipy.signal import savgol_filter, find_peaks
@@ -6223,13 +6224,23 @@ def _unmix_fit_engine(x, y, initial, method, curve_type='backfield',
     n_pts, n_par = len(x), len(res.x)
     dof = n_pts - n_par
     se = np.full(n_par, np.nan)
+    covariance_ok = True
     if dof > 0:
         try:
             JtJ = res.jac.T @ res.jac
             cov = 2.0 * res.cost / dof * np.linalg.pinv(JtJ)
             se = np.sqrt(np.clip(np.diag(cov), 0, None))
         except np.linalg.LinAlgError:
-            pass
+            # covariance failed on an otherwise-converged fit: warn and flag it
+            # so the resulting NaN standard errors are not mistaken for those of
+            # a degenerate (dof <= 0) fit
+            covariance_ok = False
+            warnings.warn(
+                'covariance matrix could not be computed (singular Jacobian); '
+                'the linearized standard errors are NaN. The parameter '
+                'estimates are still valid -- use bootstrap or Bayesian '
+                'uncertainty for this fit instead.',
+                RuntimeWarning, stacklevel=2)
 
     c, loc, dp, skew, offset = unpack(res.x)
     se_c = se[:K] * y_scale
@@ -6251,6 +6262,7 @@ def _unmix_fit_engine(x, y, initial, method, curve_type='backfield',
         'skew': np.asarray(skew)[order], 'se_skew': np.asarray(se_skew)[order],
         'offset': offset * y_scale, 'se_offset': se_offset,
         'x': x, 'y': y, 'weights': weights, 'y_scale': y_scale,
+        'covariance_ok': covariance_ok,
     }
 
 
@@ -6309,6 +6321,10 @@ def _build_unmix_result(engine, method, curve_type, vary_skew, fit_offset,
         'reduced_chi_square': rss / dof if dof > 0 else np.nan,
         'aic': n * log_term + 2 * n_params,
         'bic': n * log_term + n_params * np.log(n),
+        # True when the covariance/standard-error computation failed (singular
+        # Jacobian): the se_* fields are NaN for that reason rather than
+        # because the fit was degenerate. Normally False.
+        'covariance_singular': not engine.get('covariance_ok', True),
     }
 
     scipy_result = engine['scipy_result']

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -7699,7 +7699,8 @@ COERCIVITY_COMPONENT_LIBRARY = {
 }
 
 
-def mineral_priors(mineral_names, tighten=1.0, field_max_mT=None):
+def mineral_priors(mineral_names, tighten=1.0, widen=1.0, field_max_mT=None,
+                   overrides=None):
     """
     Build a Bayesian-unmixing prior dictionary from named mineral components.
 
@@ -7709,10 +7710,18 @@ def mineral_priors(mineral_names, tighten=1.0, field_max_mT=None):
     are sorted by their central coercivity so that the returned order
     matches the (low-to-high coercivity) component ordering of the fit.
 
-    Because these are informative priors on an ill-posed decomposition,
-    they should be treated as soft constraints; see the caveats in the
-    COERCIVITY_COMPONENT_LIBRARY documentation (AF-demagnetization vs IRM
-    acquisition, Al-substitution, generous default ranges).
+    The library windows are broad starting points; real samples often need
+    them adapted. Use `tighten` to narrow every window, `widen` to broaden
+    every window, and `overrides` to replace specific windows outright when
+    a mineral in your samples sits outside its library range (for example a
+    harder, finer-grained magnetite, or a hematite whose low-coercivity
+    shoulder starts below the library's detrital-hematite window). A typical
+    workflow is to fit unconstrained first, see where the components land,
+    and then set the windows accordingly.
+
+    Because these are informative priors on an ill-posed decomposition, they
+    should be treated as soft constraints; see the caveats in the
+    COERCIVITY_COMPONENT_LIBRARY documentation.
 
     Parameters
     ----------
@@ -7720,14 +7729,24 @@ def mineral_priors(mineral_names, tighten=1.0, field_max_mT=None):
         Component names, each a key of COERCIVITY_COMPONENT_LIBRARY (e.g.
         ['magnetite_detrital', 'hematite_pigmentary', 'hematite_detrital']).
     tighten : float
-        Factor (>= 1) by which to narrow every range about its center; 1
-        keeps the library ranges, 2 halves their width. Use only when
-        justified by independent constraints.
+        Factor (>= 1) by which to narrow every window about its center; 1
+        keeps the library width.
+    widen : float
+        Factor (>= 1) by which to broaden every window about its center; 1
+        keeps the library width. tighten and widen compose (net width factor
+        = widen / tighten).
     field_max_mT : float, optional
-        Maximum applied field of the measurement (mT). Location upper
-        bounds are clipped to this value, so that components whose library
-        range extends past the measured field (e.g. goethite in a 2 T
-        experiment) are not given prior support the data cannot constrain.
+        Maximum applied field of the measurement (mT). Location upper bounds
+        are clipped to this value, so that components whose window extends
+        past the measured field (e.g. goethite in a 2 T experiment) are not
+        given prior support the data cannot constrain.
+    overrides : dict, optional
+        Per-mineral window replacements, mapping a mineral name to a dict
+        with any of 'B_median_mT', 'dp', 'skew' as (low, high) tuples. The
+        replacement window is used in place of the library value (before
+        tighten/widen and field clipping are applied), letting you anchor to
+        the library for most minerals while tuning the ones your samples
+        require.
 
     Returns
     -------
@@ -7742,10 +7761,14 @@ def mineral_priors(mineral_names, tighten=1.0, field_max_mT=None):
         mineral_names = [mineral_names]
     if tighten < 1:
         raise ValueError('tighten must be >= 1')
+    if widen < 1:
+        raise ValueError('widen must be >= 1')
+    overrides = overrides or {}
+    scale = widen / tighten  # > 1 broadens, < 1 narrows
 
-    def _narrow(low, high):
+    def _rescale(low, high):
         center = 0.5 * (low + high)
-        half = 0.5 * (high - low) / tighten
+        half = 0.5 * (high - low) * scale
         return center - half, center + half
 
     entries = []
@@ -7754,14 +7777,15 @@ def mineral_priors(mineral_names, tighten=1.0, field_max_mT=None):
             raise KeyError(
                 f"unknown mineral component '{name}'; available: "
                 f'{sorted(COERCIVITY_COMPONENT_LIBRARY)}')
-        entry = COERCIVITY_COMPONENT_LIBRARY[name]
-        b_low, b_high = _narrow(*entry['B_median_mT'])
+        entry = {**COERCIVITY_COMPONENT_LIBRARY[name], **overrides.get(name, {})}
+        b_low, b_high = _rescale(*entry['B_median_mT'])
+        b_low = max(b_low, 1e-3)  # keep positive for log10
         if field_max_mT is not None:
             b_high = min(b_high, field_max_mT)
             b_low = min(b_low, b_high)
         entries.append((name, np.sqrt(b_low * b_high),
                         (np.log10(b_low), np.log10(b_high)),
-                        _narrow(*entry['dp']), _narrow(*entry['skew'])))
+                        _rescale(*entry['dp']), _rescale(*entry['skew'])))
     entries.sort(key=lambda item: item[1])
 
     return {
@@ -7782,9 +7806,38 @@ def _format_mT_axis(ax):
     ax.xaxis.set_major_formatter(FuncFormatter(_fmt))
 
 
+def _unmixing_component_colors(b_means_mT, color_by, class_boundaries,
+                               class_colors):
+    """Assign a color to each component, by fit order or coercivity class."""
+    n = len(b_means_mT)
+    if color_by == 'component':
+        return [f'C{i}' for i in range(n)]
+    if color_by not in ('class', 'coercivity'):
+        raise ValueError("color_by must be 'component', 'class', or "
+                         "'coercivity'")
+    if class_boundaries is None:
+        raise ValueError("class_boundaries is required when color_by='class'")
+    boundaries = np.sort(np.atleast_1d(class_boundaries).astype(float))
+    n_classes = len(boundaries) + 1
+    if class_colors is None:
+        class_colors = (['royalblue', 'crimson'] if n_classes == 2
+                        else [plt.get_cmap('coolwarm')(t)
+                              for t in np.linspace(0, 1, n_classes)])
+    if len(class_colors) != n_classes:
+        raise ValueError(f'class_colors must have {n_classes} entries '
+                         f'({len(boundaries)} boundaries + 1)')
+    # component in class k when its mean coercivity exceeds the k-th boundary;
+    # a component exactly on a boundary is assigned to the lower class
+    class_index = np.searchsorted(boundaries, np.asarray(b_means_mT),
+                                  side='left')
+    return [class_colors[k] for k in class_index]
+
+
 def plot_coercivity_unmixing(result, show_components=True,
                              show_bootstrap=True, show_initial=False,
-                             n_grid=300, figsize=None, title=None):
+                             n_grid=300, figsize=None, title=None,
+                             color_by='component', class_boundaries=None,
+                             class_colors=None):
     """
     Plot an unmixing result in its fitted data space.
 
@@ -7812,6 +7865,20 @@ def plot_coercivity_unmixing(result, show_components=True,
         Figure size; defaults depend on the number of panels.
     title : str, optional
         Figure title.
+    color_by : str
+        How to color the components. 'component' (default) colors by fit
+        order (C0, C1, ...). 'class' (or the alias 'coercivity') colors
+        each component by the coercivity class its mean field falls into,
+        so the mineralogy is read directly and a second component of the
+        same mineral does not take a different color; requires
+        class_boundaries.
+    class_boundaries : float or sequence of float, optional
+        Coercivity cut points in mT that partition the components into
+        classes when color_by='class' (e.g. 200 for a magnetite/hematite
+        split, or [30, 300] for three classes).
+    class_colors : sequence, optional
+        One color per class (length = number of boundaries + 1). Defaults
+        to blue/red for two classes, or a diverging colormap otherwise.
 
     Returns
     -------
@@ -7824,6 +7891,9 @@ def plot_coercivity_unmixing(result, show_components=True,
     param_arr = params[UNMIX_PARAM_COLUMNS].to_numpy()
     x, y = result['x'], result['y']
     x_grid = np.linspace(x.min(), x.max(), n_grid)
+    component_colors = _unmixing_component_colors(
+        params['B_mean_mT'].to_numpy(), color_by, class_boundaries,
+        class_colors)
     boot = None
     band_label = '95% bootstrap band'
     if show_bootstrap:
@@ -7857,7 +7927,7 @@ def plot_coercivity_unmixing(result, show_components=True,
                                                 curve_type=curve_type)
             for i in range(len(params)):
                 ax_curve.plot(x_grid, comps[i] + result['offset'],
-                              c=f'C{i}', alpha=0.8)
+                              c=component_colors[i], alpha=0.8)
         if boot is not None:
             curves = boot['curves']
             ax_curve.fill_between(curves['x_grid'], curves['total_p2_5'],
@@ -7874,7 +7944,7 @@ def plot_coercivity_unmixing(result, show_components=True,
         if show_components:
             comps = coercivity_spectrum_components(x_grid, param_arr)
             for i, comp_index in enumerate(params.index):
-                ax_spec.plot(x_grid, comps[i], c=f'C{i}',
+                ax_spec.plot(x_grid, comps[i], c=component_colors[i],
                              label=_component_label(comp_index))
         if show_initial:
             init_arr = _unmix_parameters_to_array(
@@ -7897,13 +7967,13 @@ def plot_coercivity_unmixing(result, show_components=True,
                     ax_spec.fill_between(curves['x_grid'],
                                          curves['components_p2_5'][i],
                                          curves['components_p97_5'][i],
-                                         color=f'C{i}', alpha=0.2)
+                                         color=component_colors[i], alpha=0.2)
         ax_spec.plot(x_grid, coercivity_spectrum_model(x_grid, param_arr),
                      c='k', label='model')
         if show_components:
             comps = coercivity_spectrum_components(x_grid, param_arr)
             for i, comp_index in enumerate(params.index):
-                ax_spec.plot(x_grid, comps[i], c=f'C{i}',
+                ax_spec.plot(x_grid, comps[i], c=component_colors[i],
                              label=_component_label(comp_index))
         if show_initial:
             init_arr = _unmix_parameters_to_array(
@@ -8627,6 +8697,96 @@ def unmix_backfield_experiments(measurements, experiments=None,
         print(f'{len(failures)} experiment(s) failed: '
               f'{[name for name, _reason in failures]}')
     return components_df, results
+
+
+def aggregate_by_class(components, boundaries_mT, class_names=None,
+                       coercivity_column='B_mean_mT',
+                       proportion_column='proportion',
+                       contribution_column='contribution',
+                       curve_factor=2.0, group_column='experiment',
+                       passthrough=('specimen', 'Bcr_mT', 'r_squared')):
+    """
+    Aggregate fitted unmixing components into coercivity classes.
+
+    Sums each component's remanence proportion (and, if available, its
+    contribution) into classes defined by one or more coercivity cut points,
+    per experiment. This is the robust way to quantify a mineral assemblage
+    from an unmixing fit: because it integrates the fitted distribution
+    within coercivity bands, the result is insensitive to how many
+    components the optimizer used or how it split a single mineral, so long
+    as the mineral populations are separated by the cut points. Typical use
+    is a magnetite/hematite split at a single boundary, but any number of
+    classes is supported.
+
+    Parameters
+    ----------
+    components : pandas.DataFrame
+        Tidy component table, e.g. from unmix_backfield_experiments (one row
+        per experiment and component).
+    boundaries_mT : float or sequence of float
+        Coercivity cut point(s) in mT. A single value gives two classes; a
+        sequence of k values gives k+1 classes. A component is placed in the
+        class between the cut points that bracket its coercivity; a component
+        exactly on a boundary goes to the lower class.
+    class_names : sequence of str, optional
+        Names for the classes, in order of increasing coercivity (length =
+        number of boundaries + 1). Defaults to 'class_1', 'class_2', ...;
+        for a two-class split you would typically pass e.g.
+        ['magnetite', 'hematite'].
+    coercivity_column : str
+        Column used to classify each component (default 'B_mean_mT').
+    proportion_column : str
+        Column summed to give each class's remanence fraction (default
+        'proportion').
+    contribution_column : str
+        Column summed (and divided by curve_factor) to give each class's
+        absolute remanence; skipped if the column is absent.
+    curve_factor : float
+        Divisor applied to summed contributions. Use 2 for a shift-corrected
+        backfield curve (which spans twice the saturation remanence) and 1
+        for an IRM acquisition curve.
+    group_column : str
+        Column identifying each specimen/experiment to aggregate within
+        (default 'experiment').
+    passthrough : sequence of str
+        Columns copied through unchanged (first value per group), e.g.
+        specimen name and fit statistics. Missing columns are ignored.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per group with the passthrough columns and, for each class,
+        a '{name}_fraction' column and (when contributions are present) a
+        '{name}_remanence' column.
+    """
+    if coercivity_column not in components.columns:
+        raise KeyError(f"components has no '{coercivity_column}' column")
+    boundaries = np.sort(np.atleast_1d(boundaries_mT).astype(float))
+    edges = np.concatenate([[-np.inf], boundaries, [np.inf]])
+    n_classes = len(edges) - 1
+    if class_names is None:
+        class_names = [f'class_{i + 1}' for i in range(n_classes)]
+    if len(class_names) != n_classes:
+        raise ValueError(f'class_names must have {n_classes} entries '
+                         f'({len(boundaries)} boundaries + 1)')
+    has_contribution = contribution_column in components.columns
+
+    rows = []
+    for group_name, group in components.groupby(group_column):
+        row = {group_column: group_name}
+        for col in passthrough:
+            if col in group.columns:
+                row[col] = group[col].iloc[0]
+        b = group[coercivity_column].to_numpy()
+        for k, name in enumerate(class_names):
+            in_class = (b > edges[k]) & (b <= edges[k + 1])
+            row[f'{name}_fraction'] = \
+                group.loc[in_class, proportion_column].sum()
+            if has_contribution:
+                row[f'{name}_remanence'] = \
+                    group.loc[in_class, contribution_column].sum() / curve_factor
+        rows.append(row)
+    return pd.DataFrame(rows)
 
 
 def parse_specimen_description(description):

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -6524,6 +6524,13 @@ def _unmix_method_maxunmix(x, magnetization, n_components=None,
     n = len(x)
     n_keep = max(int(round(n * proportion)), 3 * K + 3)
 
+    # forward the same fit settings (e.g. dp_bounds, skew_bounds) to every
+    # replicate so it runs under the identical constraints as the main fit.
+    # 'weights' is excluded: each replicate recomputes the spectrum from a
+    # random subset of the curve, so per-point weights of the full spectrum
+    # cannot align with the shorter resampled spectrum.
+    replicate_kwargs = {k: v for k, v in kwargs.items() if k != 'weights'}
+
     tracked = ['contribution', 'proportion', 'location', 'dp', 'skew',
                'sd_log', 'B_mean_mT', 'B_median_mT', 'B_peak_mT']
     samples = {name: [] for name in tracked}
@@ -6547,7 +6554,8 @@ def _unmix_method_maxunmix(x, magnetization, n_components=None,
             fit = unmix_coercivity_spectrum(
                 x_mid_b, spectrum_b, vary_skew=vary_skew,
                 initial_parameters=pd.DataFrame(init,
-                                                columns=UNMIX_PARAM_COLUMNS))
+                                                columns=UNMIX_PARAM_COLUMNS),
+                **replicate_kwargs)
         except (ValueError, RuntimeError):
             continue
         if not fit['success']:
@@ -6687,7 +6695,8 @@ def unmix_coercivity(x, magnetization, method='spectrum', n_components=None,
         Whether skew parameters vary during fitting.
     **kwargs
         Passed through to the method implementation (e.g. n_boot,
-        proportion, noise_level for 'maxunmix'; fit_offset for 'curve').
+        proportion, param_noise for 'maxunmix'; fit_offset for 'curve';
+        dp_bounds, skew_bounds for the spectrum-based methods).
 
     Returns
     -------

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -1,9 +1,12 @@
 import pandas as pd
 import numpy as np
 import copy
+import json
+import ast
 
-from scipy.optimize import minimize, brent, least_squares, minimize_scalar
-from scipy.signal import savgol_filter
+from scipy.optimize import minimize, brent, least_squares, minimize_scalar, brentq
+from scipy.signal import savgol_filter, find_peaks
+from scipy.special import erf, owens_t
 from scipy.interpolate import UnivariateSpline
 
 import matplotlib.pyplot as plt
@@ -2062,26 +2065,21 @@ def mpms_signal_blender_interactive(measurement_1, measurement_2,
 
 def extract_hysteresis_data(df, specimen_name):
     """
-    Extracts and separates Hysteresis data 
-    for a specific specimen from a dataframe.
+    Extracts hysteresis loop data for a specific specimen from a dataframe.
 
-    This function filters data for a given specimen and separates it based on 
-    different MagIC measurement method codes. It specifically looks for data 
-    corresponding to 'LP-HYS' Hysteresis Data
+    This function filters measurements for a given specimen and returns rows
+    whose MagIC method codes contain 'LP-HYS' (hysteresis loop experiments).
 
     Parameters:
-        df (pandas.DataFrame): The dataframe containing MPMS measurement data.
+        df (pandas.DataFrame): The dataframe containing MagIC measurement data.
         specimen_name (str): The name of the specimen to filter data for.
 
     Returns:
-        tuple: A tuple containing four pandas.DataFrames:
-            - fc_data: Data filtered for 'LP-FC' method if available, otherwise an empty DataFrame.
-            - zfc_data: Data filtered for 'LP-ZFC' method if available, otherwise an empty DataFrame.
-            - rtsirm_cool_data: Data filtered for 'LP-CW-SIRM:LP-MC' method if available, otherwise an empty DataFrame.
-            - rtsirm_warm_data: Data filtered for 'LP-CW-SIRM:LP-MW' method if available, otherwise an empty DataFrame.
+        pandas.DataFrame: Measurements for the specimen with 'LP-HYS' in
+            their method codes (empty if none are present).
 
     Example:
-        >>> fc, zfc, rtsirm_cool, rtsirm_warm = extract_mpms_data_dc(measurements_df, 'Specimen_1')
+        >>> hyst_data = extract_hysteresis_data(measurements_df, 'Specimen_1')
     """
 
     specimen_df = df[df['specimen'] == specimen_name]
@@ -2168,33 +2166,40 @@ def collapse_hysteresis_field_plateaus(field, magnetization):
     return np.asarray(collapsed_field, dtype=float), np.asarray(collapsed_magnetization, dtype=float)
 
 def find_hysteresis_turning_point(field):
-    """Find the single loop reversal, tolerating repeated plateaus and minor field glitches."""
+    """Find the single loop reversal, tolerating repeated plateaus and minor field glitches.
+
+    Returns the index of the last point of the first field sweep, such that
+    field[:index+1] is the first branch and field[index+1:] is the second
+    branch. Zero field steps (plateaus from repeated field values) are ignored
+    when detecting the reversal, and if field glitches produce multiple sign
+    changes, the reversal closest to the global field extremum opposite the
+    initial sweep direction is chosen.
+    """
     field = np.asarray(field, dtype=float)
     if field.size < 3:
         raise ValueError('At least three field steps are required to split a hysteresis loop')
 
     field_diff = np.diff(field)
-    nonzero_diff = field_diff[field_diff != 0]
-    if nonzero_diff.size == 0:
+    nonzero_indices = np.where(field_diff != 0)[0]
+    if nonzero_indices.size == 0:
         raise ValueError('Applied field does not vary and cannot be split into loop branches')
 
-    diff_sign = np.sign(nonzero_diff)
-    turning_points = np.where(diff_sign[:-1] * diff_sign[1:] < 0)[0] + 1
-    if len(turning_points) == 1:
-        return int(turning_points[0])
+    diff_sign = np.sign(field_diff[nonzero_indices])
+    # sign changes between consecutive non-zero field steps mark reversals;
+    # the turning point is the last index of the sweep ending at the reversal
+    sign_changes = np.where(diff_sign[:-1] * diff_sign[1:] < 0)[0]
+    if sign_changes.size == 0:
+        raise ValueError('No turning point found in the applied field. The data may not be a hysteresis loop.')
+    candidates = nonzero_indices[sign_changes] + 1
+    if candidates.size == 1:
+        return int(candidates[0])
 
     initial_direction = np.sign(np.median(diff_sign[:min(10, len(diff_sign))]))
     if initial_direction == 0:
         initial_direction = diff_sign[0]
 
     extremum_index = int(np.argmin(field) if initial_direction < 0 else np.argmax(field))
-    if len(turning_points) > 1:
-        return int(turning_points[np.argmin(np.abs(turning_points - extremum_index))])
-
-    midpoint = len(field) // 2
-    if 0 < extremum_index < len(field) - 1:
-        return extremum_index
-    return midpoint
+    return int(candidates[np.argmin(np.abs(candidates - extremum_index))])
 
 def build_symmetric_hysteresis_grid(upper_branch, lower_branch):
     """Build a symmetric field grid over the overlap shared by the two loop branches."""
@@ -2227,10 +2232,77 @@ def build_symmetric_hysteresis_grid(upper_branch, lower_branch):
     lower_grid = upper_grid[::-1]
     return upper_grid, lower_grid
 
+def sanitize_hysteresis_inputs(field, magnetization, drop_nonfinite=True):
+    """Coerce hysteresis loop inputs into clean float arrays for processing.
+
+    This helper makes the processing functions usable with data from any
+    source: MagIC measurement table columns (including ones read as text),
+    plain Python lists, or arrays exported from instrument software.
+
+    Parameters
+    ----------
+    field : array_like
+        Applied field values. Expected in tesla: the chi_HF unit conversions
+        in `linear_HF_fit`, `hyst_slope_correction`, and the nonlinear fits
+        assume tesla, so a warning is printed if the values appear to be in
+        mT or Oe (max |field| > 20).
+    magnetization : array_like
+        Magnetization or moment values, in any unit that is consistent
+        across the loop (mass-normalized Am2/kg matches MagIC conventions).
+    drop_nonfinite : bool, optional
+        If True (default), measurement pairs where either value is NaN or
+        infinite are dropped with a printed report. If False, a ValueError
+        is raised when non-finite values are present.
+
+    Returns
+    -------
+    field, magnetization : numpy.ndarray
+        Equal-length float arrays with only finite values.
+    """
+    try:
+        field = np.asarray(field, dtype=float)
+        magnetization = np.asarray(magnetization, dtype=float)
+    except (TypeError, ValueError) as error:
+        raise ValueError('Field and magnetization values must be numeric '
+                         f'(or numeric strings): {error}')
+    if field.ndim != 1 or magnetization.ndim != 1:
+        raise ValueError('Field and magnetization must be one-dimensional sequences')
+    if field.shape != magnetization.shape:
+        raise ValueError('Field and magnetization arrays must be the same length')
+
+    finite = np.isfinite(field) & np.isfinite(magnetization)
+    if not finite.all():
+        n_dropped = int(np.sum(~finite))
+        if not drop_nonfinite:
+            raise ValueError(f'{n_dropped} measurement(s) have non-finite field '
+                             'or magnetization values')
+        print(f'-W- dropping {n_dropped} measurement(s) with non-finite field '
+              'or magnetization values')
+        field = field[finite]
+        magnetization = magnetization[finite]
+
+    if field.size < 10:
+        raise ValueError('At least 10 finite measurements are required to '
+                         'process a hysteresis loop')
+
+    max_field = np.max(np.abs(field))
+    if max_field > 20:
+        print(f'-W- maximum |field| is {max_field:g}, which suggests the field '
+              'values are not in tesla (e.g. mT or Oe); the high-field '
+              'susceptibility unit conversions assume tesla')
+
+    return field, magnetization
+
 def split_hysteresis_loop(field, magnetization):
     '''
     function to split a hysteresis loop into upper and lower branches
-        by the change of sign in the applied field gradient
+        at the reversal of the applied field sweep
+
+    The loop reversal is located with `find_hysteresis_turning_point`, which
+    tolerates repeated field plateaus and minor field glitches. Loops measured
+    in either sweep order are supported: the branch measured from the positive
+    field extreme downward is returned as the upper branch regardless of
+    whether it was measured first or second.
 
     Parameters
     ----------
@@ -2241,33 +2313,30 @@ def split_hysteresis_loop(field, magnetization):
 
     Returns
     -------
-    upper_branch : tuple
-        tuple of field and magnetization values for the upper branch
-    lower_branch : tuple
-        tuple of field and magnetization values for the lower branch
+    upper_branch : list
+        [field, magnetization] for the upper branch, in ascending field order
+    lower_branch : list
+        [field, magnetization] for the lower branch, in ascending field order
     '''
     assert len(field) == len(magnetization), 'Field and magnetization arrays must be the same length'
+    field = np.asarray(field, dtype=float)
+    magnetization = np.asarray(magnetization, dtype=float)
 
-    # identify loop turning point by change in sign of the field difference
-    # split the data into upper and lower branches
-    field_gradient = np.gradient(field)
-    # There should just be one turning point in the field gradient
-    turning_points = np.where(np.diff(np.sign(field_gradient)))[0]
-    if len(turning_points) == 0:
-        raise ValueError('No turning point found in the field gradient. The data may not be a hysteresis loop.')
-    elif len(turning_points) > 1:
-        print('More than one turning point found in the gradient of the applied field')
-        print('Trying to force splitting the loop based on the number of measurements...')
-        n = len(field) // 2
-        upper_branch = [field[:n], magnetization[:n]]
-        lower_branch = [field[n:], magnetization[n:]]
+    turning_point = find_hysteresis_turning_point(field)
+    first_branch = [field[:turning_point+1], magnetization[:turning_point+1]]
+    second_branch = [field[turning_point+1:], magnetization[turning_point+1:]]
+
+    if field[0] > field[turning_point]:
+        # sweep starts at the positive extreme: the first segment is the
+        # descending upper branch; reverse it into ascending field order
+        upper_branch = [first_branch[0][::-1], first_branch[1][::-1]]
+        lower_branch = second_branch
     else:
-        turning_point = turning_points[0]
-        upper_branch = [field[:turning_point+1], magnetization[:turning_point+1]]
-        # sort the upper branch in reverse order
-        upper_branch = [field[:turning_point+1][::-1], magnetization[:turning_point+1][::-1]]
-        lower_branch = [field[turning_point+1:], magnetization[turning_point+1:]]
-    
+        # sweep starts at the negative extreme: the first segment is the
+        # ascending lower branch and the second is the descending upper branch
+        lower_branch = first_branch
+        upper_branch = [second_branch[0][::-1], second_branch[1][::-1]]
+
     return upper_branch, lower_branch
 
 def grid_hysteresis_loop(field, magnetization):
@@ -2290,8 +2359,20 @@ def grid_hysteresis_loop(field, magnetization):
         gridded magnetization values
     '''
     assert len(field) == len(magnetization), 'Field and magnetization arrays must be the same length'
+    field = np.asarray(field, dtype=float)
+    magnetization = np.asarray(magnetization, dtype=float)
+    if not (np.isfinite(field).all() and np.isfinite(magnetization).all()):
+        raise ValueError('Non-finite field or magnetization values present; '
+                         'clean the inputs first (see sanitize_hysteresis_inputs)')
 
     upper_branch, lower_branch = split_hysteresis_loop(field, magnetization)
+
+    # average any exactly repeated field steps within each branch (e.g.
+    # instrument plateaus at the loop tips) so duplicate fields do not enter
+    # the interpolation; small non-monotonic field glitches are not repaired
+    # here and np.interp will locally smooth over them
+    upper_branch = collapse_hysteresis_field_plateaus(upper_branch[0], upper_branch[1])
+    lower_branch = collapse_hysteresis_field_plateaus(lower_branch[0], lower_branch[1])
 
     upper_field, lower_field = build_symmetric_hysteresis_grid(upper_branch, lower_branch)
     grid_field = np.concatenate([upper_field, lower_field])
@@ -2707,7 +2788,15 @@ def calc_Q(H, M, type='Q'):
     """
     Calculate the quality factor (Q) for a magnetic hysteresis loop.
 
-    The Q factor is a logarithmic measure (base 10) of the signal-to-noise ratio for a hysteresis loop.
+    The Q factor is a logarithmic measure (base 10) of the signal-to-noise ratio for a
+    hysteresis loop, following Jackson and Solheid (2010): the upper and inverted lower
+    branches are treated as replicate measurements, so their mean squared moment relative
+    to the mean squared mismatch between them (the err(H) curve) quantifies signal/noise.
+    Q = log10(s/n); loops with Q >= 2 have small deviations from inversion symmetry while
+    loops with Q below ~0.3 (s/n ~ 2) are too noisy for meaningful parameter estimation.
+    The quality factor of the ferromagnetic component (Q_f of Jackson and Solheid, 2010)
+    is obtained by calling this function on the slope-corrected loop.
+
     The calculation can be performed in two modes:
         - 'Q': Uses the mean squared magnetization of both the upper and lower branches.
         - 'Qf': Uses only the upper branch.
@@ -2734,7 +2823,9 @@ def calc_Q(H, M, type='Q'):
     -----
     - The function splits the hysteresis loop into upper and lower branches using `split_hysteresis_loop`.
     - For type 'Q', the numerator is the average of the sum of squares of the upper and lower branches; for 'Qf', only the upper branch is used.
-    - The denominator is always the sum of squares of the combined (averaged) upper and reversed lower branches.
+    - The denominator is the sum of squares of err(H), the mismatch between the upper branch
+      and the inverted lower branch, so M_sn is equivalent to the 1/(1 - R^2) signal/noise
+      measure of Jackson and Solheid (2010, equation 3).
     - Higher Q values indicate a higher signal-to-noise ratio in the hysteresis loop data.
 
     Examples
@@ -2747,8 +2838,12 @@ def calc_Q(H, M, type='Q'):
     assert type in ['Q', 'Qf'], 'type must be either Q or Qf'
     H = np.array(H)
     M = np.array(M)
-    upper_branch, lower_branch = split_hysteresis_loop(H, M)  
+    upper_branch, lower_branch = split_hysteresis_loop(H, M)
     Me = upper_branch[1] + lower_branch[1][::-1]
+    # the square root follows the convention of the IRM software and HystLab
+    # (Paterson et al., 2018, equation 4): Q = log10(1/sqrt(1 - R^2)); the
+    # equation as printed in Jackson and Solheid (2010) omits the square root
+    # but their reported values include it (see Paterson et al., 2018)
     if type == 'Q':
         M_sn = np.sqrt((np.sum(upper_branch[1]**2) + np.sum(lower_branch[1][::-1]**2))/2/np.sum(Me**2))
     elif type == 'Qf':
@@ -2784,10 +2879,16 @@ def hyst_loop_centering(grid_field, grid_magnetization):
     grid_magnetization = np.array(grid_magnetization)
     R_squared, H_offset, M_offset = loop_Hshift_brent(grid_field, grid_magnetization)
 
-    M_sn, Q = calc_Q(grid_field, grid_magnetization)
-
     # re-gridding after offset correction to ensure symmetry
     centered_H, centered_M = grid_hysteresis_loop(grid_field-H_offset, grid_magnetization-M_offset)
+
+    # quality factor from the offset-corrected loop (Jackson and Solheid, 2010,
+    # section 3: Q reflects noise and drift after the effects of loop offsets
+    # are removed; HystLab likewise computes Q on the offset-corrected curves).
+    # Computing Q on the uncorrected loop would let a loop offset depress Q
+    # below the decision-tree gate that decides whether to apply the offset
+    # correction itself.
+    M_sn, Q = calc_Q(centered_H, centered_M)
 
     results = {'centered_H':centered_H, 
                'centered_M': centered_M, 
@@ -2876,9 +2977,11 @@ def linear_HF_fit(field, magnetization, HF_cutoff=0.8):
 
     Returns
     -------
-    slope : float
-        slope of the linear fit
-        can be interpreted to be the paramagnetic/diamagnetic susceptibility
+    chi_HF : float
+        high-field susceptibility of the paramagnetic/diamagnetic contribution
+        in SI units (the raw fitted slope in field units of Tesla multiplied
+        by mu_0 = 4*pi*1e-7); `hyst_slope_correction` performs the inverse
+        conversion when removing this contribution from a loop
     intercept : float
         y-intercept of the linear fit
         can be interpreted to be the saturation magnetization of the ferromagnetic component
@@ -2937,8 +3040,9 @@ def hyst_slope_correction(grid_field, grid_magnetization, chi_HF):
 
 def find_y_crossing(x, y, y_target=0.0):
     """
-    Finds the x-value where y crosses a given y_target, nearest to x = 0.
-    Uses linear interpolation between adjacent points that bracket y_target.
+    Finds the x-value where y crosses a given y_target, taking the first
+    crossing encountered in array order. Uses linear interpolation between
+    adjacent points that bracket y_target.
 
     Parameters:
         x (array-like): x-values
@@ -2946,7 +3050,8 @@ def find_y_crossing(x, y, y_target=0.0):
         y_target (float): y-value at which to find crossing (default: 0)
 
     Returns:
-        x_cross (float or None): interpolated x at y = y_target nearest to x = 0, or None if not found
+        x_cross (float or None): interpolated x at y = y_target for the first
+            crossing in array order, or None if not found
     """
     x = np.asarray(x)
     y = np.asarray(y)
@@ -2976,22 +3081,21 @@ def calc_Mr_Mrh_Mih_Brh(grid_field, grid_magnetization):
     -------
     H : numpy array
         field values of the upper branch (the two branches should have the same field values)
-    Mrh : float
-        remanent magnetization value
-    Mih : float
-        induced magnetization value
+    Mr : float
+        remanent magnetization (Mrh interpolated at zero field)
+    Mrh : numpy array
+        remanent hysteretic magnetization, (upper - lower)/2
+    Mih : numpy array
+        induced hysteretic magnetization, (upper + lower)/2
     Me : numpy array
-        error on M(H), calculated as the subtraction of the inverted lower branch from the upper branch
+        error curve err(H), the mismatch between the upper branch and the inverted lower branch
     Brh : float
-        median field of Mrh
+        median field of Mrh (field at which Mrh falls to half of Mr)
 
     '''
-    # calculate Mrh bu subtracting the upper and lower branches of a hysterisis loop
+    # calculate Mrh by subtracting the upper and lower branches of a hysteresis loop
     grid_field = np.array(grid_field)
     grid_magnetization = np.array(grid_magnetization)
-
-    grid_field = grid_field
-    grid_magnetization = grid_magnetization
 
     upper_branch, lower_branch = split_hysteresis_loop(grid_field, grid_magnetization)
 
@@ -3062,7 +3166,6 @@ def loop_saturation_stats(field, magnetization, HF_cutoff=0.8, max_field_cutoff=
     field = np.array(field)
     magnetization = np.array(magnetization)
     upper_branch, lower_branch = split_hysteresis_loop(field, magnetization)
-    Me = upper_branch[1] + lower_branch[1][::-1]
     # filter for the high field portion of each branch
     pos_high_field_index = np.where((field >= HF_cutoff*np.max(np.abs(field))) & (field <= max_field_cutoff*np.max(np.abs(field))))[0]
     neg_high_field_index = np.where((field <= -HF_cutoff*np.max(np.abs(field))) & (field >= -max_field_cutoff*np.max(np.abs(field))))[0]
@@ -3085,12 +3188,24 @@ def loop_saturation_stats(field, magnetization, HF_cutoff=0.8, max_field_cutoff=
     SSD = anova_results['SSD']
     R_squared = anova_results['R_squared']
 
-    SSPE = np.sum((upper_branch[1] - (-lower_branch[1][::-1])) ** 2)  / 2
+    # pure error from the mismatch between symmetrically equivalent points,
+    # restricted to the same high-field window used for the lack-of-fit SSD
+    # (err(H) indexed by the upper branch field covers each pair once)
+    err_field = np.asarray(upper_branch[0], dtype=float)
+    err = np.asarray(upper_branch[1], dtype=float) + np.asarray(lower_branch[1], dtype=float)[::-1]
+    max_abs_field = np.max(np.abs(field))
+    hf_pairs = (np.abs(err_field) >= HF_cutoff * max_abs_field) & \
+               (np.abs(err_field) <= max_field_cutoff * max_abs_field)
+    SSPE = np.sum(err[hf_pairs] ** 2) / 2
     SSLF = SSD - SSPE
-    MSR = SSR 
+    n_pairs = int(np.sum(hf_pairs))
+    if n_pairs <= 2:
+        raise ValueError('Too few high-field points for the lack-of-fit test; '
+                         'lower HF_cutoff or measure with finer field steps')
+    MSR = SSR
     MSD = SSD / (len(high_field) - 2)
-    MSPE = SSPE / (len(high_field) / 2)
-    MSLF = SSLF / (len(high_field)/2 - 2)
+    MSPE = SSPE / n_pairs
+    MSLF = SSLF / (n_pairs - 2)
 
     FL = MSR / MSD
     FNL = MSLF / MSPE
@@ -3113,10 +3228,11 @@ def hyst_loop_saturation_test(grid_field, grid_magnetization, max_field_cutoff=0
     """
     Assess the saturation state of a magnetic hysteresis loop based on linearity at high-field segments.
 
-    This function evaluates the degree of saturation in a hysteresis loop by calculating the first normalized linearity (FNL)
-    at 60%, 70%, and 80% of the maximum field (up to a specified cutoff). The FNL values are analyzed to determine the field
-    fraction at which the loop can be considered saturated, based on whether FNL exceeds a threshold (typically 2.5).
-    The result helps determine if the sample reached magnetic saturation during measurement.
+    This function evaluates the degree of saturation in a hysteresis loop by calculating the F statistic
+    for nonlinearity (FNL, the lack-of-fit F ratio of Jackson and Solheid, 2010) over high-field windows
+    starting at 60%, 70%, and 80% of the maximum field (up to a specified cutoff). A significant FNL
+    (above the 2.5 threshold) indicates reproducible curvature in that window, i.e. the ferromagnetic
+    moment has not saturated and a linear high-field fit is inappropriate there.
 
     Parameters
     ----------
@@ -3131,19 +3247,21 @@ def hyst_loop_saturation_test(grid_field, grid_magnetization, max_field_cutoff=0
     -------
     results_dict : dict
         Dictionary containing:
-            - 'FNL60': float, FNL at 60% of the maximum field.
-            - 'FNL70': float, FNL at 70% of the maximum field.
-            - 'FNL80': float, FNL at 80% of the maximum field.
-            - 'saturation_cutoff': float, field fraction (0.6, 0.7, 0.8, or 0.92) at which the loop is considered saturated.
-            - 'loop_is_saturated': bool, True if the loop is not saturated at 80%, 70%, or 60%.
-              (False means the loop is considered saturated at one of those field fractions.)
+            - 'FNL60': float, FNL for the window from 60% of the maximum field.
+            - 'FNL70': float, FNL for the window from 70% of the maximum field.
+            - 'FNL80': float, FNL for the window from 80% of the maximum field.
+            - 'saturation_cutoff': float, lowest field fraction (0.6, 0.7, or 0.8) at which the
+              high-field segment is statistically linear (saturated); 0.92 (the IRM default for
+              a nonlinear fit window) if no tested window is linear.
+            - 'loop_is_saturated': bool, True if the loop is saturated (linear) in at least one
+              tested high-field window; False if all windows show significant nonlinearity,
+              in which case an approach-to-saturation fit should be used.
 
     Notes
     -----
     - The function uses `loop_saturation_stats` to compute FNL values for each field fraction.
-    - FNL values above 2.5 indicate linear (unsaturated) behavior; values below suggest saturation.
-    - The 'saturation_cutoff' indicates the lowest field fraction where the loop is still considered saturated;
-      0.92 is returned if the loop does not saturate at any tested fraction (typical for IRM measurements).
+    - FNL values below 2.5 indicate statistically linear (saturated) high-field behavior;
+      values above 2.5 indicate significant nonlinearity (nonsaturation).
     - The result is converted to standard Python types using `dict_in_native_python`.
 
     Examples
@@ -3172,63 +3290,93 @@ def hyst_loop_saturation_test(grid_field, grid_magnetization, max_field_cutoff=0
     return results_dict
 
 
-def loop_closure_test(H, Mrh, HF_cutoff=0.8):
+def loop_closure_test(H, Mrh, Me=None, HF_cutoff=0.8, max_field_cutoff=0.99):
     '''
-    function for testing if the loop is open
-    
+    function for testing whether a hysteresis loop is closed at high fields
+
+    Mrh should be an even function of field for a well-behaved loop
+    (Mrh(-H) = Mrh(H)), so its field-reflection average (even part, with
+    unphysical negative values set to zero) is taken as the signal. A loop
+    that remains open at high fields (e.g. due to unsaturated high-coercivity
+    phases such as hematite or goethite) retains a significant Mrh signal in
+    the high-field window, giving a high signal-to-noise ratio (SNR) and a
+    high ratio of high-field Mrh area to total Mrh area (HAR). The noise is
+    estimated from the high-field portion of the err(H) curve when `Me` is
+    provided (matching the HystLab implementation of this test; Paterson et
+    al., 2018, section 4.5), or from the odd part of Mrh otherwise. Fields
+    above max_field_cutoff (default 99%) of the maximum field are excluded
+    from the high-field windows to avoid extreme-tip artifacts.
+
     Parameters
     ----------
     H: array-like
-        field values
+        field values of the upper branch (ascending)
     Mrh: array-like
-        remanence componentt
+        remanent hysteretic magnetization Mrh(H)
+    Me: array-like, optional
+        error curve err(H) on the same field axis (as returned by
+        calc_Mr_Mrh_Mih_Brh); used as the noise estimate when provided
     HF_cutoff: float
-        high field cutoff value taken as percentage of the max field value
+        high field cutoff value taken as fraction of the max field value
+    max_field_cutoff: float
+        upper trim of the high-field windows as fraction of the max field
 
     Returns
     -------
-    SNR: float
-        high field signal to noise ratio
-    HAR: float
-        high field area ratio
+    results : dict
+        Dictionary containing:
+            - 'SNR': float, high-field signal-to-noise ratio in dB
+            - 'HAR': float, high-field to total Mrh area ratio in dB
+            - 'loop_is_closed': bool, True if SNR < 8 dB or HAR < -48 dB
     '''
     assert len(H) == len(Mrh), 'H, Mrh must have the same length'
+    H = np.asarray(H, dtype=float)
+    Mrh = np.asarray(Mrh, dtype=float)
+    max_H = np.max(np.abs(H))
+
     pos_H_index = np.where(H > 0)
     neg_H_index = np.where(H < 0)
     pos_H = H[pos_H_index]
-    neg_H = H[neg_H_index]
     pos_Mrh = Mrh[pos_H_index]
     neg_Mrh = Mrh[neg_H_index]
 
-    pos_HF_index = np.where(H > HF_cutoff*np.max(H))
-    neg_HF_index = np.where(H < -HF_cutoff*np.max(H))
+    pos_HF_index = np.where((H > HF_cutoff*max_H) & (H <= max_field_cutoff*max_H))
+    neg_HF_index = np.where((H < -HF_cutoff*max_H) & (H >= -max_field_cutoff*max_H))
     pos_HF = H[pos_HF_index]
-    neg_HF = H[neg_HF_index]
     pos_HF_Mrh = Mrh[pos_HF_index]
     neg_HF_Mrh = Mrh[neg_HF_index]
-    
-    average_Mrh = (pos_Mrh - neg_Mrh[::-1])/2
-    # replace all negative values with 0
+
+    # field-reflection average of Mrh (signal); negative values are noise
+    # excursions and are set to 0 so that only positive signal is counted
+    average_Mrh = (pos_Mrh + neg_Mrh[::-1])/2
     average_Mrh[average_Mrh < 0] = 0
-    average_HF_Mrh = (pos_HF_Mrh - neg_HF_Mrh[::-1])/2
-    # replace all negative values with 0
+    average_HF_Mrh = (pos_HF_Mrh + neg_HF_Mrh[::-1])/2
     average_HF_Mrh[average_HF_Mrh < 0] = 0
-    HF_Mrh_noise = pos_HF_Mrh + neg_HF_Mrh[::-1]
-    # replace all negative values with 0
-    HF_Mrh_noise[HF_Mrh_noise < 0] = 0
+
+    if Me is not None:
+        # noise from the high-field portion of the err(H) curve, over both
+        # field polarities (the HystLab convention)
+        Me = np.asarray(Me, dtype=float)
+        assert len(Me) == len(H), 'H, Me must have the same length'
+        hf_noise = Me[(np.abs(H) > HF_cutoff*max_H) & (np.abs(H) <= max_field_cutoff*max_H)]
+    else:
+        # fall back to the odd part of Mrh (the residual between the field
+        # polarities); for white noise this runs ~3 dB below the err(H)-based
+        # estimate, biasing slightly toward classifying loops as open
+        hf_noise = pos_HF_Mrh - neg_HF_Mrh[::-1]
 
     HF_Mrh_signal_RMS = np.sqrt(np.mean(average_HF_Mrh**2))
-    HF_Mrh_noise_RMS = np.sqrt(np.mean(HF_Mrh_noise**2))
+    HF_Mrh_noise_RMS = np.sqrt(np.mean(hf_noise**2))
     SNR = 20*np.log10(HF_Mrh_signal_RMS/HF_Mrh_noise_RMS)
 
-    total_Mrh_area = np.trapezoid(pos_Mrh, pos_H) + np.trapezoid(-neg_Mrh[::-1], -neg_H[::-1])
-    total_HF_Mrh_area = np.trapezoid(average_Mrh, pos_H)
+    total_Mrh_area = np.trapezoid(average_Mrh, pos_H)
+    HF_Mrh_area = np.trapezoid(average_HF_Mrh, pos_HF)
 
-    HAR = 20*np.log10(total_HF_Mrh_area/total_Mrh_area)
+    HAR = 20*np.log10(HF_Mrh_area/total_Mrh_area)
     loop_is_closed = (SNR < 8) or (HAR < -48)
 
-    results = {'SNR':float(SNR), 
-               'HAR':float(HAR), 
+    results = {'SNR':float(SNR),
+               'HAR':float(HAR),
                'loop_is_closed':bool(loop_is_closed),
                }
     return results
@@ -3307,6 +3455,12 @@ def prorated_drift_correction(field, magnetization):
         apply linearly prorated correction of M(H)
         this should be applied to the gridded data
 
+    Note: the prorated ramp assumes the array order corresponds to measurement
+    time with the upper (descending) branch first, which is the order produced
+    by `grid_hysteresis_loop`. For loops originally measured in the opposite
+    sweep order the correction still closes the loop but attributes the drift
+    with the opposite sense.
+
     Parameters
     ----------
     field : numpy array
@@ -3332,7 +3486,9 @@ def prorated_drift_correction(field, magnetization):
     M_ce = upper_branch[1][upper_branch_max_idx] - lower_branch[1][lower_branch_max_idx]
 
     # apply linearly prorated correction of M(H)
-    corrected_magnetization = [M_ce * ((i-1)/(len(field)-1) - 1/2) + magnetization[i] for i in range(len(field))]
+    # delta_M_i = M_ce * (i/(N-1) - 1/2) with 0-based i, which averages to zero
+    # over the loop and removes the closure error M_ce between first and last points
+    corrected_magnetization = [M_ce * (i/(len(field)-1) - 1/2) + magnetization[i] for i in range(len(field))]
 
     return np.array(corrected_magnetization)
 
@@ -3549,7 +3705,15 @@ def hyst_HF_nonlinear_optimization(H, M, HF_cutoff, fit_type, initial_guess=[1, 
         Fit results with keys:
         - 'chi_HF', 'Ms', 'a_1', 'a_2' (for IRM) or
           'chi_HF', 'Ms', 'alpha', 'beta' (for Fabian variants)
-        - 'Fnl_lin': float, ratio comparing nonlinear vs. linear fit  
+        - 'Fnl_lin': float, F statistic for the improvement of the nonlinear fit
+          over a linear fit (Jackson and Solheid, 2010, equation 21); values above
+          ~3-3.5 indicate a statistically significant improvement for the
+          4-parameter models (for 'Fabian_fixed_beta' the degrees of freedom are
+          (1, N-3) and the 5% critical value is ~3.9-4.0). Because the nonlinear
+          coefficients are constrained non-positive, the statistic is conservative
+          under the null (saturated loops give values well below the critical
+          value, occasionally marginally negative when the bounded fit is a hair
+          worse than unconstrained least squares).
     '''
     HF_index = np.where((np.abs(H) >= HF_cutoff*np.max(np.abs(H))) & (np.abs(H) <= 0.97*np.max(np.abs(H))))[0]
 
@@ -3581,31 +3745,26 @@ def hyst_HF_nonlinear_optimization(H, M, HF_cutoff, fit_type, initial_guess=[1, 
         chi_HF, Ms, alpha = results.x
         nonlinear_fit = Fabian_nonlinear_fit(HF_field, chi_HF, Ms, alpha, -2)
 
-    # let's also report the Fnl_lin which is a measure of whether the nonlinear fit is better than a linear fit
-    # let's first make a linear fit
+    # Fnl_lin (Jackson and Solheid, 2010, equation 21) tests whether the nonlinear fit
+    # significantly improves on a linear fit:
+    # Fnl_lin = [(SSD_lin - SSD_nl)/(p_nl - p_lin)] / [SSD_nl/(N - p_nl)]
+    # where p are the number of model parameters. Values above ~3-3.5 indicate a
+    # statistically significant improvement from the nonlinear term(s).
     linear_fit_ANOVA = ANOVA(HF_field, HF_magnetization)
-    R_squared_l = 1 - linear_fit_ANOVA['R_squared']
+    SSD_lin = linear_fit_ANOVA['SSD']
+    SSD_nl = np.sum((HF_magnetization - nonlinear_fit) ** 2)
 
-    # now calculate the nonlinear fit SST
-    nl_SST = np.sum((HF_magnetization - np.mean(HF_magnetization)) ** 2)
-
-    # sum of squares due to regression
-    nl_SSR = np.sum((nonlinear_fit - np.mean(HF_magnetization)) ** 2)
-    
-    # the remaining unexplained variation (noise and lack of fit)
-    nl_SSD = np.sum((HF_magnetization - nonlinear_fit) ** 2)
-    
-    R_squared_nl = 1 - nl_SSR/nl_SST 
-
-    # calculate the Fnl_lin stat
-    Fnl_lin = R_squared_l / R_squared_nl
+    n_points = len(HF_magnetization)
+    p_lin = 2
+    p_nl = 3 if fit_type == 'Fabian_fixed_beta' else 4
+    Fnl_lin = ((SSD_lin - SSD_nl) / (p_nl - p_lin)) / (SSD_nl / (n_points - p_nl))
 
     final_result['Fnl_lin'] = Fnl_lin
     final_result_dict = dict_in_native_python(final_result)
     return final_result_dict
 
 
-def process_hyst_loop(field, magnetization, specimen_name, show_results_table=True, show_plot=True,
+def process_hyst_loop(field, magnetization, specimen_name='', show_results_table=True, show_plot=True,
                       NL_fit=False, centering_protocol='legacy'):
     """
     Process a magnetic hysteresis loop using the IRM decision tree workflow.
@@ -3614,13 +3773,23 @@ def process_hyst_loop(field, magnetization, specimen_name, show_results_table=Tr
     high-field correction, and extraction of key magnetic parameters. The workflow follows best practices in rock magnetism
     and outputs both a summary of results and a Bokeh plot visualizing the various processing steps.
 
+    The inputs need not come from a MagIC measurements table: any pair of
+    field and magnetization sequences (lists, arrays, or dataframe columns)
+    can be processed. Inputs are passed through `sanitize_hysteresis_inputs`,
+    so non-finite measurement pairs are dropped with a report, numeric
+    strings are converted, and either field sweep order (starting from
+    positive or negative saturation) is accepted.
+
     Parameters
     ----------
     field : array_like
-        Array of applied magnetic field values (typically in Tesla).
+        Array of applied magnetic field values in tesla (the chi_HF unit
+        conversions assume tesla; a warning is printed if the values appear
+        to be in mT or Oe).
     magnetization : array_like
-        Array of magnetization values (same length as `field`).
-    specimen_name : str
+        Array of magnetization values (same length as `field`), in any
+        consistent unit; mass-normalized Am2/kg matches MagIC conventions.
+    specimen_name : str, optional
         Identifier for the specimen, used for labeling plots.
     show_results_table : bool, optional
         If True (default), display a summary table of key parameters using Bokeh.
@@ -3640,7 +3809,7 @@ def process_hyst_loop(field, magnetization, specimen_name, show_results_table=Tr
             - 'gridded_M': gridded magnetization values
             - 'linearity_test_results': results of the initial linearity test
             - 'loop_is_linear': whether the loop passes the linearity test
-            - 'FNL': first normalized linearity value
+            - 'FNL': F statistic for whole-loop nonlinearity (lack-of-fit F ratio)
             - 'loop_centering_results': results of centering optimization
             - 'centered_H': centered field values
             - 'centered_M': centered magnetization values
@@ -3654,13 +3823,19 @@ def process_hyst_loop(field, magnetization, specimen_name, show_results_table=Tr
             - 'H', 'Mr', 'Mrh', 'Mih', 'Me', 'Brh': characteristic field and moment parameters
             - 'sigma': shape parameter (Fabian, 2003)
             - 'chi_HF': high-field susceptibility
-            - 'FNL60', 'FNL70', 'FNL80': FNL at 60%, 70%, and 80% field
+            - 'FNL60', 'FNL70', 'FNL80': high-field nonlinearity F statistics for windows
+              starting at 60%, 70%, and 80% of the maximum field
             - 'Ms': saturation magnetization
             - 'Bc': coercive field
             - 'M_sn_f', 'Qf': quality metrics for ferromagnetic component
-            - 'Fnl_lin': FNL from linear fit (None if saturated)
+            - 'Fnl_lin': F statistic for improvement of the nonlinear over the linear
+              high-field fit (None if the loop is saturated and no nonlinear fit is made)
             - 'plot': Bokeh figure with overlaid processing steps
     """
+    # clean the inputs (accepts lists/Series/text columns, drops non-finite
+    # pairs, warns on apparent non-tesla field units)
+    field, magnetization = sanitize_hysteresis_inputs(field, magnetization)
+
     # first grid the data into symmetric field values
     grid_fields, grid_magnetizations = grid_hysteresis_loop(field, magnetization)
 
@@ -3691,7 +3866,7 @@ def process_hyst_loop(field, magnetization, specimen_name, show_results_table=Tr
     H, Mr, Mrh, Mih, Me, Brh = calc_Mr_Mrh_Mih_Brh(centered_H, drift_corr_M)
 
     # check if the loop is closed
-    loop_closure_test_results = loop_closure_test(H, Mrh)
+    loop_closure_test_results = loop_closure_test(H, Mrh, Me)
 
     # check if the loop is saturated (high field linearity test)
     loop_saturation_stats = hyst_loop_saturation_test(centered_H, drift_corr_M)
@@ -5486,21 +5661,26 @@ def backfield_MaxUnmix(field, magnetization, n_comps=1, parameters=None, skewed=
     dMdB_50_components = np.percentile(all_component_dMdB, 50, axis=0)
     dMdB_97_5_components = np.percentile(all_component_dMdB, 97.5, axis=0)
 
-    # calculate the mean and std of the parameters
+    # calculate the mean and std of the parameters; center and sigma are
+    # fit in log10 space, so convert each bootstrap value to linear (mT)
+    # units before taking the mean/std (10**std of log values is not a
+    # standard deviation in mT)
     mean_parameters = np.mean(all_parameters, axis=0)
     std_parameters = np.std(all_parameters, axis=0)
+    center_mT = 10 ** all_parameters[:, :, 1]
+    sigma_mT = 10 ** all_parameters[:, :, 2]
 
     # report a dictionary of the mean and std of the parameters
     parameters_dict = {}
     for i in range(n_comps):
         this_parameters_dict = {
             f'g{i+1}_amplitude': mean_parameters[i][0],
-            f'g{i+1}_center': 10**mean_parameters[i][1],
-            f'g{i+1}_sigma': 10**mean_parameters[i][2],
+            f'g{i+1}_center': np.mean(center_mT[:, i]),
+            f'g{i+1}_sigma': np.mean(sigma_mT[:, i]),
             f'g{i+1}_gamma': mean_parameters[i][3],
             f'g{i+1}_amplitude_std': std_parameters[i][0],
-            f'g{i+1}_center_std': 10**std_parameters[i][1],
-            f'g{i+1}_sigma_std': 10**std_parameters[i][2],
+            f'g{i+1}_center_std': np.std(center_mT[:, i]),
+            f'g{i+1}_sigma_std': np.std(sigma_mT[:, i]),
             f'g{i+1}_gamma_std': std_parameters[i][3]
         }
         parameters_dict.update(this_parameters_dict)
@@ -5545,23 +5725,18 @@ def add_unmixing_stats_to_specimens_table(specimens_df, experiment_name, unmix_r
         unmix_result_dict = unmix_result
     else:
         raise ValueError(f"method should be either 'lmfit' or 'MaxUnmix', but got {method}")
-    # check if the description cell is type string
-    if isinstance(specimens_df[specimens_df['experiments'] == experiment_name]['description'].iloc[0], str):
-        # unpack the string to a dict, then add the new stats, then pack it back to a string
-        description_dict = eval(specimens_df[specimens_df['experiments'] == experiment_name]['description'].iloc[0])
-        for key in unmix_result_dict:
-            if key in description_dict:
-                # if the key already exists, update it
-                description_dict[key] = unmix_result_dict[key]
-            else:
-                # if the key does not exist, add it
-                description_dict[key] = unmix_result_dict[key]
-        # pack the dict back to a string
-        specimens_df.loc[specimens_df['experiments'] == experiment_name, 'description'] = str(description_dict)
-    else:
-        # if not, create a new dict
-        specimens_df.loc[specimens_df['experiments'] == experiment_name, 'description'] = str(unmix_result_dict)
-    return 
+    unmix_result_dict = dict_in_native_python(unmix_result_dict)
+    # merge into the description cell, preserving free text and any
+    # existing structured content (parsed safely rather than with eval)
+    mask = specimens_df['experiments'] == experiment_name
+    for idx in specimens_df.index[mask]:
+        text, description_dict = parse_specimen_description(
+            specimens_df.at[idx, 'description'])
+        description_dict.update(unmix_result_dict)
+        payload = json.dumps(description_dict)
+        specimens_df.at[idx, 'description'] = (
+            f'{text} | {payload}' if text else payload)
+    return
 
 def add_Bcr_to_specimens_table(specimens_df, experiment_name, Bcr):
     """
@@ -5584,7 +5759,3063 @@ def add_Bcr_to_specimens_table(specimens_df, experiment_name, Bcr):
     # add the Bcr value to the specimens table
     specimens_df.loc[specimens_df['experiments'] == experiment_name, 'rem_bcr'] = Bcr
 
-    return     
+    return
+
+
+# coercivity spectrum unmixing functions
+# ------------------------------------------------------------------------------------------------------------------
+# Toolkit for decomposing remanence curves (backfield demagnetization or IRM
+# acquisition) into coercivity components. Every component is a skew-normal
+# distribution in x = log10(B/mT) parameterized by its integrated area
+# ('contribution', in the units of the magnetization data), location, scale
+# ('dp'), and shape ('skew'). With skew = 0 the component reduces exactly to
+# the log-Gaussian of Robertson & France (1994). Because the skew-normal has
+# an analytic CDF (via Owen's T function), the same component model can be
+# fit in two data spaces:
+#
+#   1. spectrum space -- fitting the coercivity spectrum |dM/dlog10(B)|,
+#      following Kruiver et al. (2001), Egli (2003), and the MAX UnMix
+#      program of Maxbauer et al. (2016).
+#   2. measurement space -- fitting the measured remanence curve M(B)
+#      directly with cumulative (CDF) components, which avoids numerical
+#      differentiation and smoothing of the data altogether.
+#
+# Model selection is supported through AIC/BIC and F-tests, and parameter
+# uncertainties through both linearized (covariance) standard errors and
+# bootstrap resampling.
+
+_SQRT2 = np.sqrt(2.0)
+_SQRT2PI = np.sqrt(2.0 * np.pi)
+UNMIX_PARAM_COLUMNS = ['contribution', 'location', 'dp', 'skew']
+
+
+def _trapz(y, x):
+    """Trapezoidal integration compatible with numpy 1.x and 2.x."""
+    trapezoid = getattr(np, 'trapezoid', None)
+    if trapezoid is None:
+        trapezoid = np.trapz
+    return trapezoid(y, x)
+
+
+def skewnormal_pdf(x, location, dp, skew=0.0):
+    """
+    Skew-normal probability density function (unit area).
+
+    With skew = 0 this is a Gaussian with mean = location and standard
+    deviation = dp; in log10(B) coordinates that Gaussian is the log-Gaussian
+    coercivity distribution of Robertson & France (1994). Nonzero skew
+    follows the Azzalini (1985) formulation: negative values skew the
+    distribution toward low values (tail to the left).
+
+    Parameters
+    ----------
+    x : array-like
+        Points at which to evaluate the density (log10 of field in mT).
+    location : float
+        Location parameter (log10 mT). Equal to the mean only when skew = 0.
+    dp : float
+        Scale parameter (log10 units); must be positive. Equal to the
+        standard deviation only when skew = 0.
+    skew : float
+        Shape parameter alpha of the Azzalini skew-normal (default 0).
+
+    Returns
+    -------
+    numpy.ndarray
+        Density values with unit integrated area.
+    """
+    x = np.asarray(x, dtype=float)
+    z = (x - location) / dp
+    return np.exp(-0.5 * z * z) / (_SQRT2PI * dp) * (1.0 + erf(skew * z / _SQRT2))
+
+
+def skewnormal_cdf(x, location, dp, skew=0.0):
+    """
+    Skew-normal cumulative distribution function.
+
+    Evaluated analytically as Phi(z) - 2*T(z, skew) where T is Owen's T
+    function (scipy.special.owens_t).
+
+    Parameters
+    ----------
+    x : array-like
+        Points at which to evaluate the CDF (log10 of field in mT).
+    location : float
+        Location parameter (log10 mT).
+    dp : float
+        Scale parameter (log10 units); must be positive.
+    skew : float
+        Shape parameter alpha (default 0).
+
+    Returns
+    -------
+    numpy.ndarray
+        CDF values between 0 and 1.
+    """
+    x = np.asarray(x, dtype=float)
+    z = (x - location) / dp
+    Phi = 0.5 * (1.0 + erf(z / _SQRT2))
+    if skew == 0:
+        return Phi
+    return Phi - 2.0 * owens_t(z, skew)
+
+
+def skewnormal_stats(location, dp, skew=0.0):
+    """
+    Moments and characteristic points of a skew-normal distribution.
+
+    Parameters
+    ----------
+    location : float
+        Location parameter (log10 mT).
+    dp : float
+        Scale parameter (log10 units).
+    skew : float
+        Shape parameter alpha.
+
+    Returns
+    -------
+    dict
+        With keys 'mean', 'std', 'median', and 'mode', all in the same
+        (log10) units as location and dp. For skew = 0 all of mean, median,
+        and mode equal location and std equals dp.
+    """
+    delta = skew / np.sqrt(1.0 + skew ** 2)
+    mean = location + dp * delta * np.sqrt(2.0 / np.pi)
+    std = dp * np.sqrt(1.0 - 2.0 * delta ** 2 / np.pi)
+    if skew == 0:
+        return {'mean': mean, 'std': std, 'median': location, 'mode': location}
+    median = brentq(lambda t: skewnormal_cdf(t, location, dp, skew) - 0.5,
+                    location - 12 * dp, location + 12 * dp)
+    mode_res = minimize_scalar(lambda t: -skewnormal_pdf(t, location, dp, skew),
+                               bounds=(location - 5 * dp, location + 5 * dp),
+                               method='bounded')
+    return {'mean': mean, 'std': std, 'median': median, 'mode': float(mode_res.x)}
+
+
+def _unmix_parameters_to_array(parameters):
+    """Coerce a parameters DataFrame/array to an (n_components, 4) float array."""
+    if isinstance(parameters, pd.DataFrame):
+        missing = [c for c in UNMIX_PARAM_COLUMNS if c not in parameters.columns]
+        if missing:
+            raise KeyError(f"parameters table is missing columns: {missing}")
+        return parameters[UNMIX_PARAM_COLUMNS].to_numpy(dtype=float)
+    arr = np.atleast_2d(np.asarray(parameters, dtype=float))
+    if arr.shape[1] != 4:
+        raise ValueError("parameters must have four columns: "
+                         f"{UNMIX_PARAM_COLUMNS}")
+    return arr
+
+
+def coercivity_spectrum_components(x, parameters):
+    """
+    Evaluate each unmixing component in spectrum space (dM/dlog10 B).
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    parameters : pandas.DataFrame or array-like
+        One row per component with columns 'contribution' (area under the
+        component in magnetization units), 'location', 'dp', 'skew'.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape (n_components, len(x)).
+    """
+    arr = _unmix_parameters_to_array(parameters)
+    x = np.asarray(x, dtype=float)
+    return np.array([c * skewnormal_pdf(x, loc, dp, skew)
+                     for c, loc, dp, skew in arr])
+
+
+def coercivity_spectrum_model(x, parameters):
+    """
+    Evaluate the summed unmixing model in spectrum space.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    parameters : pandas.DataFrame or array-like
+        Component parameters (see coercivity_spectrum_components).
+
+    Returns
+    -------
+    numpy.ndarray
+        Total model spectrum at x.
+    """
+    return coercivity_spectrum_components(x, parameters).sum(axis=0)
+
+
+def coercivity_curve_components(x, parameters, curve_type='backfield'):
+    """
+    Evaluate each component in measurement space (cumulative curves).
+
+    For 'backfield' curves (processed so that magnetization decays from a
+    maximum toward zero with increasing field magnitude) each component is
+    contribution * (1 - CDF); for 'acquisition' curves each component is
+    contribution * CDF.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    parameters : pandas.DataFrame or array-like
+        Component parameters (see coercivity_spectrum_components).
+    curve_type : str
+        'backfield' or 'acquisition'.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape (n_components, len(x)).
+    """
+    assert curve_type in ('backfield', 'acquisition'), \
+        "curve_type must be 'backfield' or 'acquisition'"
+    arr = _unmix_parameters_to_array(parameters)
+    x = np.asarray(x, dtype=float)
+    comps = []
+    for c, loc, dp, skew in arr:
+        cdf = skewnormal_cdf(x, loc, dp, skew)
+        comps.append(c * (1.0 - cdf) if curve_type == 'backfield' else c * cdf)
+    return np.array(comps)
+
+
+def coercivity_curve_model(x, parameters, offset=0.0, curve_type='backfield'):
+    """
+    Evaluate the summed unmixing model in measurement space.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    parameters : pandas.DataFrame or array-like
+        Component parameters (see coercivity_spectrum_components).
+    offset : float
+        Constant baseline added to the model (accounts for a small
+        unsaturated or instrumental offset; default 0).
+    curve_type : str
+        'backfield' or 'acquisition'.
+
+    Returns
+    -------
+    numpy.ndarray
+        Total model curve at x.
+    """
+    return coercivity_curve_components(x, parameters, curve_type).sum(axis=0) + offset
+
+
+def coercivity_spectrum_from_curve(x, magnetization, curve_type='backfield'):
+    """
+    Compute a finite-difference coercivity spectrum from a remanence curve.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT), monotonically increasing.
+    magnetization : array-like
+        Magnetization values at x (shifted to positive for backfield data,
+        e.g. the 'magn_mass_shift' column from backfield_data_processing).
+    curve_type : str
+        'backfield' (decaying curve, spectrum = -dM/dx) or 'acquisition'
+        (growing curve, spectrum = dM/dx).
+
+    Returns
+    -------
+    tuple
+        (x_mid, spectrum) where x_mid are midpoints between successive x
+        values and spectrum is the centered finite-difference derivative.
+    """
+    assert curve_type in ('backfield', 'acquisition'), \
+        "curve_type must be 'backfield' or 'acquisition'"
+    x = np.asarray(x, dtype=float)
+    M = np.asarray(magnetization, dtype=float)
+    dM = np.diff(M) / np.diff(x)
+    x_mid = 0.5 * (x[1:] + x[:-1])
+    return x_mid, (-dM if curve_type == 'backfield' else dM)
+
+
+def estimate_coercivity_components(x, spectrum, n_components, smooth_window=None):
+    """
+    Automatic initial-guess estimation for unmixing components.
+
+    The spectrum is interpolated onto a uniform grid, lightly smoothed
+    (Savitzky-Golay), and searched for peaks. The n_components most
+    prominent peaks seed the component locations; widths at half maximum
+    seed dp; peak heights seed the contributions. If fewer peaks than
+    components are found, the remaining components are placed at evenly
+    spaced quantiles of the cumulative spectrum.
+
+    Initial choices matter for nonlinear fitting: these automatic estimates
+    are a starting point that can (and often should) be refined by the user,
+    e.g. with interactive_coercivity_unmixing.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    spectrum : array-like
+        Coercivity spectrum values at x.
+    n_components : int
+        Number of components to estimate.
+    smooth_window : int, optional
+        Savitzky-Golay window length (grid points). Defaults to ~1/10 of
+        the grid (minimum 5).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Initial parameters with columns 'contribution', 'location', 'dp',
+        'skew' (skew = 0), sorted by location.
+    """
+    assert isinstance(n_components, (int, np.integer)) and n_components > 0, \
+        'n_components must be a positive integer'
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(spectrum, dtype=float)
+    order = np.argsort(x)
+    x, y = x[order], y[order]
+
+    n_grid = max(200, len(x))
+    xg = np.linspace(x.min(), x.max(), n_grid)
+    yg = np.interp(xg, x, y)
+    if smooth_window is None:
+        smooth_window = max(5, (n_grid // 10) | 1)  # odd
+    else:
+        smooth_window = max(5, int(smooth_window) | 1)
+    yg_smooth = savgol_filter(yg, smooth_window, polyorder=3)
+    yg_smooth = np.clip(yg_smooth, 0, None)
+    dx = xg[1] - xg[0]
+
+    peak_idx, props = find_peaks(yg_smooth, prominence=0.02 * yg_smooth.max(),
+                                 width=1)
+    if len(peak_idx) > 0:
+        # keep the n most prominent peaks
+        keep = np.argsort(props['prominences'])[::-1][:n_components]
+        peak_idx = peak_idx[keep]
+        widths = props['widths'][keep] * dx
+    else:
+        peak_idx = np.array([], dtype=int)
+        widths = np.array([])
+
+    locations = list(xg[peak_idx])
+    dps = [max(w / 2.355, 0.05) for w in widths]  # FWHM -> sigma
+    heights = list(yg_smooth[peak_idx])
+
+    # fill any missing components at quantiles of the cumulative spectrum
+    if len(locations) < n_components:
+        cumulative = np.cumsum(yg_smooth)
+        cumulative = cumulative / cumulative[-1]
+        n_missing = n_components - len(locations)
+        quantiles = np.linspace(0.15, 0.85, n_components)
+        candidates = [xg[np.searchsorted(cumulative, q)] for q in quantiles]
+        # prefer candidate positions away from already-found peaks
+        for cand in sorted(candidates,
+                           key=lambda c: -min([abs(c - loc) for loc in locations],
+                                              default=np.inf)):
+            if n_missing == 0:
+                break
+            locations.append(cand)
+            dps.append(0.25)
+            heights.append(np.interp(cand, xg, yg_smooth))
+            n_missing -= 1
+
+    initial = pd.DataFrame({
+        'contribution': [h * dp * _SQRT2PI for h, dp in zip(heights, dps)],
+        'location': locations,
+        'dp': dps,
+        'skew': 0.0,
+    })
+    return initial.sort_values('location').reset_index(drop=True)
+
+
+def _unmix_fit_engine(x, y, initial, method, curve_type='backfield',
+                      vary_skew=True, fit_offset=True, weights=None,
+                      dp_bounds=(0.01, 2.0), skew_bounds=(-10.0, 10.0),
+                      max_nfev=20000):
+    """
+    Shared bounded least-squares engine for both unmixing data spaces.
+
+    Returns the scipy result plus unpacked, physically scaled parameter
+    arrays, standard errors, and offset. Used by unmix_coercivity_spectrum
+    and unmix_backfield_curve; not intended to be called directly.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    assert len(x) == len(y), 'x and y must have the same length'
+    finite = np.isfinite(x) & np.isfinite(y)
+    x, y = x[finite], y[finite]
+    if weights is not None:
+        weights = np.asarray(weights, dtype=float)[finite]
+
+    init_arr = _unmix_parameters_to_array(initial)
+    K = init_arr.shape[0]
+    if len(x) <= 3 * K + 1:
+        raise ValueError(f'too few data points ({len(x)}) to fit '
+                         f'{K} components')
+
+    y_scale = np.max(np.abs(y))
+    if y_scale == 0:
+        raise ValueError('y data are all zero')
+    ys = y / y_scale
+
+    c0 = np.clip(init_arr[:, 0] / y_scale, 1e-6, 20.0)
+    loc0 = np.clip(init_arr[:, 1], x.min() - 0.5, x.max() + 0.5)
+    dp0 = np.clip(init_arr[:, 2], dp_bounds[0], dp_bounds[1])
+    skew0 = np.clip(init_arr[:, 3], skew_bounds[0], skew_bounds[1])
+
+    fit_offset = fit_offset and method == 'curve'
+    p0 = np.concatenate([c0, loc0, dp0])
+    lb = np.concatenate([np.zeros(K), np.full(K, x.min() - 0.5),
+                         np.full(K, dp_bounds[0])])
+    ub = np.concatenate([np.full(K, 20.0), np.full(K, x.max() + 0.5),
+                         np.full(K, dp_bounds[1])])
+    if vary_skew:
+        p0 = np.concatenate([p0, skew0])
+        lb = np.concatenate([lb, np.full(K, skew_bounds[0])])
+        ub = np.concatenate([ub, np.full(K, skew_bounds[1])])
+    if fit_offset:
+        p0 = np.concatenate([p0, [0.0]])
+        lb = np.concatenate([lb, [-0.5]])
+        ub = np.concatenate([ub, [0.5]])
+
+    def unpack(p):
+        c = p[:K]
+        loc = p[K:2 * K]
+        dp = p[2 * K:3 * K]
+        skew = p[3 * K:4 * K] if vary_skew else skew0
+        offset = p[-1] if fit_offset else 0.0
+        return c, loc, dp, skew, offset
+
+    def model_scaled(p):
+        c, loc, dp, skew, offset = unpack(p)
+        params = np.column_stack([c, loc, dp, skew])
+        if method == 'spectrum':
+            return coercivity_spectrum_model(x, params)
+        return coercivity_curve_model(x, params, offset=offset,
+                                      curve_type=curve_type)
+
+    def residuals(p):
+        r = model_scaled(p) - ys
+        return r * weights if weights is not None else r
+
+    res = least_squares(residuals, p0, bounds=(lb, ub), method='trf',
+                        x_scale='jac', max_nfev=max_nfev)
+
+    # covariance-based standard errors (linearized approximation)
+    n_pts, n_par = len(x), len(res.x)
+    dof = n_pts - n_par
+    se = np.full(n_par, np.nan)
+    if dof > 0:
+        try:
+            JtJ = res.jac.T @ res.jac
+            cov = 2.0 * res.cost / dof * np.linalg.pinv(JtJ)
+            se = np.sqrt(np.clip(np.diag(cov), 0, None))
+        except np.linalg.LinAlgError:
+            pass
+
+    c, loc, dp, skew, offset = unpack(res.x)
+    se_c = se[:K] * y_scale
+    se_loc = se[K:2 * K]
+    se_dp = se[2 * K:3 * K]
+    se_skew = se[3 * K:4 * K] if vary_skew else np.zeros(K)
+    se_offset = se[-1] * y_scale if fit_offset else 0.0
+
+    # order components by mean coercivity
+    delta = skew / np.sqrt(1.0 + skew ** 2)
+    means = loc + dp * delta * np.sqrt(2.0 / np.pi)
+    order = np.argsort(means)
+
+    return {
+        'scipy_result': res,
+        'contribution': c[order] * y_scale, 'se_contribution': se_c[order],
+        'location': loc[order], 'se_location': se_loc[order],
+        'dp': dp[order], 'se_dp': se_dp[order],
+        'skew': np.asarray(skew)[order], 'se_skew': np.asarray(se_skew)[order],
+        'offset': offset * y_scale, 'se_offset': se_offset,
+        'x': x, 'y': y, 'weights': weights, 'y_scale': y_scale,
+    }
+
+
+def _build_unmix_result(engine, method, curve_type, vary_skew, fit_offset,
+                        initial):
+    """Assemble the standardized result dictionary from the fit engine output."""
+    K = len(engine['contribution'])
+    rows = []
+    for i in range(K):
+        stats_i = skewnormal_stats(engine['location'][i], engine['dp'][i],
+                                   engine['skew'][i])
+        rows.append({
+            'contribution': engine['contribution'][i],
+            'se_contribution': engine['se_contribution'][i],
+            'location': engine['location'][i],
+            'se_location': engine['se_location'][i],
+            'dp': engine['dp'][i],
+            'se_dp': engine['se_dp'][i],
+            'skew': engine['skew'][i],
+            'se_skew': engine['se_skew'][i],
+            'sd_log': stats_i['std'],
+            'log10_B_mean': stats_i['mean'],
+            'B_mean_mT': 10 ** stats_i['mean'],
+            'B_median_mT': 10 ** stats_i['median'],
+            'B_peak_mT': 10 ** stats_i['mode'],
+        })
+    params = pd.DataFrame(rows, index=pd.RangeIndex(1, K + 1,
+                                                    name='component'))
+    total = params['contribution'].sum()
+    params.insert(1, 'proportion',
+                  params['contribution'] / total if total > 0 else np.nan)
+
+    x, y = engine['x'], engine['y']
+    param_arr = params[UNMIX_PARAM_COLUMNS].to_numpy()
+    if method == 'spectrum':
+        y_fit = coercivity_spectrum_model(x, param_arr)
+    else:
+        y_fit = coercivity_curve_model(x, param_arr, offset=engine['offset'],
+                                       curve_type=curve_type)
+    residuals = y - y_fit
+    n = len(x)
+    n_params = (3 + int(vary_skew)) * K + int(fit_offset and method == 'curve')
+    rss = float(np.sum(residuals ** 2))
+    tss = float(np.sum((y - y.mean()) ** 2))
+    dof = n - n_params
+    # Gaussian-likelihood information criteria (constant terms omitted);
+    # comparable only between fits to the same data
+    with np.errstate(divide='ignore'):
+        log_term = np.log(rss / n) if rss > 0 else -np.inf
+    stats = {
+        'n': n,
+        'n_params': n_params,
+        'dof': dof,
+        'rss': rss,
+        'r_squared': 1.0 - rss / tss if tss > 0 else np.nan,
+        'reduced_chi_square': rss / dof if dof > 0 else np.nan,
+        'aic': n * log_term + 2 * n_params,
+        'bic': n * log_term + n_params * np.log(n),
+    }
+
+    scipy_result = engine['scipy_result']
+    initial_df = (initial.copy() if isinstance(initial, pd.DataFrame)
+                  else pd.DataFrame(_unmix_parameters_to_array(initial),
+                                    columns=UNMIX_PARAM_COLUMNS))
+    return {
+        'method': method,
+        'curve_type': curve_type,
+        'n_components': K,
+        'success': bool(scipy_result.success),
+        'message': scipy_result.message,
+        'params': params,
+        'offset': engine['offset'],
+        'se_offset': engine['se_offset'],
+        'x': x,
+        'y': y,
+        'y_fit': y_fit,
+        'residuals': residuals,
+        'weights': engine['weights'],
+        'stats': stats,
+        'initial_parameters': initial_df,
+        'vary_skew': vary_skew,
+    }
+
+
+def unmix_coercivity_spectrum(x, spectrum, n_components=None,
+                              initial_parameters=None, vary_skew=True,
+                              weights=None, dp_bounds=(0.01, 2.0),
+                              skew_bounds=(-10.0, 10.0)):
+    """
+    Unmix a coercivity spectrum into skew-normal (log-Gaussian) components.
+
+    Fits the derivative spectrum dM/dlog10(B) with a sum of skew-normal
+    densities, following the approach popularized by Kruiver et al. (2001)
+    and the MAX UnMix program (Maxbauer et al., 2016). Compared to fitting
+    the measured curve directly (unmix_backfield_curve) this operates on a
+    numerically differentiated (and possibly smoothed) version of the data,
+    so the choice of smoothing can influence the result; the advantage is
+    that components are fit in the space where they are most readily
+    interpreted visually.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT), e.g. midpoints from
+        coercivity_spectrum_from_curve.
+    spectrum : array-like
+        Coercivity spectrum values at x (magnetization per decade).
+    n_components : int, optional
+        Number of components. Required if initial_parameters is None.
+    initial_parameters : pandas.DataFrame, optional
+        Initial guesses with columns 'contribution', 'location', 'dp',
+        'skew' (one row per component). If None, automatic estimates from
+        estimate_coercivity_components are used.
+    vary_skew : bool
+        If False, skew values are fixed at their initial values (default 0,
+        i.e. symmetric log-Gaussian components).
+    weights : array-like, optional
+        Multiplicative weights applied to the residuals.
+    dp_bounds : tuple
+        (min, max) bounds on the dp scale parameter in log10 units.
+    skew_bounds : tuple
+        (min, max) bounds on the skew shape parameter.
+
+    Returns
+    -------
+    dict
+        Standardized result dictionary with keys including 'params' (a
+        DataFrame of fitted parameters, linearized standard errors, and
+        derived quantities such as B_mean_mT and proportion), 'y_fit',
+        'residuals', 'stats' (rss, r_squared, aic, bic, ...), 'success',
+        and 'initial_parameters'.
+    """
+    if initial_parameters is None:
+        if n_components is None:
+            raise ValueError('specify n_components or initial_parameters')
+        initial_parameters = estimate_coercivity_components(x, spectrum,
+                                                            n_components)
+    elif (n_components is not None
+          and len(initial_parameters) != n_components):
+        raise ValueError('n_components does not match the number of rows in '
+                         'initial_parameters')
+    engine = _unmix_fit_engine(x, spectrum, initial_parameters,
+                               method='spectrum', vary_skew=vary_skew,
+                               weights=weights, dp_bounds=dp_bounds,
+                               skew_bounds=skew_bounds)
+    return _build_unmix_result(engine, 'spectrum', 'backfield', vary_skew,
+                               False, initial_parameters)
+
+
+def unmix_backfield_curve(x, magnetization, n_components=None,
+                          initial_parameters=None, curve_type='backfield',
+                          vary_skew=True, fit_offset=True, weights=None,
+                          dp_bounds=(0.01, 2.0), skew_bounds=(-10.0, 10.0)):
+    """
+    Unmix a remanence curve by fitting cumulative components directly.
+
+    Fits the measured curve M(log10 B) with a sum of skew-normal CDF
+    components (plus an optional constant offset), avoiding numerical
+    differentiation and smoothing entirely. The component parameterization
+    is identical to unmix_coercivity_spectrum, so results from the two
+    data spaces are directly comparable. Fitting in measurement space uses
+    the raw measurements with their original noise structure; fitting in
+    spectrum space can be more visually intuitive. Agreement between the
+    two approaches is a good indication of a robust unmixing model.
+
+    For backfield data processed with backfield_data_processing, pass
+    x = 'log_dc_field' and magnetization = 'magn_mass_shift'. Note that the
+    shifted backfield curve spans twice the saturation remanence, so each
+    fitted 'contribution' is twice the remanence carried by that component;
+    'proportion' values are unaffected.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    magnetization : array-like
+        Remanence curve values at x (shifted positive for backfield data).
+    n_components : int, optional
+        Number of components. Required if initial_parameters is None.
+    initial_parameters : pandas.DataFrame, optional
+        Initial guesses (see unmix_coercivity_spectrum). If None, automatic
+        estimates are derived from the finite-difference spectrum.
+    curve_type : str
+        'backfield' (decaying curve) or 'acquisition' (growing curve).
+    vary_skew : bool
+        If False, skew values are fixed at their initial values.
+    fit_offset : bool
+        Whether to fit a constant baseline offset (default True).
+    weights : array-like, optional
+        Multiplicative weights applied to the residuals.
+    dp_bounds, skew_bounds : tuple
+        Bounds as in unmix_coercivity_spectrum.
+
+    Returns
+    -------
+    dict
+        Standardized result dictionary (see unmix_coercivity_spectrum),
+        additionally including the fitted 'offset' and 'se_offset'.
+    """
+    if initial_parameters is None:
+        if n_components is None:
+            raise ValueError('specify n_components or initial_parameters')
+        x_mid, spec = coercivity_spectrum_from_curve(x, magnetization,
+                                                     curve_type)
+        initial_parameters = estimate_coercivity_components(x_mid, spec,
+                                                            n_components)
+    elif (n_components is not None
+          and len(initial_parameters) != n_components):
+        raise ValueError('n_components does not match the number of rows in '
+                         'initial_parameters')
+    engine = _unmix_fit_engine(x, magnetization, initial_parameters,
+                               method='curve', curve_type=curve_type,
+                               vary_skew=vary_skew, fit_offset=fit_offset,
+                               weights=weights, dp_bounds=dp_bounds,
+                               skew_bounds=skew_bounds)
+    return _build_unmix_result(engine, 'curve', curve_type, vary_skew,
+                               fit_offset, initial_parameters)
+
+
+def _unmix_method_spectrum(x, magnetization, n_components=None,
+                           initial_parameters=None, curve_type='backfield',
+                           vary_skew=True, **kwargs):
+    """Registered 'spectrum' method: finite-difference spectrum fit."""
+    x_mid, spectrum = coercivity_spectrum_from_curve(x, magnetization,
+                                                     curve_type)
+    return unmix_coercivity_spectrum(x_mid, spectrum,
+                                     n_components=n_components,
+                                     initial_parameters=initial_parameters,
+                                     vary_skew=vary_skew, **kwargs)
+
+
+def _unmix_method_curve(x, magnetization, n_components=None,
+                        initial_parameters=None, curve_type='backfield',
+                        vary_skew=True, **kwargs):
+    """Registered 'curve' method: direct measurement-space fit."""
+    return unmix_backfield_curve(x, magnetization, n_components=n_components,
+                                 initial_parameters=initial_parameters,
+                                 curve_type=curve_type, vary_skew=vary_skew,
+                                 **kwargs)
+
+
+def _unmix_method_maxunmix(x, magnetization, n_components=None,
+                           initial_parameters=None, curve_type='backfield',
+                           vary_skew=True, n_boot=100, proportion=0.95,
+                           noise_level=0.02, random_seed=None, **kwargs):
+    """
+    Registered 'maxunmix' method: emulation of the MAX UnMix workflow.
+
+    Fits skew-normal components to the coercivity spectrum and estimates
+    uncertainties with the MAX UnMix resampling scheme (case resampling of
+    95% of the data with 2% multiplicative Gaussian noise; Maxbauer et al.,
+    2016). Results are comparable to the MAX UnMix web application, with
+    the caveats that skewness here follows the Azzalini parameterization
+    rather than the Fernandez-Steel one used by MAX UnMix, and that
+    contributions are parameterized by component area rather than peak
+    height.
+    """
+    result = _unmix_method_spectrum(x, magnetization,
+                                    n_components=n_components,
+                                    initial_parameters=initial_parameters,
+                                    curve_type=curve_type,
+                                    vary_skew=vary_skew, **kwargs)
+    return unmixing_bootstrap(result, n_boot=n_boot, resample='cases',
+                              proportion=proportion, noise_level=noise_level,
+                              random_seed=random_seed)
+
+
+UNMIXING_METHODS = {
+    'spectrum': _unmix_method_spectrum,
+    'curve': _unmix_method_curve,
+    'maxunmix': _unmix_method_maxunmix,
+}
+
+
+def register_unmixing_method(name, function):
+    """
+    Register a custom coercivity unmixing method.
+
+    Registered methods become available through unmix_coercivity and
+    unmix_backfield_experiments alongside the built-in 'spectrum', 'curve',
+    and 'maxunmix' methods. The function must accept
+    (x, magnetization, n_components=None, initial_parameters=None,
+    curve_type='backfield', vary_skew=True, **kwargs) and return the
+    standardized result dictionary (see unmix_coercivity_spectrum); the
+    component model helpers (skewnormal_pdf, coercivity_spectrum_model,
+    coercivity_curve_model, ...) can be reused when implementing new
+    methods.
+
+    Parameters
+    ----------
+    name : str
+        Name under which the method is registered.
+    function : callable
+        The method implementation.
+
+    Returns
+    -------
+    None
+    """
+    if not callable(function):
+        raise TypeError('function must be callable')
+    UNMIXING_METHODS[name] = function
+
+
+def unmix_coercivity(x, magnetization, method='spectrum', n_components=None,
+                     initial_parameters=None, curve_type='backfield',
+                     vary_skew=True, **kwargs):
+    """
+    Unmix a remanence curve into coercivity components with a named method.
+
+    This is the common entry point to the unmixing approaches implemented
+    in rockmagpy (and to any user-registered methods; see
+    register_unmixing_method). All methods take the measured remanence
+    curve -- not a precomputed derivative -- and share the same skew-normal
+    component parameterization, so their results are directly comparable.
+
+    Built-in methods:
+
+    - 'spectrum': fits the finite-difference coercivity spectrum
+      dM/dlog10(B) with skew-normal components (Kruiver et al., 2001;
+      Egli, 2003 lineage). Point estimates only; combine with
+      unmixing_bootstrap for uncertainties.
+    - 'curve': fits the measured curve directly with cumulative
+      (CDF) components, avoiding numerical differentiation entirely.
+    - 'maxunmix': the 'spectrum' fit plus the MAX UnMix resampling
+      uncertainty scheme (Maxbauer et al., 2016): 95% case resampling with
+      2% noise, 100 replicates by default.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT), e.g. 'log_dc_field' from
+        backfield_data_processing.
+    magnetization : array-like
+        Remanence curve values at x (e.g. 'magn_mass_shift').
+    method : str
+        Name of a registered unmixing method (default 'spectrum').
+    n_components : int, optional
+        Number of components (required if initial_parameters is None).
+    initial_parameters : pandas.DataFrame, optional
+        Initial guesses with columns 'contribution', 'location', 'dp',
+        'skew'; automatic estimates are used when omitted.
+    curve_type : str
+        'backfield' or 'acquisition'.
+    vary_skew : bool
+        Whether skew parameters vary during fitting.
+    **kwargs
+        Passed through to the method implementation (e.g. n_boot,
+        proportion, noise_level for 'maxunmix'; fit_offset for 'curve').
+
+    Returns
+    -------
+    dict
+        Standardized result dictionary (see unmix_coercivity_spectrum).
+    """
+    if method not in UNMIXING_METHODS:
+        raise ValueError(f"unknown unmixing method '{method}'; available: "
+                         f'{sorted(UNMIXING_METHODS)}')
+    return UNMIXING_METHODS[method](x, magnetization,
+                                    n_components=n_components,
+                                    initial_parameters=initial_parameters,
+                                    curve_type=curve_type,
+                                    vary_skew=vary_skew, **kwargs)
+
+
+def compare_unmixing_models(results):
+    """
+    Compare unmixing fits with different numbers of components.
+
+    Builds a comparison table with information criteria and sequential
+    F-tests. All results must be fits of the same data with the same
+    method ('spectrum' or 'curve'); AIC/BIC values are only meaningful
+    relative to one another under that condition. The F-test compares each
+    model to the previous (simpler) one; a small p-value indicates the
+    additional component produces a statistically significant improvement.
+    As emphasized by Maxbauer et al. (2016) and Egli (2003), statistical
+    significance alone should not decide the number of components --
+    independent knowledge of the likely magnetic mineralogy should inform
+    the choice.
+
+    Parameters
+    ----------
+    results : list of dict
+        Result dictionaries from unmix_coercivity_spectrum or
+        unmix_backfield_curve, typically with increasing n_components.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per model with n_components, n_params, rss, r_squared,
+        aic, bic, delta_aic, delta_bic, F, and p_value columns.
+    """
+    from scipy.stats import f as f_distribution
+    if len(results) == 0:
+        raise ValueError('results list is empty')
+    methods = {r['method'] for r in results}
+    lengths = {len(r['x']) for r in results}
+    if len(methods) > 1 or len(lengths) > 1:
+        raise ValueError('all results must fit the same data with the same '
+                         'method for a meaningful comparison')
+    ordered = sorted(results, key=lambda r: r['stats']['n_params'])
+    rows = []
+    for i, r in enumerate(ordered):
+        s = r['stats']
+        row = {
+            'n_components': r['n_components'],
+            'n_params': s['n_params'],
+            'rss': s['rss'],
+            'r_squared': s['r_squared'],
+            'aic': s['aic'],
+            'bic': s['bic'],
+            'F': np.nan,
+            'p_value': np.nan,
+        }
+        if i > 0:
+            s0 = ordered[i - 1]['stats']
+            dp_extra = s['n_params'] - s0['n_params']
+            if dp_extra > 0 and s['dof'] > 0 and s['rss'] > 0:
+                F = ((s0['rss'] - s['rss']) / dp_extra) / (s['rss'] / s['dof'])
+                row['F'] = F
+                row['p_value'] = float(f_distribution.sf(F, dp_extra,
+                                                         s['dof']))
+        rows.append(row)
+    table = pd.DataFrame(rows)
+    table['delta_aic'] = table['aic'] - table['aic'].min()
+    table['delta_bic'] = table['bic'] - table['bic'].min()
+    return table
+
+
+def estimate_measurement_noise(x, magnetization, curve_type='backfield'):
+    """
+    Robustly estimate the measurement noise of a remanence curve.
+
+    Uses a third-difference (DER_SNR-style) estimator that suppresses the
+    smooth signal and returns a robust standard deviation of the residual
+    scatter, without any smoothing or model fitting. This provides the
+    noise scale needed to judge when an unmixing model fits "to within the
+    measurement noise" (see select_n_components).
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT); the data are sorted by x internally.
+    magnetization : array-like
+        Remanence curve values at x.
+    curve_type : str
+        Unused; accepted for signature consistency with the unmixing
+        functions.
+
+    Returns
+    -------
+    float
+        Estimated measurement noise standard deviation in magnetization
+        units.
+    """
+    x = np.asarray(x, dtype=float)
+    M = np.asarray(magnetization, dtype=float)
+    order = np.argsort(x)
+    M = M[order]
+    if len(M) < 5:
+        return float(np.std(M))
+    # |2 M_i - M_{i-2} - M_{i+2}| cancels linear trends; the median makes it
+    # robust to the minority of high-curvature points on a sigmoidal curve
+    differences = np.abs(2 * M[2:-2] - M[:-4] - M[4:])
+    return float(1.482602 / np.sqrt(6) * np.median(differences))
+
+
+def select_n_components(x, magnetization, method='curve', min_components=1,
+                        max_components=4, criterion='parsimony',
+                        min_improvement=0.02, noise_level=None,
+                        reduced_chi2_target=1.0, curve_type='backfield',
+                        vary_skew=False, verbose=False, **kwargs):
+    """
+    Choose the number of coercivity components by a parsimony rule.
+
+    Fits models with a range of component counts and selects the simplest
+    one that adequately describes the data. This is deliberately different
+    from minimizing an information criterion or maximizing the Bayesian
+    evidence: with high-resolution, low-noise curves those measures tend to
+    keep favoring more components indefinitely, because a real coercivity
+    distribution is never exactly log-Gaussian and each added component
+    removes a little more systematic misfit. Following the parsimony
+    principle emphasized by Egli (2003) and Heslop (2015), an extra
+    component is accepted only when it produces a large enough improvement,
+    so a simpler adequate model is preferred.
+
+    Two selection criteria are provided:
+
+    - 'parsimony' (default): an added component is retained only if it
+      reduces the residual sum of squares by at least `min_improvement`
+      times the baseline (single-component) residual. Because the second
+      component typically removes most of the baseline misfit while a
+      spurious third component removes only a tiny fraction of it, this
+      robustly stops at the mineralogically meaningful count regardless of
+      the noise level.
+    - 'chi2': the simplest model whose reduced chi-square (using
+      `noise_level`, estimated with estimate_measurement_noise if not
+      given) falls at or below `reduced_chi2_target`, i.e. the simplest
+      model that fits to within the measurement noise. This is more
+      principled when a trustworthy noise level is available, but is
+      sensitive to the accuracy of that noise estimate.
+
+    In all cases the returned table reports the fit statistics, the
+    fractional RSS improvement per added component, and (when a noise level
+    is available) the reduced chi-square, so the selection can be inspected
+    and overridden.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    magnetization : array-like
+        Remanence curve values at x.
+    method : str
+        Registered unmixing method used for each fit (default 'curve').
+    min_components, max_components : int
+        Range of component counts to consider.
+    criterion : str
+        'parsimony' or 'chi2'.
+    min_improvement : float
+        For 'parsimony': minimum fraction of the baseline residual an added
+        component must explain to be retained (default 0.02).
+    noise_level : float, optional
+        Measurement noise standard deviation for 'chi2'; estimated from the
+        data if not given.
+    reduced_chi2_target : float
+        For 'chi2': the reduced chi-square at or below which a model is
+        considered adequate (default 1.0).
+    curve_type : str
+        'backfield' or 'acquisition'.
+    vary_skew : bool
+        Whether skew varies during fitting.
+    verbose : bool
+        Print the selection outcome.
+    **kwargs
+        Passed to the unmixing method.
+
+    Returns
+    -------
+    tuple
+        (selected_n, table, results) where selected_n is the chosen number
+        of components, table is a DataFrame of per-model statistics (with a
+        boolean 'selected' column), and results maps component count ->
+        result dictionary.
+    """
+    assert criterion in ('parsimony', 'chi2'), \
+        "criterion must be 'parsimony' or 'chi2'"
+    if method not in UNMIXING_METHODS:
+        raise ValueError(f"unknown unmixing method '{method}'; available: "
+                         f'{sorted(UNMIXING_METHODS)}')
+    counts = list(range(min_components, max_components + 1))
+    if len(counts) == 0:
+        raise ValueError('max_components must be >= min_components')
+
+    if noise_level is None:
+        noise_level = estimate_measurement_noise(x, magnetization, curve_type)
+
+    results = {}
+    rows = []
+    for K in counts:
+        result = unmix_coercivity(x, magnetization, method=method,
+                                  n_components=K, curve_type=curve_type,
+                                  vary_skew=vary_skew, **kwargs)
+        results[K] = result
+        stats = result['stats']
+        rows.append({
+            'n_components': K,
+            'n_params': stats['n_params'],
+            'rss': stats['rss'],
+            'r_squared': stats['r_squared'],
+            'aic': stats['aic'],
+            'bic': stats['bic'],
+            'reduced_chi2': (stats['rss'] / (noise_level ** 2 * stats['dof'])
+                             if stats['dof'] > 0 else np.nan),
+        })
+    table = pd.DataFrame(rows)
+
+    baseline_rss = table['rss'].iloc[0]
+    improvement = [np.nan]
+    for i in range(1, len(table)):
+        improvement.append((table['rss'].iloc[i - 1] - table['rss'].iloc[i])
+                           / baseline_rss if baseline_rss > 0 else np.nan)
+    table['rss_improvement_fraction'] = improvement
+
+    if criterion == 'parsimony':
+        selected = counts[0]
+        for i in range(1, len(table)):
+            if table['rss_improvement_fraction'].iloc[i] >= min_improvement:
+                selected = counts[i]
+            else:
+                break
+    else:  # chi2 adequacy
+        adequate = table[table['reduced_chi2'] <= reduced_chi2_target]
+        selected = (int(adequate['n_components'].iloc[0]) if len(adequate)
+                    else counts[-1])
+
+    table['selected'] = table['n_components'] == selected
+    if verbose:
+        print(f"selected {selected} component(s) by '{criterion}' criterion "
+              f'(noise ~ {noise_level:.3g})')
+    return selected, table, results
+
+
+def unmixing_bootstrap(result, n_boot=500, resample='cases', proportion=1.0,
+                       noise_level=None, random_seed=None, n_grid=200,
+                       verbose=False):
+    """
+    Bootstrap uncertainty estimation for an unmixing result.
+
+    Repeatedly refits the model to resampled data, starting each fit from
+    the best-fit parameters, and summarizes the distributions of parameters
+    and model curves. Two resampling schemes are available:
+
+    - 'cases': data points are drawn with replacement ('proportion'
+      controls the resample size relative to the data). With
+      proportion=0.95 and noise_level=0.02 this emulates the resampling
+      scheme of the MAX UnMix program (Maxbauer et al., 2016).
+    - 'residuals': the best-fit curve is perturbed with resampled fit
+      residuals, preserving the field spacing of the original data.
+
+    Bootstrap distributions capture the full nonlinearity of the model and
+    are generally more trustworthy than the linearized standard errors in
+    the 'params' table, especially for strongly overlapping components.
+
+    Parameters
+    ----------
+    result : dict
+        Result from unmix_coercivity_spectrum or unmix_backfield_curve.
+    n_boot : int
+        Number of bootstrap replicates (default 500).
+    resample : str
+        'cases' or 'residuals'.
+    proportion : float
+        Fraction of the data resampled per replicate for 'cases' (default 1).
+    noise_level : float, optional
+        If given, multiplicative Gaussian noise with this relative standard
+        deviation is added to each resampled dataset (MAX UnMix uses 0.02).
+    random_seed : None, int, or numpy.random.Generator
+        Seed for reproducibility.
+    n_grid : int
+        Number of grid points for the model-curve confidence bands.
+    verbose : bool
+        Print a progress summary.
+
+    Returns
+    -------
+    dict
+        A copy of the input result with an added 'bootstrap' entry
+        containing 'param_summary' (per-component mean/std/percentiles for
+        each parameter and derived quantity), 'curves' (percentile bands of
+        the total and per-component model on 'x_grid'), 'n_success', and
+        'param_samples' (the raw bootstrap parameter arrays).
+    """
+    assert resample in ('cases', 'residuals'), \
+        "resample must be 'cases' or 'residuals'"
+    assert 0 < proportion <= 1, 'proportion must be in (0, 1]'
+    rng = _resolve_rng(random_seed)
+
+    x, y = result['x'], result['y']
+    method = result['method']
+    curve_type = result['curve_type']
+    vary_skew = result['vary_skew']
+    K = result['n_components']
+    best = result['params'][UNMIX_PARAM_COLUMNS].copy().reset_index(drop=True)
+    n = len(x)
+    n_sample = max(int(n * proportion), 3 * K + 2)
+
+    x_grid = np.linspace(x.min(), x.max(), n_grid)
+    tracked = ['contribution', 'proportion', 'location', 'dp', 'skew',
+               'sd_log', 'B_mean_mT', 'B_median_mT', 'B_peak_mT']
+    samples = {name: [] for name in tracked}
+    total_curves = []
+    comp_curves = []
+    n_success = 0
+
+    for _ in range(n_boot):
+        if resample == 'cases':
+            idx = rng.choice(n, size=n_sample, replace=True)
+            xb, yb = x[idx], y[idx]
+        else:
+            perturbation = rng.choice(result['residuals'], size=n,
+                                      replace=True)
+            xb, yb = x, result['y_fit'] + perturbation
+        if noise_level is not None:
+            yb = yb * (1.0 + rng.normal(0.0, noise_level, size=len(yb)))
+        try:
+            if method == 'spectrum':
+                fit = unmix_coercivity_spectrum(xb, yb,
+                                                initial_parameters=best,
+                                                vary_skew=vary_skew)
+            else:
+                fit = unmix_backfield_curve(xb, yb, initial_parameters=best,
+                                            curve_type=curve_type,
+                                            vary_skew=vary_skew)
+        except (ValueError, RuntimeError):
+            continue
+        if not fit['success']:
+            continue
+        # components are sorted by mean coercivity within each fit, which
+        # aligns replicate components with the reference ordering
+        p = fit['params']
+        for name in tracked:
+            samples[name].append(p[name].to_numpy())
+        arr = p[UNMIX_PARAM_COLUMNS].to_numpy()
+        if method == 'spectrum':
+            total_curves.append(coercivity_spectrum_model(x_grid, arr))
+            comp_curves.append(coercivity_spectrum_components(x_grid, arr))
+        else:
+            total_curves.append(coercivity_curve_model(
+                x_grid, arr, offset=fit['offset'], curve_type=curve_type))
+            comp_curves.append(coercivity_curve_components(
+                x_grid, arr, curve_type=curve_type))
+        n_success += 1
+
+    if n_success < max(10, n_boot // 10):
+        raise RuntimeError(f'only {n_success} of {n_boot} bootstrap '
+                           'replicates converged; check the fit or initial '
+                           'parameters')
+    if verbose:
+        print(f'{n_success}/{n_boot} bootstrap replicates converged')
+
+    percentiles = [2.5, 50, 97.5]
+    summary_rows = []
+    for comp in range(K):
+        row = {'component': comp + 1}
+        for name in tracked:
+            vals = np.array([s[comp] for s in samples[name]])
+            row[f'{name}_mean'] = vals.mean()
+            row[f'{name}_std'] = vals.std()
+            for pct in percentiles:
+                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
+                    np.percentile(vals, pct)
+        summary_rows.append(row)
+    param_summary = pd.DataFrame(summary_rows).set_index('component')
+
+    total_curves = np.array(total_curves)
+    comp_curves = np.array(comp_curves)
+    curves = {
+        'x_grid': x_grid,
+        'total_p2_5': np.percentile(total_curves, 2.5, axis=0),
+        'total_p50': np.percentile(total_curves, 50, axis=0),
+        'total_p97_5': np.percentile(total_curves, 97.5, axis=0),
+        'components_p2_5': np.percentile(comp_curves, 2.5, axis=0),
+        'components_p50': np.percentile(comp_curves, 50, axis=0),
+        'components_p97_5': np.percentile(comp_curves, 97.5, axis=0),
+    }
+
+    result_out = copy.deepcopy(result)
+    result_out['bootstrap'] = {
+        'n_boot': n_boot,
+        'n_success': n_success,
+        'resample': resample,
+        'proportion': proportion,
+        'noise_level': noise_level,
+        'param_summary': param_summary,
+        'param_samples': {name: np.array(vals)
+                          for name, vals in samples.items()},
+        'curves': curves,
+    }
+    return result_out
+
+
+def unmixing_multistart(x, magnetization, method='spectrum', n_components=2,
+                        n_starts=100, vary_skew=False, curve_type='backfield',
+                        random_seed=None, location_tolerance=0.1,
+                        proportion_tolerance=0.05, verbose=False, **kwargs):
+    """
+    Map the distinct unmixing solutions reachable from many initializations.
+
+    Coercivity unmixing is a non-convex problem: fits started from
+    different initial parameters can converge to different local minima
+    that describe the data almost equally well. A single fit (and a
+    bootstrap of it, which restarts every replicate from the best-fit
+    values) is conditioned on one solution basin and therefore hides this
+    non-uniqueness. This function launches the fit from n_starts dispersed
+    random initializations (plus the automatic peak-detection estimate),
+    clusters the converged solutions, and reports each distinct solution
+    with its fit statistics and Akaike weight, making the degeneracy of
+    the decomposition explicit.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    magnetization : array-like
+        Remanence curve values at x (e.g. 'magn_mass_shift').
+    method : str
+        Registered unmixing method used for each fit (default 'spectrum').
+    n_components : int
+        Number of components (default 2).
+    n_starts : int
+        Number of random initializations (default 100).
+    vary_skew : bool
+        Whether skew varies during fitting; random starts draw skew from
+        [-5, 5] when True.
+    curve_type : str
+        'backfield' or 'acquisition'.
+    random_seed : None, int, or numpy.random.Generator
+        Seed for reproducible starting points.
+    location_tolerance : float
+        Two solutions are considered the same when all component
+        locations agree within this tolerance (log10 units, default 0.1)
+        and all proportions agree within proportion_tolerance.
+    proportion_tolerance : float
+        Proportion agreement tolerance (default 0.05).
+    verbose : bool
+        Print a summary of the distinct solutions.
+    **kwargs
+        Passed through to the unmixing method.
+
+    Returns
+    -------
+    dict
+        The best (lowest RSS) result dictionary, augmented with a
+        'multistart' entry containing 'solutions' (a DataFrame with one
+        row per distinct solution: n_hits, rss, r_squared, aic,
+        delta_aic, akaike_weight, and per-component B_mean_mT / sd_log /
+        proportion columns), 'results' (the representative result
+        dictionary for each solution, in the same order), 'n_starts', and
+        'n_converged'.
+    """
+    if method not in UNMIXING_METHODS:
+        raise ValueError(f"unknown unmixing method '{method}'; available: "
+                         f'{sorted(UNMIXING_METHODS)}')
+    rng = _resolve_rng(random_seed)
+    x = np.asarray(x, dtype=float)
+    M = np.asarray(magnetization, dtype=float)
+    x_mid, spectrum = coercivity_spectrum_from_curve(x, M, curve_type)
+    total_area = np.abs(_trapz(spectrum, x_mid))
+    K = n_components
+
+    starting_tables = [None]  # None -> automatic estimation inside the method
+    lo, hi = x.min() + 0.05, x.max() - 0.05
+    for _ in range(n_starts):
+        locations = np.sort(rng.uniform(lo, hi, size=K))
+        dps = np.exp(rng.uniform(np.log(0.03), np.log(0.8), size=K))
+        proportions = rng.dirichlet(np.ones(K))
+        skews = rng.uniform(-5, 5, size=K) if vary_skew else np.zeros(K)
+        starting_tables.append(pd.DataFrame({
+            'contribution': proportions * total_area,
+            'location': locations,
+            'dp': dps,
+            'skew': skews,
+        }))
+
+    fits = []
+    for table in starting_tables:
+        try:
+            fit = unmix_coercivity(x, M, method=method,
+                                   n_components=K if table is None else None,
+                                   initial_parameters=table,
+                                   curve_type=curve_type,
+                                   vary_skew=vary_skew, **kwargs)
+        except (ValueError, RuntimeError):
+            continue
+        if fit['success'] and np.isfinite(fit['stats']['rss']):
+            fits.append(fit)
+    if not fits:
+        raise RuntimeError('no multistart fits converged')
+
+    # cluster converged fits into distinct solutions (best fit first)
+    fits.sort(key=lambda f: f['stats']['rss'])
+    clusters = []  # list of dicts: {'representative': fit, 'n_hits': int}
+    for fit in fits:
+        locations = fit['params']['location'].to_numpy()
+        proportions = fit['params']['proportion'].to_numpy()
+        for cluster in clusters:
+            ref = cluster['representative']['params']
+            same_location = np.all(np.abs(
+                locations - ref['location'].to_numpy()) <= location_tolerance)
+            same_proportion = np.all(np.abs(
+                proportions - ref['proportion'].to_numpy())
+                <= proportion_tolerance)
+            if same_location and same_proportion:
+                cluster['n_hits'] += 1
+                break
+        else:
+            clusters.append({'representative': fit, 'n_hits': 1})
+
+    aics = np.array([c['representative']['stats']['aic'] for c in clusters])
+    delta_aic = aics - aics.min()
+    with np.errstate(over='ignore'):
+        weights = np.exp(-0.5 * delta_aic)
+    weights = weights / weights.sum()
+
+    rows = []
+    for i, cluster in enumerate(clusters):
+        fit = cluster['representative']
+        row = {
+            'solution': i + 1,
+            'n_hits': cluster['n_hits'],
+            'rss': fit['stats']['rss'],
+            'r_squared': fit['stats']['r_squared'],
+            'aic': fit['stats']['aic'],
+            'delta_aic': delta_aic[i],
+            'akaike_weight': weights[i],
+        }
+        for comp_index, prow in fit['params'].iterrows():
+            row[f'B_mean_mT_c{comp_index}'] = prow['B_mean_mT']
+            row[f'sd_log_c{comp_index}'] = prow['sd_log']
+            row[f'proportion_c{comp_index}'] = prow['proportion']
+        rows.append(row)
+    solutions = pd.DataFrame(rows).set_index('solution')
+
+    if verbose:
+        print(f'{len(fits)}/{len(starting_tables)} fits converged; '
+              f'{len(clusters)} distinct solution(s)')
+
+    best = copy.deepcopy(clusters[0]['representative'])
+    best['multistart'] = {
+        'solutions': solutions,
+        'results': [c['representative'] for c in clusters],
+        'n_starts': len(starting_tables),
+        'n_converged': len(fits),
+        'method': method,
+    }
+    return best
+
+
+# Bayesian unmixing via nested sampling
+# ------------------------------------------------------------------------------------------------------------------
+
+def _check_dynesty():
+    try:
+        import dynesty  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            'dynesty is required for Bayesian unmixing. '
+            'Install it with: pip install dynesty')
+
+
+def _ordered_uniform_transform(u, low, high):
+    """
+    Map unit-cube draws to ordered uniform order statistics on [low, high].
+
+    Uses the standard recursive inverse-CDF construction so that the
+    returned values are jointly distributed as the order statistics of K
+    independent uniforms, which enforces component ordering (and thereby
+    removes label switching) without distorting the prior.
+    """
+    K = len(u)
+    ordered = np.empty(K)
+    upper = 1.0
+    for k in range(K - 1, -1, -1):
+        upper = upper * u[k] ** (1.0 / (k + 1))
+        ordered[k] = upper
+    return low + (high - low) * ordered
+
+
+def unmix_coercivity_bayes(x, magnetization, n_components=2,
+                           curve_type='backfield', vary_skew=False,
+                           fit_offset=True, priors=None, nlive=250,
+                           dlogz=0.1, sample='rslice', random_seed=None,
+                           n_grid=200, n_posterior_curves=300,
+                           verbose=False):
+    """
+    Bayesian coercivity unmixing by nested sampling (requires dynesty).
+
+    The measured remanence curve is modeled in measurement space (where an
+    independent Gaussian noise model is defensible; numerically
+    differentiated spectra have correlated noise) as a sum of cumulative
+    skew-normal components plus an offset, with the noise standard
+    deviation treated as a free parameter. The posterior is sampled with
+    static nested sampling (Skilling, 2006) as implemented in dynesty
+    (Speagle, 2020), which also returns the Bayesian evidence (logz) --
+    the principled criterion for choosing the number of components
+    (compare logz between runs with different n_components).
+
+    Unlike bootstrap resampling of a single fit, the posterior represents
+    the full range of component decompositions consistent with the data
+    and priors: parameter trade-offs between overlapping components appear
+    as wide, correlated, and possibly multimodal posterior distributions
+    rather than being hidden by a single optimizer solution.
+
+    Component locations are sampled as ordered order-statistics, which
+    fixes component labels without distorting the prior. Default priors
+    are weakly informative (locations uniform across the measured field
+    range, dispersions log-uniform on [0.02, 1.0] decades, contributions
+    uniform up to ~3x the data range); mineralogical knowledge can be
+    injected through the priors argument.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT).
+    magnetization : array-like
+        Remanence curve values at x (e.g. 'magn_mass_shift').
+    n_components : int
+        Number of components (default 2).
+    curve_type : str
+        'backfield' or 'acquisition'.
+    vary_skew : bool
+        Sample component skew (uniform prior on [-10, 10]); default False
+        (symmetric log-Gaussian components).
+    fit_offset : bool
+        Include a constant baseline offset (default True).
+    priors : dict, optional
+        Overrides for the default prior bounds. Recognized keys:
+        'location', 'dp', 'contribution', 'skew' map to a list of
+        (low, high) tuples, one per component (locations/dp in log10
+        units, contributions in the units of the magnetization data);
+        'offset' and 'noise' map to a single (low, high) tuple in
+        magnetization units. When per-component 'location' bounds are
+        given they replace the ordered-uniform construction, so they
+        should be non-overlapping or ordered to keep labels meaningful.
+    nlive : int
+        Number of live points (default 250).
+    dlogz : float
+        Evidence convergence tolerance (default 0.1).
+    sample : str
+        dynesty sampling method (default 'rslice'). Slice sampling is
+        robust to the thin, curved likelihood ridges that overlapping
+        components produce; the dynesty default uniform-ellipsoid
+        sampler can stall on such geometries.
+    random_seed : None, int, or numpy.random.Generator
+        Seed for reproducibility.
+    n_grid : int
+        Grid size for posterior model bands.
+    n_posterior_curves : int
+        Number of posterior draws used for the model bands (default 300).
+    verbose : bool
+        Show dynesty progress.
+
+    Returns
+    -------
+    dict
+        Standardized result dictionary (parameters set to posterior
+        medians) with an added 'bayes' entry containing 'param_summary'
+        (per-component posterior mean/std/percentiles, same format as the
+        bootstrap summary), 'samples' (equally weighted posterior draws
+        for every parameter and derived quantity), 'logz', 'logzerr',
+        'noise' (posterior median noise standard deviation), and 'curves'
+        (posterior percentile bands of the model).
+    """
+    _check_dynesty()
+    import dynesty
+    assert curve_type in ('backfield', 'acquisition'), \
+        "curve_type must be 'backfield' or 'acquisition'"
+    rng = _resolve_rng(random_seed)
+    priors = dict(priors or {})
+
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(magnetization, dtype=float)
+    finite = np.isfinite(x) & np.isfinite(y)
+    x, y = x[finite], y[finite]
+    y_scale = np.max(np.abs(y))
+    if y_scale == 0:
+        raise ValueError('magnetization data are all zero')
+    ys = y / y_scale
+    K = n_components
+    n_data = len(x)
+
+    # prior bounds (normalized units for contribution/offset/noise)
+    location_bounds = priors.get('location')
+    if location_bounds is not None:
+        location_bounds = [tuple(b) for b in location_bounds]
+        assert len(location_bounds) == K
+    location_range = (x.min() - 0.2, x.max() + 0.2)
+    dp_bounds = priors.get('dp', [(0.02, 1.0)] * K)
+    contribution_bounds = [(low / y_scale, high / y_scale) for low, high in
+                           priors.get('contribution',
+                                      [(0.0, 3.0 * y_scale)] * K)]
+    skew_bounds = priors.get('skew', [(-10.0, 10.0)] * K)
+    offset_low, offset_high = np.array(
+        priors.get('offset', (-0.2 * y_scale, 0.2 * y_scale))) / y_scale
+    noise_low, noise_high = np.array(
+        priors.get('noise', (1e-4 * y_scale, 0.3 * y_scale))) / y_scale
+
+    ndim = 3 * K + (K if vary_skew else 0) + (1 if fit_offset else 0) + 1
+
+    def prior_transform(u):
+        theta = np.empty(ndim)
+        i = 0
+        for k in range(K):  # contributions
+            low, high = contribution_bounds[k]
+            theta[i] = low + (high - low) * u[i]
+            i += 1
+        if location_bounds is None:  # ordered locations
+            theta[i:i + K] = _ordered_uniform_transform(
+                u[i:i + K], location_range[0], location_range[1])
+        else:
+            for k in range(K):
+                low, high = location_bounds[k]
+                theta[i + k] = low + (high - low) * u[i + k]
+        i += K
+        for k in range(K):  # dispersions, log-uniform
+            low, high = dp_bounds[k]
+            theta[i] = np.exp(np.log(low)
+                              + (np.log(high) - np.log(low)) * u[i])
+            i += 1
+        if vary_skew:
+            for k in range(K):
+                low, high = skew_bounds[k]
+                theta[i] = low + (high - low) * u[i]
+                i += 1
+        if fit_offset:
+            theta[i] = offset_low + (offset_high - offset_low) * u[i]
+            i += 1
+        theta[i] = np.exp(np.log(noise_low)
+                          + (np.log(noise_high) - np.log(noise_low)) * u[i])
+        return theta
+
+    def unpack(theta):
+        c = theta[:K]
+        loc = theta[K:2 * K]
+        dp = theta[2 * K:3 * K]
+        i = 3 * K
+        if vary_skew:
+            skew = theta[i:i + K]
+            i += K
+        else:
+            skew = np.zeros(K)
+        offset = theta[i] if fit_offset else 0.0
+        noise = theta[-1]
+        return c, loc, dp, skew, offset, noise
+
+    log_norm = -0.5 * n_data * np.log(2.0 * np.pi)
+
+    def loglike(theta):
+        c, loc, dp, skew, offset, noise = unpack(theta)
+        params = np.column_stack([c, loc, dp, skew])
+        model = coercivity_curve_model(x, params, offset=offset,
+                                       curve_type=curve_type)
+        residual = (model - ys) / noise
+        value = log_norm - n_data * np.log(noise) \
+            - 0.5 * float(residual @ residual)
+        return value if np.isfinite(value) else -1e300
+
+    sampler = dynesty.NestedSampler(loglike, prior_transform, ndim,
+                                    nlive=nlive, sample=sample, rstate=rng)
+    sampler.run_nested(dlogz=dlogz, print_progress=verbose)
+    ns_results = sampler.results
+    samples = ns_results.samples_equal(rstate=rng)
+
+    # per-draw derived quantities (analytic, vectorized)
+    contributions = samples[:, :K] * y_scale
+    locations = samples[:, K:2 * K]
+    dps = samples[:, 2 * K:3 * K]
+    skews = samples[:, 3 * K:4 * K] if vary_skew else np.zeros_like(locations)
+    offsets = (samples[:, -2] * y_scale if fit_offset
+               else np.zeros(len(samples)))
+    noises = samples[:, -1] * y_scale
+    deltas = skews / np.sqrt(1.0 + skews ** 2)
+    means_log = locations + dps * deltas * np.sqrt(2.0 / np.pi)
+    sd_logs = dps * np.sqrt(1.0 - 2.0 * deltas ** 2 / np.pi)
+    proportions = contributions / contributions.sum(axis=1, keepdims=True)
+    derived = {
+        'contribution': contributions,
+        'proportion': proportions,
+        'location': locations,
+        'dp': dps,
+        'skew': skews,
+        'sd_log': sd_logs,
+        'B_mean_mT': 10 ** means_log,
+    }
+
+    percentiles = [2.5, 50, 97.5]
+    summary_rows = []
+    for comp in range(K):
+        row = {'component': comp + 1}
+        for name, values in derived.items():
+            column = values[:, comp]
+            row[f'{name}_mean'] = column.mean()
+            row[f'{name}_std'] = column.std()
+            for pct in percentiles:
+                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
+                    np.percentile(column, pct)
+        summary_rows.append(row)
+    param_summary = pd.DataFrame(summary_rows).set_index('component')
+
+    # posterior-median parameter table in the standard result format
+    median_params = np.column_stack([
+        np.median(contributions, axis=0), np.median(locations, axis=0),
+        np.median(dps, axis=0), np.median(skews, axis=0)])
+    offset_median = float(np.median(offsets))
+    rows = []
+    for comp in range(K):
+        c_med, loc_med, dp_med, skew_med = median_params[comp]
+        stats_comp = skewnormal_stats(loc_med, dp_med, skew_med)
+        rows.append({
+            'contribution': c_med,
+            'se_contribution': contributions[:, comp].std(),
+            'location': loc_med,
+            'se_location': locations[:, comp].std(),
+            'dp': dp_med,
+            'se_dp': dps[:, comp].std(),
+            'skew': skew_med,
+            'se_skew': skews[:, comp].std(),
+            'sd_log': stats_comp['std'],
+            'log10_B_mean': stats_comp['mean'],
+            'B_mean_mT': 10 ** stats_comp['mean'],
+            'B_median_mT': 10 ** stats_comp['median'],
+            'B_peak_mT': 10 ** stats_comp['mode'],
+        })
+    params = pd.DataFrame(rows, index=pd.RangeIndex(1, K + 1,
+                                                    name='component'))
+    total = params['contribution'].sum()
+    params.insert(1, 'proportion', params['contribution'] / total)
+
+    y_fit = coercivity_curve_model(x, median_params, offset=offset_median,
+                                   curve_type=curve_type)
+    residuals = y - y_fit
+    rss = float(np.sum(residuals ** 2))
+    tss = float(np.sum((y - y.mean()) ** 2))
+    n_params = ndim
+    stats = {
+        'n': n_data,
+        'n_params': n_params,
+        'dof': n_data - n_params,
+        'rss': rss,
+        'r_squared': 1.0 - rss / tss if tss > 0 else np.nan,
+        'reduced_chi_square': (rss / (n_data - n_params)
+                               if n_data > n_params else np.nan),
+        'aic': np.nan,  # use logz for Bayesian model comparison
+        'bic': np.nan,
+        'logz': float(ns_results.logz[-1]),
+        'logzerr': float(ns_results.logzerr[-1]),
+    }
+
+    # posterior model bands from a subset of equally weighted draws
+    x_grid = np.linspace(x.min(), x.max(), n_grid)
+    n_draws = min(n_posterior_curves, len(samples))
+    draw_index = rng.choice(len(samples), size=n_draws, replace=False)
+    total_curves = np.empty((n_draws, n_grid))
+    comp_curves = np.empty((n_draws, K, n_grid))
+    for j, index in enumerate(draw_index):
+        draw_params = np.column_stack([
+            contributions[index], locations[index], dps[index],
+            skews[index]])
+        comps = coercivity_curve_components(x_grid, draw_params,
+                                            curve_type=curve_type)
+        comp_curves[j] = comps
+        total_curves[j] = comps.sum(axis=0) + offsets[index]
+    curves = {
+        'x_grid': x_grid,
+        'total_p2_5': np.percentile(total_curves, 2.5, axis=0),
+        'total_p50': np.percentile(total_curves, 50, axis=0),
+        'total_p97_5': np.percentile(total_curves, 97.5, axis=0),
+        'components_p2_5': np.percentile(comp_curves, 2.5, axis=0),
+        'components_p50': np.percentile(comp_curves, 50, axis=0),
+        'components_p97_5': np.percentile(comp_curves, 97.5, axis=0),
+    }
+
+    initial_df = pd.DataFrame(median_params, columns=UNMIX_PARAM_COLUMNS)
+    return {
+        'method': 'bayes',
+        'curve_type': curve_type,
+        'n_components': K,
+        'success': True,
+        'message': (f'nested sampling converged '
+                    f'(logz = {stats["logz"]:.2f} '
+                    f'+/- {stats["logzerr"]:.2f})'),
+        'params': params,
+        'offset': offset_median,
+        'se_offset': float(np.std(offsets)),
+        'x': x,
+        'y': y,
+        'y_fit': y_fit,
+        'residuals': residuals,
+        'weights': None,
+        'stats': stats,
+        'initial_parameters': initial_df,
+        'vary_skew': vary_skew,
+        'bayes': {
+            'param_summary': param_summary,
+            'samples': {**{name: values for name, values in derived.items()},
+                        'offset': offsets, 'noise': noises},
+            'logz': stats['logz'],
+            'logzerr': stats['logzerr'],
+            'noise': float(np.median(noises)),
+            'ncall': int(ns_results.ncall.sum()),
+            'niter': int(ns_results.niter),
+            'nlive': nlive,
+            'curves': curves,
+        },
+    }
+
+
+def _unmix_method_bayes(x, magnetization, n_components=None,
+                        initial_parameters=None, curve_type='backfield',
+                        vary_skew=False, priors=None, **kwargs):
+    """
+    Registered 'bayes' method: nested-sampling posterior in measurement
+    space. If initial_parameters are supplied (e.g. from the interactive
+    widget) and no explicit priors are given, per-component location and
+    dispersion priors are centered on them.
+    """
+    # a priors dict from mineral_priors() carries one entry per component,
+    # so n_components can be inferred from it
+    if (n_components is None and priors is not None
+            and priors.get('location') is not None):
+        n_components = len(priors['location'])
+    if initial_parameters is not None:
+        if n_components is None:
+            n_components = len(initial_parameters)
+        if priors is None:
+            table = _unmix_parameters_to_array(initial_parameters)
+            order = np.argsort(table[:, 1])
+            table = table[order]
+            priors = {
+                'location': [(row[1] - max(3 * row[2], 0.3),
+                              row[1] + max(3 * row[2], 0.3))
+                             for row in table],
+                'dp': [(max(row[2] / 4, 0.02), min(row[2] * 4, 1.5))
+                       for row in table],
+            }
+    if n_components is None:
+        raise ValueError('specify n_components, initial_parameters, or priors')
+    return unmix_coercivity_bayes(x, magnetization,
+                                  n_components=n_components,
+                                  curve_type=curve_type,
+                                  vary_skew=vary_skew, priors=priors,
+                                  **kwargs)
+
+
+UNMIXING_METHODS['bayes'] = _unmix_method_bayes
+
+
+# Coercivity component prior library
+# ------------------------------------------------------------------------------------------------------------------
+# Characteristic coercivity ranges for common remanence-carrying magnetic
+# mineral components, for use as informative priors in Bayesian unmixing
+# (unmix_coercivity_bayes) or as initial parameters for the least-squares
+# methods. Covered minerals: magnetite (igneous, detrital, eolian,
+# pedogenic/extracellular, and biogenic soft/hard), oxidized maghemite, the
+# ferrimagnetic iron sulphides greigite and pyrrhotite, and the
+# antiferromagnetic iron oxides/oxyhydroxides hematite (pigmentary/detrital)
+# and goethite. Each entry gives a plausible range for the median coercivity
+# (B_median_mT), the dispersion (dp, in log10 units), and the skew, together
+# with the literature source.
+#
+# IMPORTANT CAVEATS:
+#  * The magnetite-family values derive from Egli (2004a,b), whose component
+#    analysis is based on AF demagnetization of ARM/IRM and reports the
+#    median destructive field (MDF) of the coercivity distribution. For IRM
+#    acquisition or backfield curves the relevant quantity is the median
+#    acquisition/remanence field, which is comparable to the MDF for a given
+#    mineral population but not identical; treat these as soft, approximate
+#    priors, not calibrations.
+#  * The sulphide, hematite, and goethite values are from Roberts (2025),
+#    "Mineral Magnetism". These ranges are broad on purpose: they overlap
+#    one another (greigite and pyrrhotite overlap biogenic-hard magnetite
+#    and maghemite; pyrrhotite overlaps pigmentary hematite), so a coercivity
+#    prior constrains a window, it does not identify a mineral. Al-substitution
+#    drives hematite coercivity up to ~1300 mT and then collapses it toward
+#    zero at high substitution, while Al- and micro-goethite can fall below
+#    ~60 mT.
+#  * Pyrrhotite and goethite do not magnetically saturate in ordinary
+#    laboratory fields (pyrrhotite needs >2 T; goethite is unsaturated even
+#    in 57 T fields), so a typical backfield or IRM experiment (<= 2-5 T)
+#    captures only the low-coercivity tail of such a component and
+#    underestimates its contribution; pass field_max_mT to keep priors within
+#    the measured range and interpret any such contribution as a minimum.
+#  * Component fitting near the SP/SD threshold can produce a spurious
+#    low-coercivity component (Heslop et al., 2004); an unexpectedly soft
+#    component should be checked against independent evidence.
+#  * Ranges are deliberately generous (roughly the spread of the cited
+#    populations, not a single sample). Narrow them with the `tighten`
+#    argument of mineral_priors only when justified by independent data.
+#
+# Values are the (low, high) bounds of a uniform prior on each quantity.
+COERCIVITY_COMPONENT_LIBRARY = {
+    'magnetite_pedogenic': {
+        'B_median_mT': (12.0, 25.0), 'dp': (0.25, 0.38),
+        'skew': (-1.0, 0.0),
+        'source': 'Egli (2004a), components PD/EX; Roberts (2025) '
+                  '(pedogenic / extracellular ultrafine magnetite)',
+        'note': 'ultrafine SP-SSD magnetite; MDF ~16-18 mT, DP ~0.30, '
+                'strongly left-skewed'},
+    'magnetite_detrital': {
+        'B_median_mT': (18.0, 40.0), 'dp': (0.30, 0.45),
+        'skew': (-0.7, 0.0),
+        'source': 'Egli (2004a), component D; Roberts (2025) '
+                  '(detrital magnetite)',
+        'note': 'coarse detrital magnetite in water-lain sediments; '
+                'MDF ~25-33 mT, DP ~0.35-0.40'},
+    'magnetite_igneous': {
+        'B_median_mT': (8.0, 40.0), 'dp': (0.20, 0.50),
+        'skew': (-0.6, 0.2),
+        'source': 'Roberts (2025), magnetite chapter (grain-size '
+                  'systematics of primary magmatic magnetite)',
+        'note': 'primary magmatic (titano)magnetite; broad and grain-size '
+                'dependent, spanning low-coercivity coarse PSD-MD grains to '
+                'finer PSD/SD grains in rapidly cooled volcanics; oxidation '
+                'to titanomaghemite raises coercivity (see '
+                'maghemite_oxidized)'},
+    'magnetite_eolian': {
+        'B_median_mT': (18.0, 45.0), 'dp': (0.20, 0.40),
+        'skew': (-0.6, 0.0),
+        'source': 'Egli (2004a), component ED; Roberts (2025) '
+                  '(wind-blown dust magnetite)',
+        'note': 'aeolian / loess detrital magnetite'},
+    'magnetite_biogenic_soft': {
+        'B_median_mT': (25.0, 55.0), 'dp': (0.10, 0.25),
+        'skew': (-0.5, 0.0),
+        'source': 'Egli (2004a), component BS; Roberts (2025) '
+                  '(low-coercivity magnetosomes)',
+        'note': 'biogenic soft magnetite; diagnostic narrow DP (~0.1-0.2)'},
+    'magnetite_biogenic_hard': {
+        'B_median_mT': (50.0, 100.0), 'dp': (0.08, 0.22),
+        'skew': (-0.3, 0.2),
+        'source': 'Egli (2004a), component BH; Roberts (2025) '
+                  '(high-coercivity magnetosomes)',
+        'note': 'biogenic hard magnetite; diagnostic very narrow DP'},
+    'maghemite_oxidized': {
+        'B_median_mT': (45.0, 110.0), 'dp': (0.15, 0.35),
+        'skew': (-0.6, 0.2),
+        'source': 'Egli (2004a), component L; Roberts (2025) '
+                  '(oxidized maghemite in loess)',
+        'note': 'low-temperature-oxidized magnetite/maghemite; '
+                'higher coercivity than parent magnetite'},
+    'greigite': {
+        'B_median_mT': (30.0, 95.0), 'dp': (0.15, 0.35),
+        'skew': (-0.4, 0.4),
+        'source': 'Roberts (2025), greigite chapter (Roberts et al., '
+                  '2011b compilation)',
+        'note': 'authigenic ferrimagnetic iron sulphide; stable-SD '
+                'greigite Bcr ~75 mT (60-95 mT), SD+MD mixtures ~45 mT, '
+                'MD-dominated ~25 mT; saturates below ~0.3 T'},
+    'pyrrhotite': {
+        'B_median_mT': (25.0, 150.0), 'dp': (0.20, 0.45),
+        'skew': (-0.5, 0.5),
+        'source': 'Roberts (2025), pyrrhotite chapter',
+        'note': 'monoclinic 4C pyrrhotite; medium- to high-coercivity '
+                'ferrimagnet, Bcr from ~15-20 mT (coarse MD) to ~100-200 mT '
+                '(fine SD), with metamorphic/3C samples reaching >300 mT; '
+                'requires >2 T to saturate, so backfield contributions are '
+                'minimum estimates'},
+    'hematite_pigmentary': {
+        'B_median_mT': (150.0, 700.0), 'dp': (0.35, 0.95),
+        'skew': (-0.5, 1.5),
+        'source': 'Maxbauer et al. (2016); Swanson-Hysell et al. (2019) '
+                  'red bed pigmentary hematite',
+        'note': 'fine pigmentary hematite; broad, often skewed distribution'},
+    'hematite_detrital': {
+        'B_median_mT': (500.0, 1500.0), 'dp': (0.18, 0.40),
+        'skew': (-0.5, 1.0),
+        'source': 'Swanson-Hysell et al. (2019); Ozdemir & Dunlop (2014); '
+                  'Roberts (2025) specular / detrital hematite',
+        'note': 'coarser specular/detrital hematite; narrower, '
+                'higher-coercivity than pigmentary hematite; Al-substituted '
+                'hematite coercivity peaks near ~7 mol% Al (~1300 mT) and '
+                'collapses at higher substitution'},
+    'hematite': {
+        'B_median_mT': (150.0, 1500.0), 'dp': (0.20, 0.90),
+        'skew': (-0.5, 1.5),
+        'source': 'Ozdemir & Dunlop (2014); Heslop (2015); Roberts (2025)',
+        'note': 'generic hematite window spanning pigmentary and detrital '
+                'end-members; use the specific entries when possible'},
+    'goethite': {
+        'B_median_mT': (300.0, 5000.0), 'dp': (0.20, 0.60),
+        'skew': (-0.5, 1.0),
+        'source': 'Roberts (2025) goethite chapter; Heslop (2015)',
+        'note': 'very high coercivity, but with a huge natural range: '
+                'fitted goethite components span ~300-5000 mT and FORC '
+                'coercivities in well-crystalline goethite exceed 700 mT, '
+                'while Al-substituted and microparticulate goethite can '
+                'fall below ~60 mT. Goethite remanence is unsaturated even '
+                'in 57 T fields, so ordinary backfield/IRM experiments see '
+                'only its low-coercivity tail: treat any fitted goethite '
+                'contribution as a minimum and pass field_max_mT'},
+}
+
+
+def mineral_priors(mineral_names, tighten=1.0, field_max_mT=None):
+    """
+    Build a Bayesian-unmixing prior dictionary from named mineral components.
+
+    Converts a list of component names from COERCIVITY_COMPONENT_LIBRARY
+    into the `priors` dictionary accepted by unmix_coercivity_bayes, with
+    one location and dispersion (and skew) prior per component. Components
+    are sorted by their central coercivity so that the returned order
+    matches the (low-to-high coercivity) component ordering of the fit.
+
+    Because these are informative priors on an ill-posed decomposition,
+    they should be treated as soft constraints; see the caveats in the
+    COERCIVITY_COMPONENT_LIBRARY documentation (AF-demagnetization vs IRM
+    acquisition, Al-substitution, generous default ranges).
+
+    Parameters
+    ----------
+    mineral_names : list of str
+        Component names, each a key of COERCIVITY_COMPONENT_LIBRARY (e.g.
+        ['magnetite_detrital', 'hematite_pigmentary', 'hematite_detrital']).
+    tighten : float
+        Factor (>= 1) by which to narrow every range about its center; 1
+        keeps the library ranges, 2 halves their width. Use only when
+        justified by independent constraints.
+    field_max_mT : float, optional
+        Maximum applied field of the measurement (mT). Location upper
+        bounds are clipped to this value, so that components whose library
+        range extends past the measured field (e.g. goethite in a 2 T
+        experiment) are not given prior support the data cannot constrain.
+
+    Returns
+    -------
+    dict
+        A priors dictionary with 'location', 'dp', and 'skew' keys, each a
+        list of (low, high) tuples in the order of increasing coercivity,
+        suitable for `unmix_coercivity_bayes(..., priors=...)`. The chosen
+        component names, in the same order, are returned under the
+        'components' key.
+    """
+    if isinstance(mineral_names, str):
+        mineral_names = [mineral_names]
+    if tighten < 1:
+        raise ValueError('tighten must be >= 1')
+
+    def _narrow(low, high):
+        center = 0.5 * (low + high)
+        half = 0.5 * (high - low) / tighten
+        return center - half, center + half
+
+    entries = []
+    for name in mineral_names:
+        if name not in COERCIVITY_COMPONENT_LIBRARY:
+            raise KeyError(
+                f"unknown mineral component '{name}'; available: "
+                f'{sorted(COERCIVITY_COMPONENT_LIBRARY)}')
+        entry = COERCIVITY_COMPONENT_LIBRARY[name]
+        b_low, b_high = _narrow(*entry['B_median_mT'])
+        if field_max_mT is not None:
+            b_high = min(b_high, field_max_mT)
+            b_low = min(b_low, b_high)
+        entries.append((name, np.sqrt(b_low * b_high),
+                        (np.log10(b_low), np.log10(b_high)),
+                        _narrow(*entry['dp']), _narrow(*entry['skew'])))
+    entries.sort(key=lambda item: item[1])
+
+    return {
+        'components': [item[0] for item in entries],
+        'location': [item[2] for item in entries],
+        'dp': [item[3] for item in entries],
+        'skew': [item[4] for item in entries],
+    }
+
+
+def _format_mT_axis(ax):
+    """Label a log10(B) axis with field values in mT."""
+    from matplotlib.ticker import FuncFormatter
+
+    def _fmt(value, _pos):
+        field = 10 ** value
+        return f'{field:g}' if field < 1000 else f'{field:.0f}'
+    ax.xaxis.set_major_formatter(FuncFormatter(_fmt))
+
+
+def plot_coercivity_unmixing(result, show_components=True,
+                             show_bootstrap=True, show_initial=False,
+                             n_grid=300, figsize=None, title=None):
+    """
+    Plot an unmixing result in its fitted data space.
+
+    For spectrum-space fits a single panel shows the data, total model, and
+    components. For measurement-space (curve) fits an upper panel shows the
+    measured curve with the cumulative model and a lower panel shows the
+    finite-difference spectrum of the data with the implied component
+    density curves. Bootstrap 95% bands are drawn when present.
+
+    Parameters
+    ----------
+    result : dict
+        Result from unmix_coercivity_spectrum, unmix_backfield_curve, or
+        unmixing_bootstrap.
+    show_components : bool
+        Draw the individual components (default True).
+    show_bootstrap : bool
+        Draw bootstrap confidence bands if available (default True).
+    show_initial : bool
+        Also draw the model implied by the initial parameters (dotted),
+        useful for judging how far the optimizer moved (default False).
+    n_grid : int
+        Number of points for smooth model curves.
+    figsize : tuple, optional
+        Figure size; defaults depend on the number of panels.
+    title : str, optional
+        Figure title.
+
+    Returns
+    -------
+    tuple
+        (fig, axes) with axes a list of the panel axes.
+    """
+    method = result['method']
+    curve_type = result['curve_type']
+    params = result['params']
+    param_arr = params[UNMIX_PARAM_COLUMNS].to_numpy()
+    x, y = result['x'], result['y']
+    x_grid = np.linspace(x.min(), x.max(), n_grid)
+    boot = None
+    band_label = '95% bootstrap band'
+    if show_bootstrap:
+        if 'bootstrap' in result:
+            boot = result['bootstrap']
+        elif 'bayes' in result:
+            boot = result['bayes']
+            band_label = '95% credible band'
+
+    plot_as_curve = method in ('curve', 'bayes')
+    n_panels = 2 if plot_as_curve else 1
+    if figsize is None:
+        figsize = (8, 4.5 * n_panels)
+    fig, axes = plt.subplots(nrows=n_panels, ncols=1, figsize=figsize,
+                             sharex=True)
+    axes = list(np.atleast_1d(axes))
+
+    def _component_label(i):
+        row = params.loc[i]
+        return (f'component {i}: {row["B_mean_mT"]:.0f} mT, '
+                f'DP {row["sd_log"]:.2f}, {row["proportion"] * 100:.0f}%')
+
+    if plot_as_curve:
+        ax_curve, ax_spec = axes
+        ax_curve.scatter(x, y, c='grey', s=12, label='measurements')
+        ax_curve.plot(x_grid, coercivity_curve_model(
+            x_grid, param_arr, offset=result['offset'],
+            curve_type=curve_type), c='k', label='model')
+        if show_components:
+            comps = coercivity_curve_components(x_grid, param_arr,
+                                                curve_type=curve_type)
+            for i in range(len(params)):
+                ax_curve.plot(x_grid, comps[i] + result['offset'],
+                              c=f'C{i}', alpha=0.8)
+        if boot is not None:
+            curves = boot['curves']
+            ax_curve.fill_between(curves['x_grid'], curves['total_p2_5'],
+                                  curves['total_p97_5'], color='k',
+                                  alpha=0.2, label=band_label)
+        ax_curve.set_ylabel('magnetization')
+        ax_curve.legend(fontsize=9)
+        # implied spectrum panel from finite differences of the data
+        x_mid, spec = coercivity_spectrum_from_curve(x, y, curve_type)
+        ax_spec.scatter(x_mid, spec, c='grey', s=12,
+                        label='finite-difference spectrum')
+        ax_spec.plot(x_grid, coercivity_spectrum_model(x_grid, param_arr),
+                     c='k', label='model')
+        if show_components:
+            comps = coercivity_spectrum_components(x_grid, param_arr)
+            for i, comp_index in enumerate(params.index):
+                ax_spec.plot(x_grid, comps[i], c=f'C{i}',
+                             label=_component_label(comp_index))
+        if show_initial:
+            init_arr = _unmix_parameters_to_array(
+                result['initial_parameters'])
+            ax_spec.plot(x_grid, coercivity_spectrum_model(x_grid, init_arr),
+                         c='k', ls=':', alpha=0.6, label='initial model')
+        ax_spec.set_ylabel('dM/dlog$_{10}$(B)')
+        ax_spec.set_xlabel('field (mT)')
+        ax_spec.legend(fontsize=9)
+    else:
+        ax_spec = axes[0]
+        ax_spec.scatter(x, y, c='grey', s=12, label='coercivity spectrum')
+        if boot is not None:
+            curves = boot['curves']
+            ax_spec.fill_between(curves['x_grid'], curves['total_p2_5'],
+                                 curves['total_p97_5'], color='k', alpha=0.2,
+                                 label=band_label)
+            if show_components:
+                for i in range(len(params)):
+                    ax_spec.fill_between(curves['x_grid'],
+                                         curves['components_p2_5'][i],
+                                         curves['components_p97_5'][i],
+                                         color=f'C{i}', alpha=0.2)
+        ax_spec.plot(x_grid, coercivity_spectrum_model(x_grid, param_arr),
+                     c='k', label='model')
+        if show_components:
+            comps = coercivity_spectrum_components(x_grid, param_arr)
+            for i, comp_index in enumerate(params.index):
+                ax_spec.plot(x_grid, comps[i], c=f'C{i}',
+                             label=_component_label(comp_index))
+        if show_initial:
+            init_arr = _unmix_parameters_to_array(
+                result['initial_parameters'])
+            ax_spec.plot(x_grid, coercivity_spectrum_model(x_grid, init_arr),
+                         c='k', ls=':', alpha=0.6, label='initial model')
+        ax_spec.set_ylabel('dM/dlog$_{10}$(B)')
+        ax_spec.set_xlabel('field (mT)')
+        ax_spec.legend(fontsize=9)
+
+    for ax in axes:
+        _format_mT_axis(ax)
+    if title is not None:
+        fig.suptitle(title)
+    fig.tight_layout()
+    return fig, axes
+
+
+def _unmixing_samples(result):
+    """
+    Return the per-draw parameter samples from a bootstrap or Bayesian result.
+
+    Both unmixing_bootstrap and unmix_coercivity_bayes attach a dictionary of
+    posterior/bootstrap draws (one array of shape (n_draws, n_components) per
+    tracked quantity). This helper returns that dictionary along with a label
+    describing the uncertainty source, or raises if the result carries no
+    draws.
+
+    Returns
+    -------
+    tuple
+        (samples, source_label) where samples maps quantity name -> array of
+        shape (n_draws, n_components) and source_label is 'bootstrap' or
+        'posterior'.
+    """
+    if 'bayes' in result:
+        return result['bayes']['samples'], 'posterior'
+    if 'bootstrap' in result:
+        return result['bootstrap']['param_samples'], 'bootstrap'
+    raise ValueError('result has no bootstrap or Bayesian draws; run '
+                     'unmixing_bootstrap or method="bayes" first')
+
+
+def plot_unmixing_posterior(result, quantity='B_mean_mT', bins=40,
+                            figsize=None, colors=None):
+    """
+    Plot marginal uncertainty distributions of a component quantity.
+
+    Draws one histogram per component of the requested derived quantity from
+    the bootstrap or Bayesian draws, with the median and 95% interval marked.
+    This visualizes how tightly each component parameter is constrained,
+    including asymmetric and multimodal uncertainties that a single
+    standard-error value cannot convey.
+
+    Parameters
+    ----------
+    result : dict
+        Result from unmixing_bootstrap or unmix_coercivity_bayes.
+    quantity : str
+        Name of the quantity to plot (e.g. 'B_mean_mT', 'proportion',
+        'sd_log', 'location', 'dp', 'skew'). Must be present in the draws.
+    bins : int
+        Number of histogram bins.
+    figsize : tuple, optional
+        Figure size; defaults to (7, 2.2 * n_components).
+    colors : list, optional
+        Per-component colors; defaults to the matplotlib C0, C1, ... cycle.
+
+    Returns
+    -------
+    tuple
+        (fig, axes).
+    """
+    samples, source = _unmixing_samples(result)
+    if quantity not in samples:
+        raise KeyError(f"'{quantity}' is not in the draws; available: "
+                       f'{sorted(samples)}')
+    values = np.asarray(samples[quantity])
+    K = values.shape[1]
+    log_x = quantity in ('B_mean_mT', 'B_median_mT', 'B_peak_mT')
+    if figsize is None:
+        figsize = (7, 2.2 * K)
+    if colors is None:
+        colors = [f'C{i}' for i in range(K)]
+    fig, axes = plt.subplots(K, 1, figsize=figsize, squeeze=False)
+    axes = axes.ravel()
+    for i in range(K):
+        column = values[:, i]
+        median = np.median(column)
+        low, high = np.percentile(column, [2.5, 97.5])
+        if log_x:
+            bin_edges = np.logspace(np.log10(column.min()),
+                                    np.log10(column.max()), bins)
+            axes[i].set_xscale('log')
+        else:
+            bin_edges = bins
+        axes[i].hist(column, bins=bin_edges, color=colors[i], alpha=0.6,
+                     density=True)
+        axes[i].axvline(median, color='k', lw=1.2,
+                        label=f'median {median:.3g}')
+        axes[i].axvline(low, color='k', ls='--', lw=0.9)
+        axes[i].axvline(high, color='k', ls='--', lw=0.9,
+                        label=f'95%: [{low:.3g}, {high:.3g}]')
+        axes[i].set_ylabel(f'component {i + 1}')
+        axes[i].legend(fontsize=8)
+    axes[-1].set_xlabel(f'{quantity} ({source} draws)')
+    fig.tight_layout()
+    return fig, axes
+
+
+def plot_unmixing_tradeoff(result, x='B_mean_mT', y='proportion',
+                           component=None, figsize=(5, 5), colors=None):
+    """
+    Scatter two component quantities across draws to reveal parameter trade-offs.
+
+    Overlapping coercivity components trade parameters against one another;
+    plotting one quantity against another across the bootstrap or posterior
+    draws exposes these correlations (and any multimodality) that marginal
+    intervals hide. By default every component is shown; pass a component
+    index to isolate one.
+
+    Parameters
+    ----------
+    result : dict
+        Result from unmixing_bootstrap or unmix_coercivity_bayes.
+    x, y : str
+        Quantity names for the two axes (e.g. 'B_mean_mT', 'proportion',
+        'sd_log').
+    component : int, optional
+        1-based component index to plot alone; if None, all components are
+        overlaid.
+    figsize : tuple
+        Figure size.
+    colors : list, optional
+        Per-component colors.
+
+    Returns
+    -------
+    tuple
+        (fig, ax).
+    """
+    samples, source = _unmixing_samples(result)
+    for name in (x, y):
+        if name not in samples:
+            raise KeyError(f"'{name}' is not in the draws; available: "
+                           f'{sorted(samples)}')
+    xv = np.asarray(samples[x])
+    yv = np.asarray(samples[y])
+    K = xv.shape[1]
+    components = range(K) if component is None else [component - 1]
+    if colors is None:
+        colors = [f'C{i}' for i in range(K)]
+    fig, ax = plt.subplots(figsize=figsize)
+    for i in components:
+        ax.scatter(xv[:, i], yv[:, i], s=6, alpha=0.25, color=colors[i],
+                   edgecolors='none', label=f'component {i + 1}')
+    if x in ('B_mean_mT', 'B_median_mT', 'B_peak_mT'):
+        ax.set_xscale('log')
+    if y in ('B_mean_mT', 'B_median_mT', 'B_peak_mT'):
+        ax.set_yscale('log')
+    ax.set_xlabel(x)
+    ax.set_ylabel(y)
+    ax.set_title(f'parameter trade-off ({source} draws)')
+    if component is None and K > 1:
+        ax.legend(fontsize=8)
+    fig.tight_layout()
+    return fig, ax
+
+
+def plot_unmixing_ensemble(result, space='spectrum', n_draws=200, n_grid=300,
+                           show_components=True, figsize=(8, 5), title=None,
+                           colors=None, random_seed=None):
+    """
+    Overlay many draws of the model curves to visualize decomposition spread.
+
+    Rather than a single best fit with an error band, this draws the total
+    model and (optionally) the individual components for many bootstrap or
+    posterior samples, so the full range of decompositions consistent with
+    the data is visible directly -- including cases where components exchange
+    coercivity or amplitude between draws.
+
+    Parameters
+    ----------
+    result : dict
+        Result from unmixing_bootstrap or unmix_coercivity_bayes.
+    space : str
+        'spectrum' (dM/dlog10 B) or 'curve' (measurement space).
+    n_draws : int
+        Number of draws to overlay (capped at the number available).
+    n_grid : int
+        Number of field points for the smooth curves.
+    show_components : bool
+        Overlay per-component curves in addition to the total.
+    figsize : tuple
+        Figure size.
+    title : str, optional
+        Figure title.
+    colors : list, optional
+        Per-component colors.
+    random_seed : None, int, or numpy.random.Generator
+        Seed for choosing which draws to plot.
+
+    Returns
+    -------
+    tuple
+        (fig, ax).
+    """
+    assert space in ('spectrum', 'curve'), \
+        "space must be 'spectrum' or 'curve'"
+    samples, source = _unmixing_samples(result)
+    rng = _resolve_rng(random_seed)
+    curve_type = result['curve_type']
+    x, y = result['x'], result['y']
+    x_grid = np.linspace(x.min(), x.max(), n_grid)
+
+    contribution = np.asarray(samples['contribution'])
+    location = np.asarray(samples['location'])
+    dp = np.asarray(samples['dp'])
+    skew = np.asarray(samples['skew'])
+    n_available, K = contribution.shape
+    if colors is None:
+        colors = [f'C{i}' for i in range(K)]
+    offset_draws = np.asarray(result['bayes']['samples']['offset']) \
+        if ('bayes' in result and space == 'curve') else None
+
+    n_plot = min(n_draws, n_available)
+    idx = rng.choice(n_available, size=n_plot, replace=False)
+
+    fig, ax = plt.subplots(figsize=figsize)
+    # data
+    if space == 'spectrum':
+        x_mid, spectrum = coercivity_spectrum_from_curve(x, y, curve_type)
+        ax.scatter(x_mid, spectrum, s=10, c='grey', alpha=0.5, zorder=3,
+                   label='data spectrum')
+    else:
+        ax.scatter(x, y, s=10, c='grey', alpha=0.5, zorder=3, label='data')
+
+    for draw, j in enumerate(idx):
+        params = np.column_stack([contribution[j], location[j], dp[j],
+                                  skew[j]])
+        if space == 'spectrum':
+            total = coercivity_spectrum_model(x_grid, params)
+            comps = (coercivity_spectrum_components(x_grid, params)
+                     if show_components else None)
+        else:
+            offset = offset_draws[j] if offset_draws is not None \
+                else result['offset']
+            total = coercivity_curve_model(x_grid, params, offset=offset,
+                                           curve_type=curve_type)
+            comps = (coercivity_curve_components(x_grid, params,
+                                                 curve_type=curve_type)
+                     if show_components else None)
+        ax.plot(x_grid, total, color='k', alpha=0.04, lw=0.8,
+                label='model draws' if draw == 0 else None)
+        if comps is not None:
+            for i in range(K):
+                ax.plot(x_grid, comps[i], color=colors[i], alpha=0.04,
+                        lw=0.8,
+                        label=f'component {i + 1}' if draw == 0 else None)
+    ax.set_xlabel('field (mT)')
+    ax.set_ylabel('dM/dlog$_{10}$(B)' if space == 'spectrum'
+                  else 'magnetization')
+    _format_mT_axis(ax)
+    ax.set_title(title if title is not None
+                 else f'ensemble of {n_plot} {source} draws')
+    # legend with opaque proxies
+    handles, labels = ax.get_legend_handles_labels()
+    for handle in handles:
+        handle.set_alpha(1.0)
+    ax.legend(handles, labels, fontsize=8)
+    fig.tight_layout()
+    return fig, ax
+
+
+def plot_multistart_solutions(result, max_solutions=6, space='spectrum',
+                              n_grid=300, figsize=None, colors=None):
+    """
+    Visualize the distinct solutions found by a multi-start analysis.
+
+    Produces a panel of small multiples, one per distinct solution (ordered
+    by Akaike weight), each showing that solution's decomposition against the
+    data, plus a final parameter-space map that places every solution's
+    components on a coercivity-versus-proportion plot. Together these make
+    the non-uniqueness of the decomposition concrete: how many genuinely
+    different solutions the data admit, how each partitions the spectrum, and
+    how much statistical support each carries.
+
+    Parameters
+    ----------
+    result : dict
+        Result from unmixing_multistart (carries a 'multistart' entry).
+    max_solutions : int
+        Maximum number of distinct solutions to draw as small multiples
+        (the highest-weight solutions are shown).
+    space : str
+        'spectrum' (dM/dlog10 B) or 'curve' (measurement space) for the
+        decomposition panels.
+    n_grid : int
+        Number of field points for the smooth model curves.
+    figsize : tuple, optional
+        Figure size; a default is chosen from the panel count.
+    colors : list, optional
+        Per-solution colors; defaults to the tab10 cycle.
+
+    Returns
+    -------
+    tuple
+        (fig, axes).
+    """
+    if 'multistart' not in result:
+        raise ValueError('result has no multistart analysis; run '
+                         'unmixing_multistart first')
+    assert space in ('spectrum', 'curve'), \
+        "space must be 'spectrum' or 'curve'"
+    multistart = result['multistart']
+    solutions = multistart['solutions']
+    solution_results = multistart['results']
+    curve_type = result['curve_type']
+    x, y = result['x'], result['y']
+    x_grid = np.linspace(x.min(), x.max(), n_grid)
+
+    # order solutions by Akaike weight (descending)
+    order = np.argsort(solutions['akaike_weight'].to_numpy())[::-1]
+    n_show = min(max_solutions, len(order))
+    order = order[:n_show]
+    if colors is None:
+        cmap = plt.get_cmap('tab10')
+        colors = [cmap(i % 10) for i in range(len(solution_results))]
+
+    n_panels = n_show + 1  # decompositions + parameter map
+    n_cols = min(3, n_panels)
+    n_rows = int(np.ceil(n_panels / n_cols))
+    if figsize is None:
+        figsize = (4.2 * n_cols, 3.2 * n_rows)
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=figsize, squeeze=False)
+    axes_flat = axes.ravel()
+
+    if space == 'spectrum':
+        x_data, y_data = coercivity_spectrum_from_curve(x, y, curve_type)
+    else:
+        x_data, y_data = x, y
+
+    for panel, sol_idx in enumerate(order):
+        ax = axes_flat[panel]
+        fit = solution_results[sol_idx]
+        params = fit['params'][UNMIX_PARAM_COLUMNS].to_numpy()
+        weight = solutions['akaike_weight'].iloc[sol_idx]
+        n_hits = int(solutions['n_hits'].iloc[sol_idx])
+        ax.scatter(x_data, y_data, s=8, c='lightgrey', zorder=1)
+        if space == 'spectrum':
+            total = coercivity_spectrum_model(x_grid, params)
+            comps = coercivity_spectrum_components(x_grid, params)
+        else:
+            total = coercivity_curve_model(x_grid, params,
+                                           offset=fit.get('offset', 0.0),
+                                           curve_type=curve_type)
+            comps = coercivity_curve_components(x_grid, params,
+                                                curve_type=curve_type)
+        for i in range(len(params)):
+            ax.plot(x_grid, comps[i], color=colors[sol_idx], lw=1.2,
+                    alpha=0.9)
+        ax.plot(x_grid, total, color='k', lw=1.2)
+        ax.set_title(f'solution {sol_idx + 1}: weight {weight:.2f}, '
+                     f'{n_hits} starts', fontsize=9,
+                     color=colors[sol_idx])
+        _format_mT_axis(ax)
+        ax.set_xlabel('field (mT)', fontsize=8)
+        ax.tick_params(labelsize=7)
+
+    # parameter-space map panel
+    ax_map = axes_flat[n_show]
+    for sol_idx in order:
+        row = solutions.iloc[sol_idx]
+        weight = row['akaike_weight']
+        component_cols = [c for c in solutions.columns
+                          if c.startswith('B_mean_mT_c')]
+        for col in component_cols:
+            suffix = col.split('_c')[-1]
+            proportion = row.get(f'proportion_c{suffix}', np.nan)
+            ax_map.scatter(row[col], proportion, s=30 + 300 * weight,
+                           color=colors[sol_idx], alpha=0.7,
+                           edgecolors='k', linewidths=0.5)
+    # x-data are already in mT (not log10 units), so a plain log scale is used
+    ax_map.set_xscale('log')
+    ax_map.set_xlabel('component mean coercivity (mT)', fontsize=8)
+    ax_map.set_ylabel('proportion', fontsize=8)
+    ax_map.set_title('solution map (size = Akaike weight)', fontsize=9)
+    ax_map.tick_params(labelsize=7)
+
+    for ax in axes_flat[n_panels:]:
+        ax.axis('off')
+    fig.tight_layout()
+    return fig, axes_flat[:n_panels]
+
+
+def interactive_coercivity_unmixing(x, magnetization, n_components=2,
+                                    method='spectrum',
+                                    curve_type='backfield', vary_skew=True,
+                                    figsize=(9, 5)):
+    """
+    Interactive widget for choosing initial unmixing parameters visually.
+
+    Initial parameter choices strongly influence nonlinear unmixing fits.
+    This widget shows the coercivity spectrum with a live model built from
+    per-component sliders (peak field in mT on a log scale, proportion of
+    the total remanence, dispersion DP, and skew). Sliders are seeded from
+    automatic peak detection. Pressing "Fit" runs the chosen optimizer
+    (spectrum- or measurement-space) starting from the current slider
+    values and overlays the optimized model.
+
+    *Important*: run `%matplotlib widget` in the notebook first so the
+    figure updates live.
+
+    Parameters
+    ----------
+    x : array-like
+        log10 of field values (mT), e.g. 'log_dc_field' from
+        backfield_data_processing.
+    magnetization : array-like
+        Remanence curve values at x (e.g. 'magn_mass_shift').
+    n_components : int
+        Number of components (default 2).
+    method : str
+        'spectrum' or 'curve' -- the fitting approach used by the Fit
+        button.
+    curve_type : str
+        'backfield' or 'acquisition'.
+    vary_skew : bool
+        Include skew sliders and let the fit vary skew (default True).
+    figsize : tuple
+        Figure size.
+
+    Returns
+    -------
+    dict
+        A live handle with keys 'initial_parameters' (DataFrame updated as
+        sliders move; pass to the unmixing functions) and 'result' (filled
+        with the standardized result dictionary after Fit is pressed).
+    """
+    _check_ipywidgets()
+    assert method in ('spectrum', 'curve'), \
+        "method must be 'spectrum' or 'curve'"
+    x = np.asarray(x, dtype=float)
+    M = np.asarray(magnetization, dtype=float)
+    x_mid, spectrum = coercivity_spectrum_from_curve(x, M, curve_type)
+    total_area = _trapz(spectrum, x_mid)
+    x_grid = np.linspace(x.min(), x.max(), 300)
+
+    auto = estimate_coercivity_components(x_mid, spectrum, n_components)
+    handle = {'initial_parameters': None, 'result': None}
+
+    fig, ax = plt.subplots(figsize=figsize)
+    fig.canvas.header_visible = False
+
+    sliders = []
+    for i in range(n_components):
+        peak_mT = 10 ** auto['location'][i]
+        proportion_0 = min(auto['contribution'][i] / total_area, 1.0)
+        column = [
+            widgets.FloatLogSlider(value=peak_mT, base=10,
+                                   min=x.min(), max=x.max(), step=0.01,
+                                   description=f'B{i + 1} (mT)',
+                                   continuous_update=False),
+            widgets.FloatSlider(value=round(proportion_0, 2), min=0.0,
+                                max=1.0, step=0.01,
+                                description=f'proportion{i + 1}',
+                                continuous_update=False),
+            widgets.FloatSlider(value=round(auto['dp'][i], 2), min=0.02,
+                                max=1.2, step=0.01,
+                                description=f'DP{i + 1}',
+                                continuous_update=False),
+        ]
+        if vary_skew:
+            column.append(widgets.FloatSlider(value=0.0, min=-8.0, max=8.0,
+                                              step=0.1,
+                                              description=f'skew{i + 1}',
+                                              continuous_update=False))
+        sliders.append(column)
+
+    fit_button = widgets.Button(description='Fit from these values',
+                                button_style='primary')
+    output = Output()
+
+    def slider_parameters():
+        rows = []
+        for column in sliders:
+            rows.append({
+                'contribution': column[1].value * total_area,
+                'location': np.log10(column[0].value),
+                'dp': column[2].value,
+                'skew': column[3].value if vary_skew else 0.0,
+            })
+        return pd.DataFrame(rows)
+
+    def redraw(*_args):
+        parameters = slider_parameters()
+        handle['initial_parameters'] = parameters
+        ax.clear()
+        ax.scatter(x_mid, spectrum, c='grey', s=10, alpha=0.6,
+                   label='coercivity spectrum')
+        arr = parameters[UNMIX_PARAM_COLUMNS].to_numpy()
+        comps = coercivity_spectrum_components(x_grid, arr)
+        for i in range(n_components):
+            ax.plot(x_grid, comps[i], c=f'C{i}', ls='--', alpha=0.8,
+                    label=f'component {i + 1}')
+        ax.plot(x_grid, comps.sum(axis=0), c='k', ls='--', alpha=0.8,
+                label='total (manual)')
+        if handle['result'] is not None:
+            fitted = handle['result']['params'][UNMIX_PARAM_COLUMNS].to_numpy()
+            fitted_comps = coercivity_spectrum_components(x_grid, fitted)
+            for i in range(n_components):
+                ax.plot(x_grid, fitted_comps[i], c=f'C{i}')
+            ax.plot(x_grid, fitted_comps.sum(axis=0), c='k',
+                    label='total (fitted)')
+        ax.set_xlabel('field (mT)')
+        ax.set_ylabel('dM/dlog$_{10}$(B)')
+        _format_mT_axis(ax)
+        ax.legend(fontsize=8)
+        fig.canvas.draw_idle()
+
+    def run_fit(_button):
+        parameters = slider_parameters()
+        with output:
+            output.clear_output()
+            try:
+                if method == 'spectrum':
+                    handle['result'] = unmix_coercivity_spectrum(
+                        x_mid, spectrum, initial_parameters=parameters,
+                        vary_skew=vary_skew)
+                else:
+                    handle['result'] = unmix_backfield_curve(
+                        x, M, initial_parameters=parameters,
+                        curve_type=curve_type, vary_skew=vary_skew)
+            except (ValueError, RuntimeError) as error:
+                print(f'fit failed: {error}')
+                return
+            stats = handle['result']['stats']
+            print(f"fit success: {handle['result']['success']}, "
+                  f"R^2 = {stats['r_squared']:.5f}, "
+                  f"AIC = {stats['aic']:.1f}, BIC = {stats['bic']:.1f}")
+            display(handle['result']['params'].round(4))
+        redraw()
+
+    for column in sliders:
+        for slider in column:
+            slider.observe(redraw, names='value')
+    fit_button.on_click(run_fit)
+
+    display(HBox([VBox(column) for column in sliders]))
+    display(fit_button)
+    display(output)
+    redraw()
+    return handle
+
+
+def unmix_backfield_experiments(measurements, experiments=None,
+                                n_components=2, method='spectrum',
+                                initial_parameters=None, vary_skew=True,
+                                n_boot=0, resample='cases',
+                                proportion=1.0, noise_level=None,
+                                smooth_mode='spline', smooth_frac=0.0,
+                                drop_first=False, field='treat_dc_field',
+                                magnetization='magn_mass', random_seed=None,
+                                verbose=True, **method_kwargs):
+    """
+    Batch coercivity unmixing of backfield experiments in a MagIC
+    measurements table.
+
+    Each experiment is processed with backfield_data_processing and unmixed
+    with the requested method (any name registered in UNMIXING_METHODS,
+    dispatched through unmix_coercivity). When initial parameters are not
+    supplied they are estimated automatically per experiment; supplying a
+    common initial-parameter table (or a per-experiment dict, e.g. built
+    with interactive_coercivity_unmixing) enforces a consistent starting
+    model across specimens, which aids comparability of the resulting
+    components.
+
+    Parameters
+    ----------
+    measurements : pandas.DataFrame
+        MagIC measurements table (must include 'experiment', 'specimen',
+        'method_codes', and the field/magnetization columns).
+    experiments : list, optional
+        Experiment names to process. Defaults to all experiments whose
+        method_codes include 'LP-BCR-BF'.
+    n_components : int
+        Number of components fit to each experiment (default 2).
+    method : str
+        Registered unmixing method name: 'spectrum', 'curve', 'maxunmix',
+        or a custom method added with register_unmixing_method.
+    initial_parameters : pandas.DataFrame or dict, optional
+        Either a single initial-parameter table applied to every
+        experiment, or a dict mapping experiment name -> table. Experiments
+        missing from the dict fall back to automatic estimation.
+    vary_skew : bool
+        Whether skew parameters vary during fitting.
+    n_boot : int
+        If > 0, ensure each result carries a bootstrap with this many
+        replicates (methods that bootstrap internally, like 'maxunmix',
+        are not re-bootstrapped).
+    resample, proportion, noise_level : see unmixing_bootstrap.
+    smooth_mode, smooth_frac, drop_first : see backfield_data_processing.
+        The defaults (spline with smooth_frac=0) leave the data unsmoothed.
+    field, magnetization : str
+        Column names in the measurements table.
+    random_seed : None, int, or numpy.random.Generator
+        Seed for reproducible bootstraps.
+    verbose : bool
+        Print progress and failures.
+    **method_kwargs
+        Additional keyword arguments passed to the unmixing method.
+
+    Returns
+    -------
+    tuple
+        (components_df, results) where components_df is a tidy DataFrame
+        with one row per experiment and component (parameters, derived
+        coercivities, uncertainties, fit statistics, and Bcr) and results
+        is a dict mapping experiment name -> full result dictionary.
+    """
+    if method not in UNMIXING_METHODS:
+        raise ValueError(f"unknown unmixing method '{method}'; available: "
+                         f'{sorted(UNMIXING_METHODS)}')
+    if experiments is None:
+        is_backfield = measurements['method_codes'].astype(str).str.contains(
+            'LP-BCR-BF', na=False)
+        experiments = list(pd.unique(
+            measurements.loc[is_backfield, 'experiment']))
+    if len(experiments) == 0:
+        raise ValueError('no backfield experiments found')
+    rng = _resolve_rng(random_seed)
+
+    results = {}
+    rows = []
+    failures = []
+    for experiment_name in experiments:
+        experiment = measurements[
+            measurements['experiment'] == experiment_name].copy()
+        if len(experiment) == 0:
+            failures.append((experiment_name, 'experiment not found'))
+            continue
+        specimen = (experiment['specimen'].iloc[0]
+                    if 'specimen' in experiment.columns else '')
+        try:
+            processed, Bcr = backfield_data_processing(
+                experiment, field=field, magnetization=magnetization,
+                smooth_mode=smooth_mode, smooth_frac=smooth_frac,
+                drop_first=drop_first)
+            x = processed['log_dc_field'].to_numpy()
+            M = processed['magn_mass_shift'].to_numpy()
+            if smooth_frac > 0:
+                x_s = processed['smoothed_log_dc_field'].to_numpy()
+                M_s = processed['smoothed_magn_mass_shift'].to_numpy()
+            else:
+                x_s, M_s = x, M
+
+            if isinstance(initial_parameters, dict):
+                initial = initial_parameters.get(experiment_name)
+            else:
+                initial = initial_parameters
+            if initial is not None:
+                initial = initial.copy()
+
+            # methods operating on the derivative use the (optionally
+            # smoothed) curve; the measurement-space method always fits
+            # the unsmoothed data
+            x_fit, M_fit = (x, M) if method == 'curve' else (x_s, M_s)
+            if method == 'maxunmix':
+                method_kwargs.setdefault('n_boot', n_boot if n_boot > 0
+                                         else 100)
+                method_kwargs.setdefault('random_seed', rng)
+            result = unmix_coercivity(
+                x_fit, M_fit, method=method, n_components=n_components,
+                initial_parameters=initial, vary_skew=vary_skew,
+                **method_kwargs)
+            if n_boot > 0 and 'bootstrap' not in result and 'bayes' not in result:
+                result = unmixing_bootstrap(
+                    result, n_boot=n_boot, resample=resample,
+                    proportion=proportion, noise_level=noise_level,
+                    random_seed=rng)
+        except (ValueError, RuntimeError, KeyError) as error:
+            failures.append((experiment_name, str(error)))
+            if verbose:
+                print(f'  {experiment_name}: FAILED ({error})')
+            continue
+
+        results[experiment_name] = result
+        stats = result['stats']
+        for comp_index, prow in result['params'].iterrows():
+            row = {
+                'experiment': experiment_name,
+                'specimen': specimen,
+                'method': method,
+                'n_components': n_components,
+                'component': comp_index,
+                'success': result['success'],
+                'Bcr_mT': Bcr * 1e3 if np.isfinite(Bcr) else np.nan,
+                'rss': stats['rss'],
+                'r_squared': stats['r_squared'],
+                'aic': stats['aic'],
+                'bic': stats['bic'],
+            }
+            row.update(prow.to_dict())
+            uncertainty = result.get('bootstrap') or result.get('bayes')
+            if uncertainty is not None:
+                summary_row = uncertainty['param_summary'].loc[comp_index]
+                for name in ['proportion', 'B_mean_mT', 'sd_log']:
+                    row[f'{name}_std'] = summary_row[f'{name}_std']
+                    row[f'{name}_p2_5'] = summary_row[f'{name}_p2_5']
+                    row[f'{name}_p97_5'] = summary_row[f'{name}_p97_5']
+            rows.append(row)
+        if verbose:
+            summary = ', '.join(
+                f"{prow['B_mean_mT']:.0f} mT ({prow['proportion'] * 100:.0f}%)"
+                for _i, prow in result['params'].iterrows())
+            print(f'  {experiment_name} ({specimen}): {summary}, '
+                  f"R^2 = {stats['r_squared']:.4f}")
+
+    components_df = pd.DataFrame(rows)
+    if verbose and failures:
+        print(f'{len(failures)} experiment(s) failed: '
+              f'{[name for name, _reason in failures]}')
+    return components_df, results
+
+
+def parse_specimen_description(description):
+    """
+    Parse a MagIC specimens 'description' cell into (text, dict).
+
+    The description convention used here stores free text and a
+    machine-readable JSON dictionary separated by ' | '. Legacy cells that
+    contain a Python dict repr (from older rockmagpy versions) are parsed
+    with ast.literal_eval.
+
+    Parameters
+    ----------
+    description : str or NaN
+        Contents of the description cell.
+
+    Returns
+    -------
+    tuple
+        (text, data) where text is the free-text portion (str, possibly
+        empty) and data is the parsed dictionary (possibly empty).
+    """
+    if description is None or (isinstance(description, float)
+                               and np.isnan(description)):
+        return '', {}
+    description = str(description).strip()
+    if not description:
+        return '', {}
+    text, data = description, {}
+    if ' | ' in description:
+        candidate_text, candidate_json = description.split(' | ', 1)
+        try:
+            data = json.loads(candidate_json)
+            return candidate_text, data
+        except (json.JSONDecodeError, ValueError):
+            pass
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(description)
+            if isinstance(parsed, dict):
+                return '', parsed
+        except (ValueError, SyntaxError):
+            continue
+    return text, data
+
+
+def _unmixing_component_record(row):
+    """Build the JSON-serializable record for one unmixing component row."""
+    record = {
+        'component': int(row['component']),
+        'B_mean_mT': round(float(row['B_mean_mT']), 2),
+        'B_median_mT': round(float(row['B_median_mT']), 2),
+        'DP': round(float(row['sd_log']), 4),
+        'skew': round(float(row['skew']), 4),
+        'proportion': round(float(row['proportion']), 4),
+        'contribution': float(row['contribution']),
+    }
+    if 'B_mean_mT_p2_5' in row.index and pd.notna(row['B_mean_mT_p2_5']):
+        record['B_mean_mT_95CI'] = [round(float(row['B_mean_mT_p2_5']), 2),
+                                    round(float(row['B_mean_mT_p97_5']), 2)]
+        record['proportion_95CI'] = [round(float(row['proportion_p2_5']), 4),
+                                     round(float(row['proportion_p97_5']), 4)]
+    return record
+
+
+def _match_specimen_rows(specimens_df, experiment_name, specimen_name):
+    """Boolean mask of specimens rows matching an experiment (or specimen)."""
+    if 'experiments' in specimens_df.columns:
+        mask = specimens_df['experiments'].astype(str).str.contains(
+            str(experiment_name), na=False, regex=False)
+    else:
+        mask = pd.Series(False, index=specimens_df.index)
+    if not mask.any() and 'specimen' in specimens_df.columns:
+        mask = specimens_df['specimen'] == specimen_name
+    return mask
+
+
+def unmixing_to_specimens_table(specimens_df, components_df, mode='rows'):
+    """
+    Record coercivity unmixing results in a MagIC specimens table.
+
+    Two recording conventions are supported:
+
+    - mode='rows' (default, conformant with the MagIC data model): one new
+      specimens row is appended per experiment and component, populating
+      the controlled-vocabulary columns rem_cmf (component median field,
+      in tesla), rem_cd (component dispersion, log10 units), and
+      rem_n_comp (number of components in the model), along with specimen
+      identity columns copied from the matching existing row. The full
+      parameter set (proportion, skew, confidence intervals, ...) is
+      stored as JSON in each new row's 'description' cell. Rows from a
+      previous call for the same experiments are replaced.
+    - mode='description': the matching existing specimens rows are updated
+      in place, storing the complete unmixing model as JSON under the
+      'coercivity_unmixing' key in 'description' (any existing free text
+      is preserved with a 'text | json' convention readable by
+      parse_specimen_description).
+
+    Parameters
+    ----------
+    specimens_df : pandas.DataFrame
+        MagIC specimens table.
+    components_df : pandas.DataFrame
+        Tidy components table from unmix_backfield_experiments.
+    mode : str
+        'rows' or 'description'.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The updated specimens table. With mode='description' the input
+        table is also modified in place; with mode='rows' a new table is
+        returned (pandas cannot append rows in place).
+    """
+    assert mode in ('rows', 'description'), \
+        "mode must be 'rows' or 'description'"
+    if 'description' not in specimens_df.columns:
+        specimens_df['description'] = np.nan
+    specimens_df['description'] = specimens_df['description'].astype(object)
+
+    if mode == 'description':
+        for experiment_name, group in components_df.groupby('experiment'):
+            first = group.iloc[0]
+            unmix_record = {
+                'method': f"rockmagpy_{first['method']}",
+                'software_version': pmagpy_version,
+                'n_components': int(first['n_components']),
+                'r_squared': round(float(first['r_squared']), 5),
+                'components': [_unmixing_component_record(row)
+                               for _i, row in group.iterrows()],
+            }
+            mask = _match_specimen_rows(specimens_df, experiment_name,
+                                        first['specimen'])
+            for idx in specimens_df.index[mask]:
+                text, data = parse_specimen_description(
+                    specimens_df.at[idx, 'description'])
+                data['coercivity_unmixing'] = unmix_record
+                payload = json.dumps(data)
+                specimens_df.at[idx, 'description'] = (
+                    f'{text} | {payload}' if text else payload)
+        return specimens_df
+
+    # mode == 'rows': one MagIC specimens row per component
+    identity_columns = ['specimen', 'sample', 'experiments', 'citations',
+                        'result_quality', 'weight', 'volume']
+    new_rows = []
+    processed_experiments = []
+    for experiment_name, group in components_df.groupby('experiment'):
+        first = group.iloc[0]
+        mask = _match_specimen_rows(specimens_df, experiment_name,
+                                    first['specimen'])
+        template = (specimens_df.loc[mask].iloc[0]
+                    if mask.any() else pd.Series(dtype=object))
+        processed_experiments.append(str(experiment_name))
+        for _i, row in group.iterrows():
+            new_row = {col: template[col] for col in identity_columns
+                       if col in template.index and pd.notna(template[col])}
+            new_row.setdefault('specimen', first['specimen'])
+            new_row.setdefault('experiments', str(experiment_name))
+            new_row['method_codes'] = 'LP-BCR-BF'
+            new_row['software_packages'] = pmagpy_version
+            new_row['rem_cmf'] = float(row['B_median_mT']) * 1e-3  # tesla
+            new_row['rem_cd'] = float(row['sd_log'])
+            new_row['rem_n_comp'] = int(row['n_components'])
+            if pd.notna(row.get('Bcr_mT')):
+                new_row['rem_bcr'] = float(row['Bcr_mT']) * 1e-3  # tesla
+            record = {'coercivity_unmixing': {
+                'method': f"rockmagpy_{row['method']}",
+                'software_version': pmagpy_version,
+                'experiment': str(experiment_name),
+                'n_components': int(row['n_components']),
+                'r_squared': round(float(row['r_squared']), 5),
+                'component': _unmixing_component_record(row),
+            }}
+            new_row['description'] = json.dumps(record)
+            new_rows.append(new_row)
+
+    # drop rows added by a previous call for these experiments
+    is_previous = (specimens_df['description'].astype(str).str.contains(
+        '"coercivity_unmixing"', na=False, regex=False)
+        & specimens_df.get('rem_cmf', pd.Series(np.nan,
+                                                index=specimens_df.index))
+        .notna())
+    if 'experiments' in specimens_df.columns:
+        in_processed = specimens_df['experiments'].astype(str).isin(
+            processed_experiments)
+        is_previous = is_previous & in_processed
+    kept = specimens_df.loc[~is_previous]
+    return pd.concat([kept, pd.DataFrame(new_rows)], ignore_index=True)
 
 
 # Day plot functions

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -5727,8 +5727,16 @@ def add_unmixing_stats_to_specimens_table(specimens_df, experiment_name, unmix_r
         raise ValueError(f"method should be either 'lmfit' or 'MaxUnmix', but got {method}")
     unmix_result_dict = dict_in_native_python(unmix_result_dict)
     # merge into the description cell, preserving free text and any
-    # existing structured content (parsed safely rather than with eval)
-    mask = specimens_df['experiments'] == experiment_name
+    # existing structured content (parsed safely rather than with eval).
+    # Match with the shared contains-logic so a colon-delimited 'experiments'
+    # cell (several experiments per row) is found, and fail loudly rather than
+    # silently recording nothing when the experiment is absent.
+    mask = _match_specimen_rows(specimens_df, experiment_name, None)
+    if not mask.any():
+        raise ValueError(
+            f"no specimens row matches experiment '{experiment_name}'; its "
+            "unmixing stats were not recorded. Check the name against the "
+            "specimens table's 'experiments' column.")
     for idx in specimens_df.index[mask]:
         text, description_dict = parse_specimen_description(
             specimens_df.at[idx, 'description'])
@@ -5756,8 +5764,16 @@ def add_Bcr_to_specimens_table(specimens_df, experiment_name, Bcr):
     if 'rem_bcr' not in specimens_df.columns:
         # add the rem_bcr column to the specimens table
         specimens_df['rem_bcr'] = np.nan
+    # match with the shared contains-logic so a colon-delimited 'experiments'
+    # cell is found, and fail loudly rather than silently writing nothing
+    mask = _match_specimen_rows(specimens_df, experiment_name, None)
+    if not mask.any():
+        raise ValueError(
+            f"no specimens row matches experiment '{experiment_name}'; the "
+            "Bcr value was not recorded. Check the name against the "
+            "specimens table's 'experiments' column.")
     # add the Bcr value to the specimens table
-    specimens_df.loc[specimens_df['experiments'] == experiment_name, 'rem_bcr'] = Bcr
+    specimens_df.loc[mask, 'rem_bcr'] = Bcr
 
     return
 

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -6880,7 +6880,12 @@ def select_n_components(x, magnetization, method='curve', min_components=1,
       pushes the reduced chi-square of a real-count model just above one), and
       it is sensitive to the residual scatter of the noise estimate. Prefer
       'parsimony', or supply a trusted `noise_level` and a `reduced_chi2_target`
-      slightly above 1, when using it.
+      slightly above 1, when using it. For spectrum-space methods ('spectrum',
+      'maxunmix', or a Bayesian fit with space='spectrum') the residuals and
+      hence the noise are in dM/dlog10(B) units, so the noise is estimated on
+      the finite-difference spectrum rather than the measured curve; that
+      spectrum noise is mildly correlated, which the estimator does not model,
+      making the spectrum-space chi2 more approximate still.
 
     In all cases the returned table reports the fit statistics, the
     fractional RSS improvement per added component, and (when a noise level
@@ -6934,8 +6939,28 @@ def select_n_components(x, magnetization, method='curve', min_components=1,
     if len(counts) == 0:
         raise ValueError('max_components must be >= min_components')
 
+    # The chi2 adequacy test compares the fit residual sum of squares to the
+    # noise level, so the noise must be estimated in the SAME data space the
+    # residuals live in. Spectrum-space methods ('spectrum', 'maxunmix', and
+    # Bayesian fits with space='spectrum') fit dM/dlog10(B), not the measured
+    # curve, so their rss is in spectrum units; estimating the noise on the
+    # measured curve instead would mix units and inflate reduced_chi2 by the
+    # (large) finite-difference amplification factor, defeating the criterion.
+    # The spacing-aware estimator applied to the finite-difference spectrum
+    # returns the spectrum-space noise scale directly, accounting for the
+    # non-uniform log-grid spacing. (The finite-difference spectrum noise is
+    # mildly correlated, which this white-noise estimator does not model, so
+    # the spectrum-space chi2 is approximate -- consistent with chi2 being the
+    # less robust criterion; see the note below.)
+    fits_spectrum = (method in ('spectrum', 'maxunmix')
+                     or (method == 'bayes' and kwargs.get('space') == 'spectrum'))
     if noise_level is None:
-        noise_level = estimate_measurement_noise(x, magnetization, curve_type)
+        if fits_spectrum:
+            noise_x, noise_y = coercivity_spectrum_from_curve(
+                x, magnetization, curve_type)
+        else:
+            noise_x, noise_y = x, magnetization
+        noise_level = estimate_measurement_noise(noise_x, noise_y, curve_type)
 
     results = {}
     rows = []
@@ -9341,6 +9366,13 @@ def _unmixing_component_record(row):
     return record
 
 
+# Marker written into (and matched from) the JSON 'description' of specimens
+# rows that unmixing_to_specimens_table(mode='rows') creates, so a re-run
+# removes exactly its own previous component rows -- and never an original
+# specimen row that merely carries a mode='description' payload or a rem_cmf.
+_UNMIXING_ROW_MARKER = 'coercivity_unmixing_component_row'
+
+
 def _match_specimen_rows(specimens_df, experiment_name, specimen_name):
     """Boolean mask of specimens rows matching an experiment (or specimen)."""
     if 'experiments' in specimens_df.columns:
@@ -9418,8 +9450,14 @@ def unmixing_to_specimens_table(specimens_df, components_df, mode='rows'):
                     f'{text} | {payload}' if text else payload)
         return specimens_df
 
-    # mode == 'rows': one MagIC specimens row per component
-    identity_columns = ['specimen', 'sample', 'experiments', 'citations',
+    # mode == 'rows': one MagIC specimens row per component.
+    # 'experiments' is deliberately NOT copied from the template: the template
+    # row may list several experiments (colon-delimited), but a component
+    # result derives from just this backfield experiment, so each new row's
+    # 'experiments' is set to the single experiment_name below. Copying the
+    # full colon-delimited string instead would also break the exact-match
+    # cleanup, causing rows to accumulate on re-runs.
+    identity_columns = ['specimen', 'sample', 'citations',
                         'result_quality', 'weight', 'volume']
     new_rows = []
     processed_experiments = []
@@ -9446,6 +9484,7 @@ def unmixing_to_specimens_table(specimens_df, components_df, mode='rows'):
                 'method': f"rockmagpy_{row['method']}",
                 'software_version': pmagpy_version,
                 'experiment': str(experiment_name),
+                'record_type': _UNMIXING_ROW_MARKER,
                 'n_components': int(row['n_components']),
                 'r_squared': round(float(row['r_squared']), 5),
                 'component': _unmixing_component_record(row),
@@ -9453,15 +9492,21 @@ def unmixing_to_specimens_table(specimens_df, components_df, mode='rows'):
             new_row['description'] = json.dumps(record)
             new_rows.append(new_row)
 
-    # drop rows added by a previous call for these experiments
-    is_previous = (specimens_df['description'].astype(str).str.contains(
-        '"coercivity_unmixing"', na=False, regex=False)
-        & specimens_df.get('rem_cmf', pd.Series(np.nan,
-                                                index=specimens_df.index))
-        .notna())
+    # Drop only the component rows a PREVIOUS mode='rows' call created for these
+    # experiments. Rows are identified by the explicit marker this function
+    # writes, never by a generic 'coercivity_unmixing' string or a populated
+    # rem_cmf -- so an original specimen row carrying a mode='description'
+    # payload (or an independently populated rem_cmf) is never removed.
+    is_previous = specimens_df['description'].astype(str).str.contains(
+        _UNMIXING_ROW_MARKER, na=False, regex=False)
     if 'experiments' in specimens_df.columns:
-        in_processed = specimens_df['experiments'].astype(str).isin(
-            processed_experiments)
+        processed_set = set(processed_experiments)
+        # split on ':' so a row is matched whether its 'experiments' cell holds
+        # the single experiment_name (as newly written) or a colon-delimited
+        # list (e.g. a legacy row from before this fix), without the substring
+        # false positives a plain str.contains would introduce
+        in_processed = specimens_df['experiments'].apply(
+            lambda cell: bool(set(str(cell).split(':')) & processed_set))
         is_previous = is_previous & in_processed
     kept = specimens_df.loc[~is_previous]
     return pd.concat([kept, pd.DataFrame(new_rows)], ignore_index=True)

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -8139,8 +8139,19 @@ def mineral_priors(mineral_names, tighten=1.0, widen=1.0, field_max_mT=None,
         b_low, b_high = _rescale(*entry['B_median_mT'])
         b_low = max(b_low, 1e-3)  # keep positive for log10
         if field_max_mT is not None:
+            # clip the upper bound to the measured field, but refuse to clip a
+            # window whose lower bound is already at or above it: that would
+            # collapse the window to zero width and silently pin the component
+            # at exactly log10(field_max_mT). Such a component sits entirely
+            # beyond the measured field and cannot be constrained here.
+            if b_low >= field_max_mT:
+                raise ValueError(
+                    f"component '{name}': its coercivity window starts at "
+                    f"{b_low:g} mT, at or above the maximum applied field "
+                    f"({field_max_mT:g} mT), so this experiment cannot "
+                    f"constrain {name}. Remove it from the mineral list, "
+                    f"widen the field range, or supply an override window.")
             b_high = min(b_high, field_max_mT)
-            b_low = min(b_low, b_high)
         entries.append((name, np.sqrt(b_low * b_high),
                         (np.log10(b_low), np.log10(b_high)),
                         _rescale(*entry['dp']), _rescale(*entry['skew'])))

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -8598,6 +8598,12 @@ def plot_unmixing_posterior(result, quantity='B_mean_mT', bins=40,
         raise KeyError(f"'{quantity}' is not in the draws; available: "
                        f'{sorted(samples)}')
     values = np.asarray(samples[quantity])
+    # per-component quantities are 2-D (n_draws, n_components); global
+    # quantities such as 'offset' and 'noise' are 1-D (n_draws,) -- show those
+    # as a single histogram rather than splitting by component
+    per_component = values.ndim > 1
+    if not per_component:
+        values = values[:, None]
     K = values.shape[1]
     log_x = quantity in ('B_mean_mT', 'B_median_mT', 'B_peak_mT')
     if figsize is None:
@@ -8623,7 +8629,7 @@ def plot_unmixing_posterior(result, quantity='B_mean_mT', bins=40,
         axes[i].axvline(low, color='k', ls='--', lw=0.9)
         axes[i].axvline(high, color='k', ls='--', lw=0.9,
                         label=f'95%: [{low:.3g}, {high:.3g}]')
-        axes[i].set_ylabel(f'component {i + 1}')
+        axes[i].set_ylabel(f'component {i + 1}' if per_component else 'density')
         axes[i].legend(fontsize=8)
     axes[-1].set_xlabel(f'{quantity} ({source} draws)')
     fig.tight_layout()
@@ -8668,13 +8674,24 @@ def plot_unmixing_tradeoff(result, x='B_mean_mT', y='proportion',
                            f'{sorted(samples)}')
     xv = np.asarray(samples[x])
     yv = np.asarray(samples[y])
-    K = xv.shape[1]
+    # global quantities ('offset', 'noise') are 1-D; treat them as a single
+    # column so they can be paired with per-component quantities (broadcast
+    # across components) or with each other (a single scatter)
+    if xv.ndim == 1:
+        xv = xv[:, None]
+    if yv.ndim == 1:
+        yv = yv[:, None]
+    Kx, Ky = xv.shape[1], yv.shape[1]
+    K = max(Kx, Ky)
     components = range(K) if component is None else [component - 1]
     if colors is None:
         colors = [f'C{i}' for i in range(K)]
     fig, ax = plt.subplots(figsize=figsize)
     for i in components:
-        ax.scatter(xv[:, i], yv[:, i], s=6, alpha=0.25, color=colors[i],
+        # a global (single-column) quantity is reused for every component
+        xi = xv[:, min(i, Kx - 1)]
+        yi = yv[:, min(i, Ky - 1)]
+        ax.scatter(xi, yi, s=6, alpha=0.25, color=colors[i],
                    edgecolors='none', label=f'component {i + 1}')
     if x in ('B_mean_mT', 'B_median_mT', 'B_peak_mT'):
         ax.set_xscale('log')

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -7063,8 +7063,20 @@ def unmixing_bootstrap(result, n_boot=500, resample='cases', proportion=1.0,
     assert 0 < proportion <= 1, 'proportion must be in (0, 1]'
     rng = _resolve_rng(random_seed)
 
-    x, y = result['x'], result['y']
     method = result['method']
+    if method == 'bayes':
+        raise ValueError(
+            "unmixing_bootstrap does not apply to Bayesian results, which "
+            "already carry full posterior uncertainty in "
+            "result['bayes']['param_summary'] (credible intervals). To "
+            "bootstrap a least-squares fit, pass a 'curve', 'spectrum', or "
+            "'maxunmix' result instead.")
+    # dispatch the refit on the stored fitting space, not the method name:
+    # 'spectrum' and 'maxunmix' both fit the derivative spectrum, so both
+    # must be refit with the spectrum model (keying on method == 'spectrum'
+    # alone sent maxunmix results through the cumulative-curve branch)
+    fits_spectrum = _result_is_spectrum(result)
+    x, y = result['x'], result['y']
     curve_type = result['curve_type']
     vary_skew = result['vary_skew']
     K = result['n_components']
@@ -7091,7 +7103,7 @@ def unmixing_bootstrap(result, n_boot=500, resample='cases', proportion=1.0,
         if noise_level is not None:
             yb = yb * (1.0 + rng.normal(0.0, noise_level, size=len(yb)))
         try:
-            if method == 'spectrum':
+            if fits_spectrum:
                 fit = unmix_coercivity_spectrum(xb, yb,
                                                 initial_parameters=best,
                                                 vary_skew=vary_skew)
@@ -7109,7 +7121,7 @@ def unmixing_bootstrap(result, n_boot=500, resample='cases', proportion=1.0,
         for name in tracked:
             samples[name].append(p[name].to_numpy())
         arr = p[UNMIX_PARAM_COLUMNS].to_numpy()
-        if method == 'spectrum':
+        if fits_spectrum:
             total_curves.append(coercivity_spectrum_model(x_grid, arr))
             comp_curves.append(coercivity_spectrum_components(x_grid, arr))
         else:

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -5682,6 +5682,21 @@ def backfield_MaxUnmix(field, magnetization, n_comps=1, parameters=None, skewed=
             where the given data points are bootstrap resampled with replacement
             and the unmixing is done with the same original estimates for each iteration
 
+    .. deprecated::
+        Use ``unmix_coercivity(x, magnetization, method='maxunmix')`` (or
+        ``unmix_backfield_experiments``) instead, which reproduces the MAX
+        UnMix resampling workflow of Maxbauer et al. (2016) more faithfully
+        (95% subsampling without replacement plus restart-parameter
+        perturbation, rather than resampling with replacement) within the
+        standard unmixing result format. Note the parameter conventions
+        differ: this function's lmfit table uses peak-height
+        'amplitude'/'center'/'sigma'/'gamma' (Fernandez-Steel skew) in
+        linear units, the replacement uses integrated-area
+        'contribution'/'location'/'dp'/'skew' (Azzalini skew) in log10 mT.
+        Maintaining two MAX UnMix implementations invites divergence, so
+        this one will not receive further fixes and may be removed in a
+        future release.
+
     Parameters
     ----------
     field : array-like
@@ -5705,6 +5720,12 @@ def backfield_MaxUnmix(field, magnetization, n_comps=1, parameters=None, skewed=
     random_seed : None, int, or numpy.random.Generator, optional
         Seed for reproducible bootstrap resampling (default None).
     '''
+    warnings.warn(
+        "backfield_MaxUnmix is deprecated: use unmix_coercivity(x, "
+        "magnetization, method='maxunmix') or unmix_backfield_experiments "
+        "instead (see the backfield_MaxUnmix docstring for the parameter-"
+        "convention differences)",
+        FutureWarning, stacklevel=2)
     _check_lmfit()
     assert parameters is not None, f"parameters should not be None"
     assert len(parameters) == n_comps, f"Number of rows in parameters ({len(parameters)}) should be equal to n_comps ({n_comps})"
@@ -5924,6 +5945,16 @@ _SQRT2 = np.sqrt(2.0)
 _SQRT2PI = np.sqrt(2.0 * np.pi)
 UNMIX_PARAM_COLUMNS = ['contribution', 'location', 'dp', 'skew']
 
+# Shared defaults for the unmixing entry points, so the sibling functions
+# (fitting, model selection, multistart, batch processing) agree on the model
+# class by default and a select_n_components -> unmix_coercivity workflow
+# fits the same model throughout. unmix_coercivity_bayes deliberately
+# deviates with vary_skew=False (free skew greatly increases the nested-
+# sampling cost and is usually better constrained through mineral priors;
+# see its docstring).
+DEFAULT_UNMIX_METHOD = 'spectrum'
+DEFAULT_UNMIX_VARY_SKEW = True
+
 
 def _trapz(y, x):
     """Trapezoidal integration compatible with numpy 1.x and 2.x."""
@@ -6027,6 +6058,107 @@ def skewnormal_stats(location, dp, skew=0.0):
                                bounds=(location - 5 * dp, location + 5 * dp),
                                method='bounded')
     return {'mean': mean, 'std': std, 'median': median, 'mode': float(mode_res.x)}
+
+
+def _skewnormal_median_z(skew, n_iter=60):
+    """Standardized median z of the skew-normal, vectorized over skew.
+
+    Solves Phi(z) - 2*T(z, skew) = 1/2 by bisection so per-draw medians can
+    be computed for whole posterior/bootstrap sample arrays at once; the
+    median in data units is location + dp * z.
+    """
+    skew = np.asarray(skew, dtype=float)
+    if np.all(skew == 0):
+        return np.zeros_like(skew)
+    lo = np.full_like(skew, -12.0)
+    hi = np.full_like(skew, 12.0)
+    for _ in range(n_iter):
+        mid = 0.5 * (lo + hi)
+        cdf = 0.5 * (1.0 + erf(mid / _SQRT2)) - 2.0 * owens_t(mid, skew)
+        below = cdf < 0.5
+        lo = np.where(below, mid, lo)
+        hi = np.where(below, hi, mid)
+    return 0.5 * (lo + hi)
+
+
+def _skewnormal_mode_z(skew, n_iter=100):
+    """Standardized mode z of the skew-normal, vectorized over skew.
+
+    Ternary search on the (unimodal) standardized density
+    phi(z) * (1 + erf(skew*z/sqrt(2))); the mode in data units is
+    location + dp * z.
+    """
+    skew = np.asarray(skew, dtype=float)
+    if np.all(skew == 0):
+        return np.zeros_like(skew)
+
+    def density(z):
+        return np.exp(-0.5 * z * z) * (1.0 + erf(skew * z / _SQRT2))
+
+    lo = np.full_like(skew, -5.0)
+    hi = np.full_like(skew, 5.0)
+    for _ in range(n_iter):
+        m1 = lo + (hi - lo) / 3.0
+        m2 = hi - (hi - lo) / 3.0
+        right = density(m1) < density(m2)
+        lo = np.where(right, m1, lo)
+        hi = np.where(right, hi, m2)
+    return 0.5 * (lo + hi)
+
+
+def _summarize_component_samples(samples, n_components,
+                                 percentiles=(2.5, 50, 97.5)):
+    """Per-component summary table of replicate/posterior samples.
+
+    Shared by the MAX UnMix resampling, unmixing_bootstrap, and the Bayesian
+    sampler so the three uncertainty flavors report identical column sets.
+
+    Parameters
+    ----------
+    samples : dict
+        Maps quantity name -> array-like of shape (n_draws, n_components).
+    n_components : int
+        Number of components (columns of each sample array).
+    percentiles : sequence of float
+        Percentiles to tabulate alongside mean and std.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per component with '<name>_mean', '<name>_std', and
+        '<name>_p<percentile>' columns for every quantity.
+    """
+    summary_rows = []
+    for comp in range(n_components):
+        row = {'component': comp + 1}
+        for name, values in samples.items():
+            column = np.asarray(values)[:, comp]
+            row[f'{name}_mean'] = column.mean()
+            row[f'{name}_std'] = column.std()
+            for pct in percentiles:
+                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
+                    np.percentile(column, pct)
+        summary_rows.append(row)
+    return pd.DataFrame(summary_rows).set_index('component')
+
+
+def _percentile_curve_bands(x_grid, total_curves, component_curves,
+                            percentiles=(2.5, 50, 97.5)):
+    """Percentile bands of replicate/posterior model curves on x_grid.
+
+    Shared by the same three uncertainty paths as
+    _summarize_component_samples; plot_coercivity_unmixing consumes the
+    returned keys ('total_p2_5', 'components_p50', ...).
+    """
+    total_curves = np.asarray(total_curves)
+    component_curves = np.asarray(component_curves)
+    bands = {'x_grid': x_grid}
+    for pct in percentiles:
+        key = f'p{str(pct).replace(".", "_")}'
+        bands[f'total_{key}'] = np.percentile(total_curves, pct, axis=0)
+        bands[f'components_{key}'] = np.percentile(component_curves, pct,
+                                                   axis=0)
+    return bands
 
 
 def _unmix_parameters_to_array(parameters):
@@ -6471,7 +6603,8 @@ def _build_unmix_result(engine, method, curve_type, vary_skew, fit_offset,
 
 
 def unmix_coercivity_spectrum(x, spectrum, n_components=None,
-                              initial_parameters=None, vary_skew=True,
+                              initial_parameters=None,
+                              vary_skew=DEFAULT_UNMIX_VARY_SKEW,
                               weights=None, dp_bounds=(0.01, 2.0),
                               skew_bounds=(-10.0, 10.0)):
     """
@@ -6537,8 +6670,9 @@ def unmix_coercivity_spectrum(x, spectrum, n_components=None,
 
 def unmix_backfield_curve(x, magnetization, n_components=None,
                           initial_parameters=None, curve_type='backfield',
-                          vary_skew=True, fit_offset=True, weights=None,
-                          dp_bounds=(0.01, 2.0), skew_bounds=(-10.0, 10.0)):
+                          vary_skew=DEFAULT_UNMIX_VARY_SKEW, fit_offset=True,
+                          weights=None, dp_bounds=(0.01, 2.0),
+                          skew_bounds=(-10.0, 10.0)):
     """
     Unmix a remanence curve by fitting cumulative components directly.
 
@@ -6607,7 +6741,7 @@ def unmix_backfield_curve(x, magnetization, n_components=None,
 
 def _unmix_method_spectrum(x, magnetization, n_components=None,
                            initial_parameters=None, curve_type='backfield',
-                           vary_skew=True, **kwargs):
+                           vary_skew=DEFAULT_UNMIX_VARY_SKEW, **kwargs):
     """Registered 'spectrum' method: finite-difference spectrum fit."""
     x_mid, spectrum = coercivity_spectrum_from_curve(x, magnetization,
                                                      curve_type)
@@ -6619,7 +6753,7 @@ def _unmix_method_spectrum(x, magnetization, n_components=None,
 
 def _unmix_method_curve(x, magnetization, n_components=None,
                         initial_parameters=None, curve_type='backfield',
-                        vary_skew=True, **kwargs):
+                        vary_skew=DEFAULT_UNMIX_VARY_SKEW, **kwargs):
     """Registered 'curve' method: direct measurement-space fit."""
     return unmix_backfield_curve(x, magnetization, n_components=n_components,
                                  initial_parameters=initial_parameters,
@@ -6629,7 +6763,8 @@ def _unmix_method_curve(x, magnetization, n_components=None,
 
 def _unmix_method_maxunmix(x, magnetization, n_components=None,
                            initial_parameters=None, curve_type='backfield',
-                           vary_skew=True, n_boot=100, proportion=0.95,
+                           vary_skew=DEFAULT_UNMIX_VARY_SKEW,
+                           n_boot=100, proportion=0.95,
                            param_noise=0.02, random_seed=None, n_grid=200,
                            **kwargs):
     """
@@ -6658,6 +6793,10 @@ def _unmix_method_maxunmix(x, magnetization, n_components=None,
     of the fitted data, optionally with added measurement noise, and usable
     with the measurement-space and Bayesian fits as well -- fit with
     method='spectrum' or 'curve' and call unmixing_bootstrap directly.
+
+    n_boot=0 skips the resampling entirely and returns the point fit with no
+    'bootstrap' entry; unmixing_multistart and select_n_components use this
+    for their trial fits, whose uncertainty output would be discarded.
     """
     rng = _resolve_rng(random_seed)
     x = np.asarray(x, dtype=float)
@@ -6670,6 +6809,8 @@ def _unmix_method_maxunmix(x, magnetization, n_components=None,
                                        n_components=n_components,
                                        initial_parameters=initial_parameters,
                                        vary_skew=vary_skew, **kwargs)
+    if n_boot == 0:
+        return result
     best = result['params'][UNMIX_PARAM_COLUMNS].to_numpy()
     K = result['n_components']
     n = len(x)
@@ -6724,31 +6865,9 @@ def _unmix_method_maxunmix(x, magnetization, n_components=None,
                            'replicates converged; check the fit or initial '
                            'parameters')
 
-    percentiles = [2.5, 50, 97.5]
-    summary_rows = []
-    for comp in range(K):
-        row = {'component': comp + 1}
-        for name in tracked:
-            vals = np.array([s[comp] for s in samples[name]])
-            row[f'{name}_mean'] = vals.mean()
-            row[f'{name}_std'] = vals.std()
-            for pct in percentiles:
-                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
-                    np.percentile(vals, pct)
-        summary_rows.append(row)
-    param_summary = pd.DataFrame(summary_rows).set_index('component')
-
-    total_curves = np.array(total_curves)
-    comp_curves = np.array(comp_curves)
-    curves = {
-        'x_grid': x_grid,
-        'total_p2_5': np.percentile(total_curves, 2.5, axis=0),
-        'total_p50': np.percentile(total_curves, 50, axis=0),
-        'total_p97_5': np.percentile(total_curves, 97.5, axis=0),
-        'components_p2_5': np.percentile(comp_curves, 2.5, axis=0),
-        'components_p50': np.percentile(comp_curves, 50, axis=0),
-        'components_p97_5': np.percentile(comp_curves, 97.5, axis=0),
-    }
+    param_summary = _summarize_component_samples(
+        {name: np.array(vals) for name, vals in samples.items()}, K)
+    curves = _percentile_curve_bands(x_grid, total_curves, comp_curves)
     result['bootstrap'] = {
         'method': 'maxunmix',
         'n_boot': n_boot,
@@ -6802,9 +6921,10 @@ def register_unmixing_method(name, function):
     UNMIXING_METHODS[name] = function
 
 
-def unmix_coercivity(x, magnetization, method='spectrum', n_components=None,
-                     initial_parameters=None, curve_type='backfield',
-                     vary_skew=True, **kwargs):
+def unmix_coercivity(x, magnetization, method=DEFAULT_UNMIX_METHOD,
+                     n_components=None, initial_parameters=None,
+                     curve_type='backfield',
+                     vary_skew=DEFAULT_UNMIX_VARY_SKEW, **kwargs):
     """
     Unmix a remanence curve into coercivity components with a named method.
 
@@ -7000,11 +7120,13 @@ def estimate_measurement_noise(x, magnetization, curve_type='backfield'):
     return float(1.482602 * np.median(normalized))
 
 
-def select_n_components(x, magnetization, method='curve', min_components=1,
+def select_n_components(x, magnetization, method=DEFAULT_UNMIX_METHOD,
+                        min_components=1,
                         max_components=4, criterion='parsimony',
                         min_improvement=0.02, noise_level=None,
                         reduced_chi2_target=1.0, curve_type='backfield',
-                        vary_skew=False, verbose=False, **kwargs):
+                        vary_skew=DEFAULT_UNMIX_VARY_SKEW, verbose=False,
+                        **kwargs):
     """
     Choose the number of coercivity components by a parsimony rule.
 
@@ -7059,7 +7181,8 @@ def select_n_components(x, magnetization, method='curve', min_components=1,
     magnetization : array-like
         Remanence curve values at x.
     method : str
-        Registered unmixing method used for each fit (default 'curve').
+        Registered unmixing method used for each fit (default
+        DEFAULT_UNMIX_METHOD, i.e. 'spectrum').
     min_components, max_components : int
         Range of component counts to consider.
     criterion : str
@@ -7122,12 +7245,20 @@ def select_n_components(x, magnetization, method='curve', min_components=1,
             noise_x, noise_y = x, magnetization
         noise_level = estimate_measurement_noise(noise_x, noise_y, curve_type)
 
+    # trial fits only need the point fit: for method='maxunmix' suppress the
+    # per-count resampling (n_boot=0), whose uncertainty output plays no role
+    # in the selection; the selected count is re-fit with the requested
+    # resampling after the selection below
+    trial_kwargs = dict(kwargs)
+    if method == 'maxunmix':
+        trial_kwargs['n_boot'] = 0
+
     results = {}
     rows = []
     for K in counts:
         result = unmix_coercivity(x, magnetization, method=method,
                                   n_components=K, curve_type=curve_type,
-                                  vary_skew=vary_skew, **kwargs)
+                                  vary_skew=vary_skew, **trial_kwargs)
         results[K] = result
         stats = result['stats']
         rows.append({
@@ -7162,6 +7293,14 @@ def select_n_components(x, magnetization, method='curve', min_components=1,
                     else counts[-1])
 
     table['selected'] = table['n_components'] == selected
+    if method == 'maxunmix' and kwargs.get('n_boot', 100) != 0:
+        # restore the full MAX UnMix resampling uncertainty for the selected
+        # count only
+        results[selected] = unmix_coercivity(
+            x, magnetization, method=method,
+            initial_parameters=results[selected]['params'][
+                UNMIX_PARAM_COLUMNS],
+            curve_type=curve_type, vary_skew=vary_skew, **kwargs)
     if verbose:
         print(f"selected {selected} component(s) by '{criterion}' criterion "
               f'(noise ~ {noise_level:.3g})')
@@ -7298,31 +7437,9 @@ def unmixing_bootstrap(result, n_boot=500, resample='cases', proportion=1.0,
     if verbose:
         print(f'{n_success}/{n_boot} bootstrap replicates converged')
 
-    percentiles = [2.5, 50, 97.5]
-    summary_rows = []
-    for comp in range(K):
-        row = {'component': comp + 1}
-        for name in tracked:
-            vals = np.array([s[comp] for s in samples[name]])
-            row[f'{name}_mean'] = vals.mean()
-            row[f'{name}_std'] = vals.std()
-            for pct in percentiles:
-                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
-                    np.percentile(vals, pct)
-        summary_rows.append(row)
-    param_summary = pd.DataFrame(summary_rows).set_index('component')
-
-    total_curves = np.array(total_curves)
-    comp_curves = np.array(comp_curves)
-    curves = {
-        'x_grid': x_grid,
-        'total_p2_5': np.percentile(total_curves, 2.5, axis=0),
-        'total_p50': np.percentile(total_curves, 50, axis=0),
-        'total_p97_5': np.percentile(total_curves, 97.5, axis=0),
-        'components_p2_5': np.percentile(comp_curves, 2.5, axis=0),
-        'components_p50': np.percentile(comp_curves, 50, axis=0),
-        'components_p97_5': np.percentile(comp_curves, 97.5, axis=0),
-    }
+    param_summary = _summarize_component_samples(
+        {name: np.array(vals) for name, vals in samples.items()}, K)
+    curves = _percentile_curve_bands(x_grid, total_curves, comp_curves)
 
     result_out = copy.deepcopy(result)
     result_out['bootstrap'] = {
@@ -7339,8 +7456,10 @@ def unmixing_bootstrap(result, n_boot=500, resample='cases', proportion=1.0,
     return result_out
 
 
-def unmixing_multistart(x, magnetization, method='spectrum', n_components=2,
-                        n_starts=100, vary_skew=False, curve_type='backfield',
+def unmixing_multistart(x, magnetization, method=DEFAULT_UNMIX_METHOD,
+                        n_components=2, n_starts=100,
+                        vary_skew=DEFAULT_UNMIX_VARY_SKEW,
+                        curve_type='backfield',
                         random_seed=None, location_tolerance=0.1,
                         proportion_tolerance=0.05, verbose=False, **kwargs):
     """
@@ -7364,7 +7483,8 @@ def unmixing_multistart(x, magnetization, method='spectrum', n_components=2,
     magnetization : array-like
         Remanence curve values at x (e.g. 'magn_mass_shift').
     method : str
-        Registered unmixing method used for each fit (default 'spectrum').
+        Registered unmixing method used for each fit (default
+        DEFAULT_UNMIX_METHOD, i.e. 'spectrum').
     n_components : int
         Number of components (default 2).
     n_starts : int
@@ -7422,6 +7542,15 @@ def unmixing_multistart(x, magnetization, method='spectrum', n_components=2,
             'skew': skews,
         }))
 
+    # trial fits only need the point fit: for method='maxunmix' suppress the
+    # per-trial resampling (n_boot=0) -- otherwise every trial runs the full
+    # MAX UnMix bootstrap whose uncertainty output is discarded (only rss and
+    # params feed the clustering) -- and re-run the winning solution once
+    # with the requested resampling below
+    trial_kwargs = dict(kwargs)
+    if method == 'maxunmix':
+        trial_kwargs['n_boot'] = 0
+
     fits = []
     for table in starting_tables:
         try:
@@ -7429,7 +7558,7 @@ def unmixing_multistart(x, magnetization, method='spectrum', n_components=2,
                                    n_components=K if table is None else None,
                                    initial_parameters=table,
                                    curve_type=curve_type,
-                                   vary_skew=vary_skew, **kwargs)
+                                   vary_skew=vary_skew, **trial_kwargs)
         except (ValueError, RuntimeError):
             continue
         if fit['success'] and np.isfinite(fit['stats']['rss']):
@@ -7486,6 +7615,13 @@ def unmixing_multistart(x, magnetization, method='spectrum', n_components=2,
               f'{len(clusters)} distinct solution(s)')
 
     best = copy.deepcopy(clusters[0]['representative'])
+    if method == 'maxunmix' and kwargs.get('n_boot', 100) != 0:
+        # restore the full MAX UnMix resampling uncertainty for the winning
+        # solution only
+        best = unmix_coercivity(
+            x, M, method=method,
+            initial_parameters=best['params'][UNMIX_PARAM_COLUMNS],
+            curve_type=curve_type, vary_skew=vary_skew, **kwargs)
     best['multistart'] = {
         'solutions': solutions,
         'results': [c['representative'] for c in clusters],
@@ -7590,7 +7726,10 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
         the trade-offs; with space='spectrum' the offset is not used.
     vary_skew : bool
         Sample component skew (uniform prior on [-10, 10]); default False
-        (symmetric log-Gaussian components).
+        (symmetric log-Gaussian components). This deliberately deviates from
+        DEFAULT_UNMIX_VARY_SKEW: free skew multiplies the nested-sampling
+        cost and is usually better constrained through explicit `priors`
+        windows (e.g. from mineral_priors) than left fully free.
     fit_offset : bool
         Include a constant baseline offset (default True; ignored when
         space='spectrum').
@@ -7790,6 +7929,10 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     means_log = locations + dps * deltas * np.sqrt(2.0 / np.pi)
     sd_logs = dps * np.sqrt(1.0 - 2.0 * deltas ** 2 / np.pi)
     proportions = contributions / contributions.sum(axis=1, keepdims=True)
+    # per-draw medians and modes (vectorized root/mode finding) so the Bayes
+    # summary carries the same quantity set as the bootstrap summaries
+    medians_log = locations + dps * _skewnormal_median_z(skews)
+    modes_log = locations + dps * _skewnormal_mode_z(skews)
     derived = {
         'contribution': contributions,
         'proportion': proportions,
@@ -7798,21 +7941,11 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
         'skew': skews,
         'sd_log': sd_logs,
         'B_mean_mT': 10 ** means_log,
+        'B_median_mT': 10 ** medians_log,
+        'B_peak_mT': 10 ** modes_log,
     }
 
-    percentiles = [2.5, 50, 97.5]
-    summary_rows = []
-    for comp in range(K):
-        row = {'component': comp + 1}
-        for name, values in derived.items():
-            column = values[:, comp]
-            row[f'{name}_mean'] = column.mean()
-            row[f'{name}_std'] = column.std()
-            for pct in percentiles:
-                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
-                    np.percentile(column, pct)
-        summary_rows.append(row)
-    param_summary = pd.DataFrame(summary_rows).set_index('component')
+    param_summary = _summarize_component_samples(derived, K)
 
     # posterior-median parameter table in the standard result format
     median_params = np.column_stack([
@@ -7875,15 +8008,7 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
         comps = _forward_components(x_grid, draw_params)
         comp_curves[j] = comps
         total_curves[j] = comps.sum(axis=0) + offsets[index]
-    curves = {
-        'x_grid': x_grid,
-        'total_p2_5': np.percentile(total_curves, 2.5, axis=0),
-        'total_p50': np.percentile(total_curves, 50, axis=0),
-        'total_p97_5': np.percentile(total_curves, 97.5, axis=0),
-        'components_p2_5': np.percentile(comp_curves, 2.5, axis=0),
-        'components_p50': np.percentile(comp_curves, 50, axis=0),
-        'components_p97_5': np.percentile(comp_curves, 97.5, axis=0),
-    }
+    curves = _percentile_curve_bands(x_grid, total_curves, comp_curves)
 
     initial_df = pd.DataFrame(median_params, columns=UNMIX_PARAM_COLUMNS)
     return {
@@ -9244,8 +9369,9 @@ def interactive_coercivity_unmixing(x, magnetization, n_components=2,
 
 
 def unmix_backfield_experiments(measurements, experiments=None,
-                                n_components=2, method='spectrum',
-                                initial_parameters=None, vary_skew=True,
+                                n_components=2, method=DEFAULT_UNMIX_METHOD,
+                                initial_parameters=None,
+                                vary_skew=DEFAULT_UNMIX_VARY_SKEW,
                                 n_boot=0, resample='cases',
                                 proportion=1.0, noise_level=None,
                                 smooth_mode='spline', smooth_frac=0.0,

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -6479,27 +6479,131 @@ def _unmix_method_curve(x, magnetization, n_components=None,
 def _unmix_method_maxunmix(x, magnetization, n_components=None,
                            initial_parameters=None, curve_type='backfield',
                            vary_skew=True, n_boot=100, proportion=0.95,
-                           noise_level=0.02, random_seed=None, **kwargs):
+                           param_noise=0.02, random_seed=None, n_grid=200,
+                           **kwargs):
     """
-    Registered 'maxunmix' method: emulation of the MAX UnMix workflow.
+    Registered 'maxunmix' method: a faithful reproduction of the MAX UnMix
+    resampling workflow (Maxbauer et al., 2016), for direct comparison with
+    that program.
 
-    Fits skew-normal components to the coercivity spectrum and estimates
-    uncertainties with the MAX UnMix resampling scheme (case resampling of
-    95% of the data with 2% multiplicative Gaussian noise; Maxbauer et al.,
-    2016). Results are comparable to the MAX UnMix web application, with
-    the caveats that skewness here follows the Azzalini parameterization
-    rather than the Fernandez-Steel one used by MAX UnMix, and that
-    contributions are parameterized by component area rather than peak
-    height.
+    The coercivity spectrum dM/dlog10(B) is fit with skew-normal components,
+    and uncertainties are estimated exactly as in MAX UnMix: each of `n_boot`
+    replicates (1) recomputes the spectrum from a random `proportion`
+    (default 0.95) subset of the magnetization points drawn WITHOUT
+    replacement, (2) restarts the fit from the best-fit parameters perturbed
+    by `param_noise` (default 0.02, i.e. 2%) Gaussian noise, and (3)
+    re-optimizes; percentile intervals over the converged replicates are
+    reported (attached as the 'bootstrap' entry of the result).
+
+    Two representational differences from MAX UnMix remain because they are
+    intrinsic to the rockmagpy component model rather than to the resampling:
+    skewness follows the Azzalini rather than the Fernandez-Steel (fGarch)
+    parameterization, so skew values are not numerically comparable, and
+    components are parameterized by integrated area rather than by peak
+    height. Recovered coercivities, dispersions, and relative contributions
+    are directly comparable to the MAX UnMix web application.
+
+    For the more flexible rockmagpy resampling -- case or residual resampling
+    of the fitted data, optionally with added measurement noise, and usable
+    with the measurement-space and Bayesian fits as well -- fit with
+    method='spectrum' or 'curve' and call unmixing_bootstrap directly.
     """
-    result = _unmix_method_spectrum(x, magnetization,
-                                    n_components=n_components,
-                                    initial_parameters=initial_parameters,
-                                    curve_type=curve_type,
-                                    vary_skew=vary_skew, **kwargs)
-    return unmixing_bootstrap(result, n_boot=n_boot, resample='cases',
-                              proportion=proportion, noise_level=noise_level,
-                              random_seed=random_seed)
+    rng = _resolve_rng(random_seed)
+    x = np.asarray(x, dtype=float)
+    M = np.asarray(magnetization, dtype=float)
+    finite = np.isfinite(x) & np.isfinite(M)
+    x, M = x[finite], M[finite]
+
+    x_mid, spectrum = coercivity_spectrum_from_curve(x, M, curve_type)
+    result = unmix_coercivity_spectrum(x_mid, spectrum,
+                                       n_components=n_components,
+                                       initial_parameters=initial_parameters,
+                                       vary_skew=vary_skew, **kwargs)
+    best = result['params'][UNMIX_PARAM_COLUMNS].to_numpy()
+    K = result['n_components']
+    n = len(x)
+    n_keep = max(int(round(n * proportion)), 3 * K + 3)
+
+    tracked = ['contribution', 'proportion', 'location', 'dp', 'skew',
+               'sd_log', 'B_mean_mT', 'B_median_mT', 'B_peak_mT']
+    samples = {name: [] for name in tracked}
+    x_grid = np.linspace(x_mid.min(), x_mid.max(), n_grid)
+    total_curves, comp_curves = [], []
+    n_success = 0
+    for _ in range(n_boot):
+        # (1) recompute the spectrum from a 95% subset of the curve, w/o replacement
+        idx = np.sort(rng.choice(n, size=n_keep, replace=False))
+        x_mid_b, spectrum_b = coercivity_spectrum_from_curve(x[idx], M[idx],
+                                                             curve_type)
+        # (2) restart from the best fit perturbed by ~2% Gaussian noise
+        init = best.copy()
+        init[:, 0] *= 1.0 + rng.normal(0.0, param_noise, K)   # contribution
+        init[:, 1] *= 1.0 + rng.normal(0.0, param_noise, K)   # location
+        init[:, 2] *= 1.0 + rng.normal(0.0, param_noise, K)   # dispersion
+        if vary_skew:
+            init[:, 3] += rng.normal(0.0, 5.0 * param_noise, K)  # skew jitter
+        init[:, 0] = np.abs(init[:, 0])
+        try:
+            fit = unmix_coercivity_spectrum(
+                x_mid_b, spectrum_b, vary_skew=vary_skew,
+                initial_parameters=pd.DataFrame(init,
+                                                columns=UNMIX_PARAM_COLUMNS))
+        except (ValueError, RuntimeError):
+            continue
+        if not fit['success']:
+            continue
+        p = fit['params']
+        for name in tracked:
+            samples[name].append(p[name].to_numpy())
+        arr = p[UNMIX_PARAM_COLUMNS].to_numpy()
+        total_curves.append(coercivity_spectrum_model(x_grid, arr))
+        comp_curves.append(coercivity_spectrum_components(x_grid, arr))
+        n_success += 1
+
+    if n_success < max(10, n_boot // 10):
+        raise RuntimeError(f'only {n_success} of {n_boot} MAX UnMix '
+                           'replicates converged; check the fit or initial '
+                           'parameters')
+
+    percentiles = [2.5, 50, 97.5]
+    summary_rows = []
+    for comp in range(K):
+        row = {'component': comp + 1}
+        for name in tracked:
+            vals = np.array([s[comp] for s in samples[name]])
+            row[f'{name}_mean'] = vals.mean()
+            row[f'{name}_std'] = vals.std()
+            for pct in percentiles:
+                row[f'{name}_p{str(pct).replace(".", "_")}'] = \
+                    np.percentile(vals, pct)
+        summary_rows.append(row)
+    param_summary = pd.DataFrame(summary_rows).set_index('component')
+
+    total_curves = np.array(total_curves)
+    comp_curves = np.array(comp_curves)
+    curves = {
+        'x_grid': x_grid,
+        'total_p2_5': np.percentile(total_curves, 2.5, axis=0),
+        'total_p50': np.percentile(total_curves, 50, axis=0),
+        'total_p97_5': np.percentile(total_curves, 97.5, axis=0),
+        'components_p2_5': np.percentile(comp_curves, 2.5, axis=0),
+        'components_p50': np.percentile(comp_curves, 50, axis=0),
+        'components_p97_5': np.percentile(comp_curves, 97.5, axis=0),
+    }
+    result['bootstrap'] = {
+        'method': 'maxunmix',
+        'n_boot': n_boot,
+        'n_success': n_success,
+        'resample': 'maxunmix: 95% subsample without replacement '
+                    '+ 2% restart-parameter perturbation',
+        'proportion': proportion,
+        'param_noise': param_noise,
+        'param_summary': param_summary,
+        'param_samples': {name: np.array(vals)
+                          for name, vals in samples.items()},
+        'curves': curves,
+    }
+    return result
 
 
 UNMIXING_METHODS = {
@@ -6668,11 +6772,22 @@ def estimate_measurement_noise(x, magnetization, curve_type='backfield'):
     """
     Robustly estimate the measurement noise of a remanence curve.
 
-    Uses a third-difference (DER_SNR-style) estimator that suppresses the
-    smooth signal and returns a robust standard deviation of the residual
-    scatter, without any smoothing or model fitting. This provides the
-    noise scale needed to judge when an unmixing model fits "to within the
-    measurement noise" (see select_n_components).
+    Suppresses the smooth signal and returns a robust standard deviation of
+    the residual scatter, without any smoothing or model fitting. This
+    provides the noise scale needed to judge when an unmixing model fits "to
+    within the measurement noise" (see select_n_components).
+
+    For each interior point the smooth signal is removed by comparing the
+    point to the value predicted for it by cubic interpolation through its
+    four nearest neighbours (two on each side) at their actual field
+    positions; the residual is scaled by the standard deviation that
+    combination would have under white noise, and a robust (median-absolute)
+    scale is taken. Because the interpolation is exact for any polynomial of
+    degree <= 3, this removes not just the local slope but the curvature of
+    the sigmoidal curve, so the estimator is little biased even on the coarse
+    and non-uniform (typically log-spaced) field grids of backfield/IRM
+    measurements -- unlike a plain second difference, which cancels only a
+    linear trend and inflates the noise where the curve bends.
 
     Parameters
     ----------
@@ -6693,13 +6808,36 @@ def estimate_measurement_noise(x, magnetization, curve_type='backfield'):
     x = np.asarray(x, dtype=float)
     M = np.asarray(magnetization, dtype=float)
     order = np.argsort(x)
-    M = M[order]
+    x, M = x[order], M[order]
     if len(M) < 5:
         return float(np.std(M))
-    # |2 M_i - M_{i-2} - M_{i+2}| cancels linear trends; the median makes it
-    # robust to the minority of high-curvature points on a sigmoidal curve
-    differences = np.abs(2 * M[2:-2] - M[:-4] - M[4:])
-    return float(1.482602 / np.sqrt(6) * np.median(differences))
+    # predict each interior point by cubic interpolation through its four
+    # neighbours (i-2, i-1, i+1, i+2) at their true positions; the residual
+    # cancels any signal up to a local cubic, so both slope and curvature of
+    # the smooth curve are removed for arbitrary spacing
+    c = np.arange(2, len(x) - 2)
+    x0 = x[c]
+    xa, xb, xc, xd = x[c - 2], x[c - 1], x[c + 1], x[c + 2]
+    Ma, Mb, Mc, Md = M[c - 2], M[c - 1], M[c + 1], M[c + 2]
+
+    def lagrange(xi, xj, xk, xl):
+        # weight of the point at xi in the cubic interpolant evaluated at x0
+        return ((x0 - xj) * (x0 - xk) * (x0 - xl)
+                / ((xi - xj) * (xi - xk) * (xi - xl)))
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        La = lagrange(xa, xb, xc, xd)
+        Lb = lagrange(xb, xa, xc, xd)
+        Lc = lagrange(xc, xa, xb, xd)
+        Ld = lagrange(xd, xa, xb, xc)
+        residual = M[c] - (La * Ma + Lb * Mb + Lc * Mc + Ld * Md)
+        # under white noise var(residual) = sigma^2 (1 + La^2 + Lb^2 + ...)
+        scale = np.sqrt(1.0 + La ** 2 + Lb ** 2 + Lc ** 2 + Ld ** 2)
+        normalized = np.abs(residual / scale)
+    normalized = normalized[np.isfinite(normalized)]
+    if normalized.size == 0:
+        return float(np.std(M))
+    return float(1.482602 * np.median(normalized))
 
 
 def select_n_components(x, magnetization, method='curve', min_components=1,
@@ -6733,9 +6871,16 @@ def select_n_components(x, magnetization, method='curve', min_components=1,
     - 'chi2': the simplest model whose reduced chi-square (using
       `noise_level`, estimated with estimate_measurement_noise if not
       given) falls at or below `reduced_chi2_target`, i.e. the simplest
-      model that fits to within the measurement noise. This is more
-      principled when a trustworthy noise level is available, but is
-      sensitive to the accuracy of that noise estimate.
+      model that fits to within the measurement noise. The noise estimator
+      is spacing-aware and unbiased on the coarse, log-spaced field grids of
+      backfield/IRM data, but 'chi2' remains the less robust criterion: like
+      the information criteria and the Bayesian evidence it tends to
+      over-select on high-resolution, low-noise curves (once the noise is
+      not over-estimated, any small departure of the data from a log-Gaussian
+      pushes the reduced chi-square of a real-count model just above one), and
+      it is sensitive to the residual scatter of the noise estimate. Prefer
+      'parsimony', or supply a trusted `noise_level` and a `reduced_chi2_target`
+      slightly above 1, when using it.
 
     In all cases the returned table reports the fit statistics, the
     fractional RSS improvement per added component, and (when a noise level
@@ -7185,7 +7330,8 @@ def _ordered_uniform_transform(u, low, high):
 
 
 def unmix_coercivity_bayes(x, magnetization, n_components=2,
-                           curve_type='backfield', vary_skew=False,
+                           curve_type='backfield', space='curve',
+                           vary_skew=False,
                            fit_offset=True, priors=None, nlive=250,
                            dlogz=0.1, sample='rslice', random_seed=None,
                            n_grid=200, n_posterior_curves=300,
@@ -7193,15 +7339,30 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     """
     Bayesian coercivity unmixing by nested sampling (requires dynesty).
 
-    The measured remanence curve is modeled in measurement space (where an
-    independent Gaussian noise model is defensible; numerically
-    differentiated spectra have correlated noise) as a sum of cumulative
-    skew-normal components plus an offset, with the noise standard
-    deviation treated as a free parameter. The posterior is sampled with
-    static nested sampling (Skilling, 2006) as implemented in dynesty
-    (Speagle, 2020), which also returns the Bayesian evidence (logz) --
-    the principled criterion for choosing the number of components
-    (compare logz between runs with different n_components).
+    The remanence data are modeled as a sum of skew-normal components, with
+    the noise standard deviation treated as a free parameter, and sampled
+    with static nested sampling (Skilling, 2006) as implemented in dynesty
+    (Speagle, 2020), which also returns the Bayesian evidence (logz) -- the
+    principled criterion for choosing the number of components (compare logz
+    between runs with different n_components). The fit can be performed in
+    either of two data spaces (see the `space` argument):
+
+    - space='curve' (default): the measured curve M(B) is fit directly with
+      cumulative skew-normal components plus a constant offset. An
+      independent Gaussian noise model is defensible here, and no numerical
+      differentiation is required. This is the more conservative choice.
+    - space='spectrum': the finite-difference coercivity spectrum
+      dM/dlog10(B) is fit with skew-normal densities (no offset). Fitting the
+      derivative directly reproduces the coercivity-distribution peak that a
+      curve fit can under-represent, and lets skewness be constrained by the
+      peak shape. The trade-off is that differencing correlates adjacent
+      points, so the i.i.d. Gaussian likelihood used here is an approximation
+      (the same one the least-squares and MAX UnMix spectrum fits make);
+      credible intervals in this space should be read with that caveat.
+
+    The component parameterization (contribution=area, location, dp, skew) is
+    identical in both spaces, so their results are directly comparable, and
+    comparing them is a useful robustness check.
 
     Unlike bootstrap resampling of a single fit, the posterior represents
     the full range of component decompositions consistent with the data
@@ -7226,20 +7387,32 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
         Number of components (default 2).
     curve_type : str
         'backfield' or 'acquisition'.
+    space : str
+        'curve' (fit the measured curve, default) or 'spectrum' (fit the
+        finite-difference dM/dlog10(B) spectrum). See the summary above for
+        the trade-offs; with space='spectrum' the offset is not used.
     vary_skew : bool
         Sample component skew (uniform prior on [-10, 10]); default False
         (symmetric log-Gaussian components).
     fit_offset : bool
-        Include a constant baseline offset (default True).
+        Include a constant baseline offset (default True; ignored when
+        space='spectrum').
     priors : dict, optional
         Overrides for the default prior bounds. Recognized keys:
-        'location', 'dp', 'contribution', 'skew' map to a list of
-        (low, high) tuples, one per component (locations/dp in log10
-        units, contributions in the units of the magnetization data);
+        'mean', 'location', 'dp', 'contribution', 'skew' map to a list
+        of (low, high) tuples, one per component (in log10 units for
+        'mean'/'location'/'dp', magnetization units for 'contribution');
         'offset' and 'noise' map to a single (low, high) tuple in
-        magnetization units. When per-component 'location' bounds are
-        given they replace the ordered-uniform construction, so they
-        should be non-overlapping or ordered to keep labels meaningful.
+        magnetization units. A 'mean' window constrains each component's
+        MEAN coercivity (log10 mT): the mean is sampled uniformly in the
+        window and the skew-normal location is derived from the sampled dp
+        and skew, so the window means what it says even for skewed
+        components (this is what mineral_priors produces). A 'location'
+        window instead constrains the raw location parameter directly.
+        Either replaces the weakly-informative ordered-uniform default, so
+        the windows should be non-overlapping or ordered to keep component
+        labels meaningful. 'mean' takes precedence over 'location' if both
+        are given.
     nlive : int
         Number of live points (default 250).
     dlogz : float
@@ -7273,6 +7446,8 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     import dynesty
     assert curve_type in ('backfield', 'acquisition'), \
         "curve_type must be 'backfield' or 'acquisition'"
+    assert space in ('curve', 'spectrum'), \
+        "space must be 'curve' or 'spectrum'"
     rng = _resolve_rng(random_seed)
     priors = dict(priors or {})
 
@@ -7280,6 +7455,11 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     y = np.asarray(magnetization, dtype=float)
     finite = np.isfinite(x) & np.isfinite(y)
     x, y = x[finite], y[finite]
+    if space == 'spectrum':
+        # fit the finite-difference spectrum dM/dlog10(B); there is no
+        # baseline offset in derivative space
+        x, y = coercivity_spectrum_from_curve(x, y, curve_type)
+        fit_offset = False
     y_scale = np.max(np.abs(y))
     if y_scale == 0:
         raise ValueError('magnetization data are all zero')
@@ -7287,7 +7467,29 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     K = n_components
     n_data = len(x)
 
+    def _forward(params, offset):
+        if space == 'spectrum':
+            return coercivity_spectrum_model(x, params)
+        return coercivity_curve_model(x, params, offset=offset,
+                                      curve_type=curve_type)
+
+    def _forward_components(grid, params):
+        if space == 'spectrum':
+            return coercivity_spectrum_components(grid, params)
+        return coercivity_curve_components(grid, params, curve_type=curve_type)
+
     # prior bounds (normalized units for contribution/offset/noise)
+    # A component's coercivity window can be given either directly on the
+    # skew-normal 'location' parameter, or -- preferably, and as produced by
+    # mineral_priors -- on the component's MEAN coercivity via 'mean'. For a
+    # skewed component the location is not itself a physical coercivity, so a
+    # 'mean' window keeps the constraint on the reported mean coercivity
+    # (10**mean_log): the mean is sampled uniformly in the window and the
+    # location is derived from the sampled dp and skew.
+    mean_bounds = priors.get('mean')
+    if mean_bounds is not None:
+        mean_bounds = [tuple(b) for b in mean_bounds]
+        assert len(mean_bounds) == K
     location_bounds = priors.get('location')
     if location_bounds is not None:
         location_bounds = [tuple(b) for b in location_bounds]
@@ -7305,31 +7507,42 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
 
     ndim = 3 * K + (K if vary_skew else 0) + (1 if fit_offset else 0) + 1
 
+    # unit-cube layout: contributions[0:K], locations[K:2K], dps[2K:3K],
+    # skews[3K:4K] (if vary_skew), offset, noise. dps and skews are drawn
+    # before locations so that a 'mean' window can derive the location from
+    # the sampled dp and skew.
     def prior_transform(u):
         theta = np.empty(ndim)
-        i = 0
         for k in range(K):  # contributions
             low, high = contribution_bounds[k]
-            theta[i] = low + (high - low) * u[i]
-            i += 1
-        if location_bounds is None:  # ordered locations
-            theta[i:i + K] = _ordered_uniform_transform(
-                u[i:i + K], location_range[0], location_range[1])
-        else:
-            for k in range(K):
-                low, high = location_bounds[k]
-                theta[i + k] = low + (high - low) * u[i + k]
-        i += K
+            theta[k] = low + (high - low) * u[k]
         for k in range(K):  # dispersions, log-uniform
             low, high = dp_bounds[k]
-            theta[i] = np.exp(np.log(low)
-                              + (np.log(high) - np.log(low)) * u[i])
-            i += 1
+            theta[2 * K + k] = np.exp(np.log(low)
+                                      + (np.log(high) - np.log(low))
+                                      * u[2 * K + k])
         if vary_skew:
             for k in range(K):
                 low, high = skew_bounds[k]
-                theta[i] = low + (high - low) * u[i]
-                i += 1
+                theta[3 * K + k] = low + (high - low) * u[3 * K + k]
+            skew_vals = theta[3 * K:4 * K]
+        else:
+            skew_vals = np.zeros(K)
+        if mean_bounds is not None:  # window on the mean coercivity
+            delta = skew_vals / np.sqrt(1.0 + skew_vals ** 2)
+            shift = theta[2 * K:3 * K] * delta * np.sqrt(2.0 / np.pi)
+            for k in range(K):
+                low, high = mean_bounds[k]
+                mean_log = low + (high - low) * u[K + k]
+                theta[K + k] = mean_log - shift[k]  # location = mean - shift
+        elif location_bounds is not None:  # window on the location parameter
+            for k in range(K):
+                low, high = location_bounds[k]
+                theta[K + k] = low + (high - low) * u[K + k]
+        else:  # ordered locations (weakly informative default)
+            theta[K:2 * K] = _ordered_uniform_transform(
+                u[K:2 * K], location_range[0], location_range[1])
+        i = 4 * K if vary_skew else 3 * K
         if fit_offset:
             theta[i] = offset_low + (offset_high - offset_low) * u[i]
             i += 1
@@ -7356,8 +7569,7 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     def loglike(theta):
         c, loc, dp, skew, offset, noise = unpack(theta)
         params = np.column_stack([c, loc, dp, skew])
-        model = coercivity_curve_model(x, params, offset=offset,
-                                       curve_type=curve_type)
+        model = _forward(params, offset)
         residual = (model - ys) / noise
         value = log_norm - n_data * np.log(noise) \
             - 0.5 * float(residual @ residual)
@@ -7434,8 +7646,7 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     total = params['contribution'].sum()
     params.insert(1, 'proportion', params['contribution'] / total)
 
-    y_fit = coercivity_curve_model(x, median_params, offset=offset_median,
-                                   curve_type=curve_type)
+    y_fit = _forward(median_params, offset_median)
     residuals = y - y_fit
     rss = float(np.sum(residuals ** 2))
     tss = float(np.sum((y - y.mean()) ** 2))
@@ -7464,8 +7675,7 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
         draw_params = np.column_stack([
             contributions[index], locations[index], dps[index],
             skews[index]])
-        comps = coercivity_curve_components(x_grid, draw_params,
-                                            curve_type=curve_type)
+        comps = _forward_components(x_grid, draw_params)
         comp_curves[j] = comps
         total_curves[j] = comps.sum(axis=0) + offsets[index]
     curves = {
@@ -7481,6 +7691,7 @@ def unmix_coercivity_bayes(x, magnetization, n_components=2,
     initial_df = pd.DataFrame(median_params, columns=UNMIX_PARAM_COLUMNS)
     return {
         'method': 'bayes',
+        'space': space,
         'curve_type': curve_type,
         'n_components': K,
         'success': True,
@@ -7522,11 +7733,13 @@ def _unmix_method_bayes(x, magnetization, n_components=None,
     widget) and no explicit priors are given, per-component location and
     dispersion priors are centered on them.
     """
-    # a priors dict from mineral_priors() carries one entry per component,
-    # so n_components can be inferred from it
-    if (n_components is None and priors is not None
-            and priors.get('location') is not None):
-        n_components = len(priors['location'])
+    # a priors dict from mineral_priors() carries one entry per component
+    # (as a 'mean' or 'location' window), so n_components can be inferred
+    if n_components is None and priors is not None:
+        for key in ('mean', 'location'):
+            if priors.get(key) is not None:
+                n_components = len(priors[key])
+                break
     if initial_parameters is not None:
         if n_components is None:
             n_components = len(initial_parameters)
@@ -7559,143 +7772,236 @@ UNMIXING_METHODS['bayes'] = _unmix_method_bayes
 # mineral components, for use as informative priors in Bayesian unmixing
 # (unmix_coercivity_bayes) or as initial parameters for the least-squares
 # methods. Covered minerals: magnetite (igneous, detrital, eolian,
-# pedogenic/extracellular, and biogenic soft/hard), oxidized maghemite, the
-# ferrimagnetic iron sulphides greigite and pyrrhotite, and the
-# antiferromagnetic iron oxides/oxyhydroxides hematite (pigmentary/detrital)
-# and goethite. Each entry gives a plausible range for the median coercivity
-# (B_median_mT), the dispersion (dp, in log10 units), and the skew, together
-# with the literature source.
+# pedogenic/extracellular, and biogenic soft/hard), maghemite (pure/soft and
+# oxidized-magnetite/hard), the ferrimagnetic iron sulphides greigite and
+# pyrrhotite, and the antiferromagnetic hematite (pigmentary/detrital).
+#
+# GOETHITE is deliberately NOT included. It does not magnetically saturate even
+# in ~57 T fields (Roberts 2025, p. 337; only ~2-10% of its Mr is acquired by
+# 3 T), so an ordinary backfield or IRM coercivity spectrum sees only an
+# ambiguous low-coercivity tail that overlaps hematite and cannot quantify
+# goethite; a fitted "goethite" component would be a poorly-constrained minimum
+# estimate that invites over-interpretation. A high-coercivity component that
+# might be goethite is better flagged and confirmed by independent thermal or
+# low-temperature methods (see goethite_removal).
+#
+# Each entry gives, as (low, high) bounds of a uniform prior:
+#   'B_median_mT' : the characteristic (median ~ mean) coercivity window, mT.
+#                   mineral_priors passes this to unmix_coercivity_bayes as a
+#                   'mean' window, so it constrains the component's MEAN
+#                   coercivity (10**B_mean_mT) directly, whatever its skew.
+#   'dp'          : the dispersion (one standard deviation of the log10-field
+#                   distribution), log10 units.
+#   'skew'        : the Azzalini skew-normal shape parameter (alpha), SIGNED
+#                   by the physical asymmetry (see below). NB alpha is not the
+#                   moment skewness; |alpha|~2-5 gives a visibly skewed
+#                   component, alpha=0 is a symmetric log-Gaussian.
+#
+# SOURCES AND SHAPE CONVENTIONS:
+#  * Numeric coercivity (B_median) and width (dp) ranges: the magnetite-family
+#    and maghemite/loess values are from Egli (2003; 2004a Stud. Geophys.
+#    Geod. 48, 391-446) component analysis of AF-demagnetized ARM/IRM (MDF and
+#    DP), cross-checked against the grain-size systematics in Roberts (2025)
+#    "Mineral Magnetism" (magnetite pp. 105-141, maghemite pp. 284-321).
+#    Hematite, greigite, and pyrrhotite coercivity ranges are from Roberts
+#    (2025) (hematite pp. 182-228, 267-283; sulphides pp. 356-416).
+#    IMPORTANT: Roberts (2025) does NOT tabulate DP
+#    or skew; the dp windows are therefore taken from / consistent with Egli
+#    (2003, 2004a,b), Robertson & France (1994), and Kruiver et al. (2001),
+#    not from Roberts, and are deliberately broad.
+#  * SKEW SIGN (Roberts 2025, p. 117; Egli 2003, 2004b): coercivity
+#    distributions of stable-SD, MD, and interacting magnetite (and maghemite)
+#    are NEGATIVELY (left-) skewed on the log-field axis -- a heavier
+#    low-field tail -- so those entries use alpha in roughly [-5, 0].
+#    Pyrrhotite is POSITIVELY (right-) skewed (a hard, high-field tail; Roberts
+#    p. 374), so alpha in roughly [-1, 5]. Greigite (SD) is near-symmetric,
+#    left-skewed when SP/MD is present
+#    (Roberts pp. 405-406). Hematite is variable (pigmentary components are
+#    often fit skew-right, Maxbauer et al. 2016), so a broad two-sided window
+#    is used. These signs are qualitative in Roberts; no numeric skew exists
+#    to cite.
 #
 # IMPORTANT CAVEATS:
-#  * The magnetite-family values derive from Egli (2004a,b), whose component
-#    analysis is based on AF demagnetization of ARM/IRM and reports the
-#    median destructive field (MDF) of the coercivity distribution. For IRM
-#    acquisition or backfield curves the relevant quantity is the median
-#    acquisition/remanence field, which is comparable to the MDF for a given
-#    mineral population but not identical; treat these as soft, approximate
-#    priors, not calibrations.
-#  * The sulphide, hematite, and goethite values are from Roberts (2025),
-#    "Mineral Magnetism". These ranges are broad on purpose: they overlap
-#    one another (greigite and pyrrhotite overlap biogenic-hard magnetite
-#    and maghemite; pyrrhotite overlaps pigmentary hematite), so a coercivity
-#    prior constrains a window, it does not identify a mineral. Al-substitution
-#    drives hematite coercivity up to ~1300 mT and then collapses it toward
-#    zero at high substitution, while Al- and micro-goethite can fall below
-#    ~60 mT.
-#  * Pyrrhotite and goethite do not magnetically saturate in ordinary
-#    laboratory fields (pyrrhotite needs >2 T; goethite is unsaturated even
-#    in 57 T fields), so a typical backfield or IRM experiment (<= 2-5 T)
-#    captures only the low-coercivity tail of such a component and
-#    underestimates its contribution; pass field_max_mT to keep priors within
-#    the measured range and interpret any such contribution as a minimum.
+#  * A coercivity prior constrains a WINDOW, it does not identify a mineral.
+#    The windows overlap: greigite (both saturate <0.3 T) and non-SD
+#    pyrrhotite overlap magnetite/maghemite (Roberts pp. 405-407, 374), and
+#    hard SD / metamorphic pyrrhotite overlaps pigmentary hematite.
+#  * The characteristic coercivity depends on HOW it is measured, and the
+#    ordering is systematic. For submicron magnetite Dunlop (1986, EPSL 78,
+#    288-295, doi:10.1016/0012-821X(86)90068-3) measured Hc < MDF (the AF
+#    median destructive field, i.e. the
+#    Egli values) < Bcr (the backfield remanent coercive force) < the median
+#    IRM-acquisition field, with the backfield Bcr running ~1.3-1.5x and the
+#    acquisition median ~2x the AF-MDF (e.g. a 0.1-0.2 um PSD magnetite: MDF
+#    ~18 mT, Bcr ~27-28 mT, acquisition ~39-41 mT). rockmagpy unmixing fits
+#    the backfield or IRM coercivity distribution, whose median is the Bcr or
+#    acquisition field, so a window taken from an AF-demagnetization component
+#    analysis (the magnetite family, from Egli) sits somewhat low for these
+#    curves. Treat the windows as soft, approximate priors, not calibrations,
+#    and read the finer-is-harder-but-narrower trend of Dunlop (1986) as the
+#    reason biogenic/pedogenic (fine) magnetite has both higher coercivity and
+#    lower dp than coarse detrital magnetite.
+#  * Pyrrhotite does not fully saturate in ordinary laboratory fields (>2 T to
+#    saturate; Roberts p. 374), so a typical backfield/IRM experiment (<= 2-5
+#    T) captures only its lower-coercivity part and UNDERESTIMATES its
+#    contribution; pass field_max_mT to keep priors within the measured range
+#    and read any such contribution as a minimum. (Goethite is unsaturated even
+#    at 57 T, far more extreme, and is excluded from the library for that
+#    reason -- see the header.)
+#  * Hematite coercivity is grain-size controlled (Ozdemir & Dunlop 2014,
+#    Hc ~ d^-0.61): across the fitting-relevant range of ~100s of nm
+#    (pigmentary, fine specular) to ~100s of um (coarse specular) it runs from
+#    ~1 T down to ~100-200 mT, so finer hematite is harder. (The very soft
+#    Bcr of mm-scale single crystals is not a natural sedimentary population.)
+#    Al-substitution raises hematite coercivity up to ~7-13 mol% Al and then
+#    lowers it at high substitution, but this trend is strongly confounded by
+#    covarying grain size (Roberts pp. 271-272).
 #  * Component fitting near the SP/SD threshold can produce a spurious
 #    low-coercivity component (Heslop et al., 2004); an unexpectedly soft
 #    component should be checked against independent evidence.
 #  * Ranges are deliberately generous (roughly the spread of the cited
 #    populations, not a single sample). Narrow them with the `tighten`
 #    argument of mineral_priors only when justified by independent data.
-#
-# Values are the (low, high) bounds of a uniform prior on each quantity.
 COERCIVITY_COMPONENT_LIBRARY = {
     'magnetite_pedogenic': {
-        'B_median_mT': (12.0, 25.0), 'dp': (0.25, 0.38),
-        'skew': (-1.0, 0.0),
-        'source': 'Egli (2004a), components PD/EX; Roberts (2025) '
-                  '(pedogenic / extracellular ultrafine magnetite)',
-        'note': 'ultrafine SP-SSD magnetite; MDF ~16-18 mT, DP ~0.30, '
-                'strongly left-skewed'},
+        'B_median_mT': (10.0, 25.0), 'dp': (0.25, 0.40),
+        'skew': (-5.0, 0.0),
+        'source': 'Egli (2004a) components PD/EX (MDF ~17-18 mT, DP ~0.3); '
+                  'Roberts (2025) p. 112 (unstrained, fine, soft) -- note '
+                  'Roberts p. 285/301 considers pedogenic ferrimagnet often '
+                  'to be maghemite rather than magnetite',
+        'note': 'ultrafine SP-SSD magnetite; soft, narrow, left-skewed'},
     'magnetite_detrital': {
-        'B_median_mT': (18.0, 40.0), 'dp': (0.30, 0.45),
-        'skew': (-0.7, 0.0),
-        'source': 'Egli (2004a), component D; Roberts (2025) '
-                  '(detrital magnetite)',
+        'B_median_mT': (15.0, 45.0), 'dp': (0.30, 0.45),
+        'skew': (-5.0, 0.0),
+        'source': 'Egli (2004a) component D (AF MDF ~25-33 mT, DP ~0.35-0.40); '
+                  'Dunlop (1986, doi:10.1016/0012-821X(86)90068-3) measured '
+                  'submicron PSD magnetite (0.1-0.22 um) backfield Bcr ~27-28 '
+                  'mT and median IRM-acquisition field ~39-41 mT, with broader '
+                  'spectra for coarser grains; Roberts (2025) pp. 112, 121',
         'note': 'coarse detrital magnetite in water-lain sediments; '
-                'MDF ~25-33 mT, DP ~0.35-0.40'},
+                'broad/mixed, left-skewed. Backfield Bcr and IRM-acquisition '
+                'medians run above the AF MDF (see the library caveats)'},
     'magnetite_igneous': {
-        'B_median_mT': (8.0, 40.0), 'dp': (0.20, 0.50),
-        'skew': (-0.6, 0.2),
-        'source': 'Roberts (2025), magnetite chapter (grain-size '
-                  'systematics of primary magmatic magnetite)',
+        'B_median_mT': (8.0, 45.0), 'dp': (0.20, 0.50),
+        'skew': (-5.0, 0.0),
+        'source': 'Roberts (2025) pp. 112-113 (grain-size systematics; SD '
+                  'peak Bc ~15 mT; igneous grains stressed -> higher/more '
+                  'variable coercivity than grown crystals)',
         'note': 'primary magmatic (titano)magnetite; broad and grain-size '
-                'dependent, spanning low-coercivity coarse PSD-MD grains to '
-                'finer PSD/SD grains in rapidly cooled volcanics; oxidation '
-                'to titanomaghemite raises coercivity (see '
-                'maghemite_oxidized)'},
+                'dependent, from low-coercivity coarse PSD-MD grains to finer '
+                'PSD/SD grains; oxidation to titanomaghemite raises coercivity '
+                '(see maghemite_oxidized)'},
     'magnetite_eolian': {
         'B_median_mT': (18.0, 45.0), 'dp': (0.20, 0.40),
-        'skew': (-0.6, 0.0),
-        'source': 'Egli (2004a), component ED; Roberts (2025) '
-                  '(wind-blown dust magnetite)',
-        'note': 'aeolian / loess detrital magnetite'},
+        'skew': (-5.0, 0.0),
+        'source': 'Egli (2004a) component ED (aeolian dust; MDF ~28 mT); '
+                  'Roberts (2025) does not give an eolian-specific value',
+        'note': 'aeolian / loess detrital magnetite (often partly '
+                'maghemitized)'},
     'magnetite_biogenic_soft': {
         'B_median_mT': (25.0, 55.0), 'dp': (0.10, 0.25),
-        'skew': (-0.5, 0.0),
-        'source': 'Egli (2004a), component BS; Roberts (2025) '
-                  '(low-coercivity magnetosomes)',
-        'note': 'biogenic soft magnetite; diagnostic narrow DP (~0.1-0.2)'},
+        'skew': (-5.0, 0.0),
+        'source': 'Egli (2004a) component BS (MDF ~45 mT, DP ~0.17); '
+                  'Roberts (2025) pp. 119-121',
+        'note': 'biogenic soft magnetite (equant magnetosomes); diagnostic '
+                'narrow DP (~0.1-0.2)'},
     'magnetite_biogenic_hard': {
         'B_median_mT': (50.0, 100.0), 'dp': (0.08, 0.22),
-        'skew': (-0.3, 0.2),
-        'source': 'Egli (2004a), component BH; Roberts (2025) '
-                  '(high-coercivity magnetosomes)',
-        'note': 'biogenic hard magnetite; diagnostic very narrow DP'},
+        'skew': (-5.0, 0.0),
+        'source': 'Egli (2004a) component BH (MDF ~73 mT, DP ~0.11); '
+                  'Roberts (2025) pp. 119-121',
+        'note': 'biogenic hard magnetite (elongated magnetosome chains); '
+                'diagnostic very narrow DP'},
+    'magnetite': {
+        'B_median_mT': (8.0, 100.0), 'dp': (0.15, 0.50),
+        'skew': (-5.0, 0.0),
+        'source': 'generic magnetite window spanning the specific entries '
+                  '(coarse soft ~10 mT to fine/oxidized hard ~100 mT); '
+                  'Egli (2004a); Dunlop (1986, '
+                  'doi:10.1016/0012-821X(86)90068-3) measured submicron '
+                  'magnetite backfield Bcr ~27-50 mT and IRM-acquisition '
+                  'medians ~39-68 mT (0.22 um PSD to SD), finer grains harder '
+                  'but with narrower spectra; Roberts (2025) pp. 105-141',
+        'note': 'broad default for stoichiometric-to-partly-oxidized '
+                'magnetite when the grain population is unknown; left-skewed. '
+                'Use the specific entries (detrital, biogenic, ...) when the '
+                'population is known, or maghemite_oxidized for a distinctly '
+                'harder (surface-oxidized) magnetite'},
+    'maghemite': {
+        'B_median_mT': (10.0, 40.0), 'dp': (0.15, 0.35),
+        'skew': (-5.0, 0.5),
+        'source': 'Roberts (2025) pp. 300-301 (pure gamma-Fe2O3: modal '
+                  'coercivity ~14 mT equant to ~34 mT elongated; saturates '
+                  '<100-200 mT)',
+        'note': 'pure maghemite is SOFT, softer than magnetite; skewed '
+                'distributions with a high-field tail. Distinct from the '
+                'harder oxidized-magnetite phase (maghemite_oxidized)'},
     'maghemite_oxidized': {
-        'B_median_mT': (45.0, 110.0), 'dp': (0.15, 0.35),
-        'skew': (-0.6, 0.2),
-        'source': 'Egli (2004a), component L; Roberts (2025) '
-                  '(oxidized maghemite in loess)',
-        'note': 'low-temperature-oxidized magnetite/maghemite; '
-                'higher coercivity than parent magnetite'},
+        'B_median_mT': (45.0, 90.0), 'dp': (0.15, 0.35),
+        'skew': (-5.0, 0.0),
+        'source': 'Roberts (2025) pp. 300-301 (surface-maghemitized magnetite '
+                  'Bcr ~52 mT, harder than either endmember; harder in '
+                  'coarser grains); Egli (2004a) loess component L',
+        'note': 'low-temperature (surface) oxidized magnetite (core-shell); '
+                'HARDER than either pure magnetite or pure maghemite'},
     'greigite': {
-        'B_median_mT': (30.0, 95.0), 'dp': (0.15, 0.35),
-        'skew': (-0.4, 0.4),
-        'source': 'Roberts (2025), greigite chapter (Roberts et al., '
-                  '2011b compilation)',
-        'note': 'authigenic ferrimagnetic iron sulphide; stable-SD '
-                'greigite Bcr ~75 mT (60-95 mT), SD+MD mixtures ~45 mT, '
-                'MD-dominated ~25 mT; saturates below ~0.3 T'},
+        'B_median_mT': (25.0, 95.0), 'dp': (0.15, 0.35),
+        'skew': (-3.0, 1.0),
+        'source': 'Roberts (2025) pp. 401, 405-406 (SD Bcr ~75 mT [60-95], '
+                  'SD+MD ~45 mT, MD ~24.5 mT; saturates <0.3 T)',
+        'note': 'authigenic ferrimagnetic iron sulphide; SD SFD near-'
+                'symmetric and narrow, left-skewed when SP/MD present; '
+                'overlaps magnetite (both saturate <0.3 T)'},
     'pyrrhotite': {
-        'B_median_mT': (25.0, 150.0), 'dp': (0.20, 0.45),
-        'skew': (-0.5, 0.5),
-        'source': 'Roberts (2025), pyrrhotite chapter',
-        'note': 'monoclinic 4C pyrrhotite; medium- to high-coercivity '
-                'ferrimagnet, Bcr from ~15-20 mT (coarse MD) to ~100-200 mT '
-                '(fine SD), with metamorphic/3C samples reaching >300 mT; '
-                'requires >2 T to saturate, so backfield contributions are '
-                'minimum estimates'},
+        'B_median_mT': (25.0, 200.0), 'dp': (0.20, 0.50),
+        'skew': (-1.0, 5.0),
+        'source': 'Roberts (2025) pp. 369, 373-374, 383 (4C: Bc 16-70 mT by '
+                  'grain size; FORC peaks ~30 mT MD to ~75-125 mT fine SD; '
+                  'metamorphic/3C to >300-400 mT; needs >2 T to saturate)',
+        'note': 'monoclinic 4C (+3C) pyrrhotite; medium- to high-coercivity, '
+                'strongly grain-size/polytype dependent, right-skewed (hard '
+                'tail); backfield under-samples the hard fraction, so '
+                'contributions are minimum estimates'},
     'hematite_pigmentary': {
-        'B_median_mT': (150.0, 700.0), 'dp': (0.35, 0.95),
-        'skew': (-0.5, 1.5),
-        'source': 'Maxbauer et al. (2016); Swanson-Hysell et al. (2019) '
-                  'red bed pigmentary hematite',
-        'note': 'fine pigmentary hematite; broad, often skewed distribution'},
+        'B_median_mT': (150.0, 800.0), 'dp': (0.35, 0.95),
+        'skew': (-2.0, 4.0),
+        'source': 'Ozdemir & Dunlop (2014, JGR 119, 2582-2594, '
+                  'doi:10.1002/2013JB010739): fine (~100s nm) SD hematite, '
+                  'Hc ~150-350 mT for 0.12-0.45 um and up to ~670 mT near '
+                  '0.1 um, Hcr/Hc ~1.45-1.62 -> Bcr ~220 mT to ~1 T; '
+                  'Roberts (2025) pp. 190, 197, 224; Maxbauer et al. (2016) '
+                  'red-bed pigmentary hematite (often fit skew-right)',
+        'note': 'fine pigmentary/authigenic hematite (~100s of nm); intrinsic '
+                'coercivity is high (fine SD) but the natural population is '
+                'broad and often SP-affected, so the bulk median is variable '
+                'and often lower; commonly skew-right; non-saturating in '
+                'ordinary fields, so the median is a lower bound'},
     'hematite_detrital': {
-        'B_median_mT': (500.0, 1500.0), 'dp': (0.18, 0.40),
-        'skew': (-0.5, 1.0),
-        'source': 'Swanson-Hysell et al. (2019); Ozdemir & Dunlop (2014); '
-                  'Roberts (2025) specular / detrital hematite',
-        'note': 'coarser specular/detrital hematite; narrower, '
-                'higher-coercivity than pigmentary hematite; Al-substituted '
-                'hematite coercivity peaks near ~7 mol% Al (~1300 mT) and '
-                'collapses at higher substitution'},
+        'B_median_mT': (400.0, 1500.0), 'dp': (0.18, 0.40),
+        'skew': (-2.0, 3.0),
+        'source': 'Ozdemir & Dunlop (2014, doi:10.1002/2013JB010739): '
+                  'Hc ~ d^-0.61 over the fitting-relevant ~100s nm - 100s um '
+                  'range, so fine specular is hard (several 100 mT to ~1 T) '
+                  'and coarser specular softer (down to ~100-200 mT); '
+                  'Roberts (2025) pp. 197, 224 (stable-SD, narrow, high '
+                  'unblocking 660-680 C); Swanson-Hysell et al. (2019)',
+        'note': 'detrital / specular (specularite) hematite spanning ~100s '
+                'of nm to ~100s of um; well-crystallized and narrower (lower '
+                'dp) than pigmentary hematite, harder when finer. Coercivity '
+                'is grain-size controlled (finer = harder), so a coarser '
+                'specular population overlaps the pigmentary window'},
     'hematite': {
         'B_median_mT': (150.0, 1500.0), 'dp': (0.20, 0.90),
-        'skew': (-0.5, 1.5),
-        'source': 'Ozdemir & Dunlop (2014); Heslop (2015); Roberts (2025)',
-        'note': 'generic hematite window spanning pigmentary and detrital '
-                'end-members; use the specific entries when possible'},
-    'goethite': {
-        'B_median_mT': (300.0, 5000.0), 'dp': (0.20, 0.60),
-        'skew': (-0.5, 1.0),
-        'source': 'Roberts (2025) goethite chapter; Heslop (2015)',
-        'note': 'very high coercivity, but with a huge natural range: '
-                'fitted goethite components span ~300-5000 mT and FORC '
-                'coercivities in well-crystalline goethite exceed 700 mT, '
-                'while Al-substituted and microparticulate goethite can '
-                'fall below ~60 mT. Goethite remanence is unsaturated even '
-                'in 57 T fields, so ordinary backfield/IRM experiments see '
-                'only its low-coercivity tail: treat any fitted goethite '
-                'contribution as a minimum and pass field_max_mT'},
+        'skew': (-2.0, 4.0),
+        'source': 'Ozdemir & Dunlop (2014, doi:10.1002/2013JB010739): over '
+                  'the fitting-relevant ~100s nm - 100s um range hematite Hc '
+                  'varies continuously as ~d^-0.61 (fine SD hard, coarser '
+                  'specular softer); Roberts (2025); Heslop (2015)',
+        'note': 'generic hematite window spanning the pigmentary and '
+                'specular/detrital natural populations (~100s of nm to ~100s '
+                'of um); coercivity is grain-size controlled. Use the specific '
+                'entries when the population is known'},
 }
 
 
@@ -7705,10 +8011,13 @@ def mineral_priors(mineral_names, tighten=1.0, widen=1.0, field_max_mT=None,
     Build a Bayesian-unmixing prior dictionary from named mineral components.
 
     Converts a list of component names from COERCIVITY_COMPONENT_LIBRARY
-    into the `priors` dictionary accepted by unmix_coercivity_bayes, with
-    one location and dispersion (and skew) prior per component. Components
-    are sorted by their central coercivity so that the returned order
-    matches the (low-to-high coercivity) component ordering of the fit.
+    into the `priors` dictionary accepted by unmix_coercivity_bayes, with a
+    mean-coercivity, dispersion, and skew window per component. The mean
+    window constrains the component's mean coercivity directly (the
+    skew-normal location is derived from the sampled dp and skew), so the
+    window is meaningful whatever the fitted skew. Components are sorted by
+    their central coercivity so the returned order matches the (low-to-high
+    coercivity) component ordering of the fit.
 
     The library windows are broad starting points; real samples often need
     them adapted. Use `tighten` to narrow every window, `widen` to broaden
@@ -7736,10 +8045,11 @@ def mineral_priors(mineral_names, tighten=1.0, widen=1.0, field_max_mT=None,
         keeps the library width. tighten and widen compose (net width factor
         = widen / tighten).
     field_max_mT : float, optional
-        Maximum applied field of the measurement (mT). Location upper bounds
-        are clipped to this value, so that components whose window extends
-        past the measured field (e.g. goethite in a 2 T experiment) are not
-        given prior support the data cannot constrain.
+        Maximum applied field of the measurement (mT). Coercivity upper
+        bounds are clipped to this value, so that components whose window
+        extends past the measured field (e.g. hard hematite or pyrrhotite in
+        a 1-2 T experiment) are not given prior support the data cannot
+        constrain.
     overrides : dict, optional
         Per-mineral window replacements, mapping a mineral name to a dict
         with any of 'B_median_mT', 'dp', 'skew' as (low, high) tuples. The
@@ -7751,10 +8061,12 @@ def mineral_priors(mineral_names, tighten=1.0, widen=1.0, field_max_mT=None,
     Returns
     -------
     dict
-        A priors dictionary with 'location', 'dp', and 'skew' keys, each a
-        list of (low, high) tuples in the order of increasing coercivity,
-        suitable for `unmix_coercivity_bayes(..., priors=...)`. The chosen
-        component names, in the same order, are returned under the
+        A priors dictionary with 'mean', 'dp', and 'skew' keys, each a list
+        of (low, high) tuples in the order of increasing coercivity, suitable
+        for `unmix_coercivity_bayes(..., priors=...)`. The 'mean' window
+        constrains each component's MEAN coercivity (log10 mT) -- so a library
+        window means what it says regardless of the component's skew. The
+        chosen component names, in the same order, are returned under the
         'components' key.
     """
     if isinstance(mineral_names, str):
@@ -7790,7 +8102,7 @@ def mineral_priors(mineral_names, tighten=1.0, widen=1.0, field_max_mT=None,
 
     return {
         'components': [item[0] for item in entries],
-        'location': [item[2] for item in entries],
+        'mean': [item[2] for item in entries],
         'dp': [item[3] for item in entries],
         'skew': [item[4] for item in entries],
     }
@@ -7804,6 +8116,159 @@ def _format_mT_axis(ax):
         field = 10 ** value
         return f'{field:g}' if field < 1000 else f'{field:.0f}'
     ax.xaxis.set_major_formatter(FuncFormatter(_fmt))
+
+
+# mineral family (for grouping/colouring the prior library) inferred from the
+# component name, and a colour per family
+_COERCIVITY_FAMILY_COLORS = {
+    'magnetite': '#1f77b4', 'maghemite': '#17becf', 'Fe-sulphide': '#2ca02c',
+    'hematite': '#d62728', 'other': '#7f7f7f'}
+
+
+def _coercivity_family(name):
+    """Mineral family of a COERCIVITY_COMPONENT_LIBRARY component name."""
+    if name.startswith('magnetite'):
+        return 'magnetite'
+    if name.startswith('maghemite'):
+        return 'maghemite'
+    if name in ('greigite', 'pyrrhotite'):
+        return 'Fe-sulphide'
+    if name.startswith('hematite'):
+        return 'hematite'
+    return 'other'
+
+
+def coercivity_prior_table(minerals=None):
+    """
+    Summarize the coercivity-component prior library as a table.
+
+    Parameters
+    ----------
+    minerals : list of str, optional
+        Component names, each a key of COERCIVITY_COMPONENT_LIBRARY. Defaults
+        to the whole library, ordered by central (geometric-mean) coercivity.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per component with its family, mean-coercivity window (mT),
+        dispersion window (dp, log10 units), skew (Azzalini alpha) window, the
+        implied distribution asymmetry, and the leading literature source.
+    """
+    names = list(minerals) if minerals is not None \
+        else list(COERCIVITY_COMPONENT_LIBRARY)
+    rows = []
+    for name in names:
+        if name not in COERCIVITY_COMPONENT_LIBRARY:
+            raise KeyError(f"unknown mineral component '{name}'")
+        entry = COERCIVITY_COMPONENT_LIBRARY[name]
+        b_lo, b_hi = entry['B_median_mT']
+        sk_lo, sk_hi = entry['skew']
+        sk_c = 0.5 * (sk_lo + sk_hi)
+        asymmetry = ('left (low-field tail)' if sk_c < -0.3 else
+                     'right (high-field tail)' if sk_c > 0.3 else
+                     'near-symmetric')
+        rows.append({
+            'component': name,
+            'family': _coercivity_family(name),
+            'mean coercivity (mT)': f'{b_lo:g}-{b_hi:g}',
+            'dp (log10)': f"{entry['dp'][0]:g}-{entry['dp'][1]:g}",
+            'skew (alpha)': f'{sk_lo:g}-{sk_hi:g}',
+            'asymmetry': asymmetry,
+            'central coercivity (mT)': float(np.sqrt(b_lo * b_hi)),
+            'source': entry['source'].split(';')[0],
+        })
+    table = pd.DataFrame(rows).sort_values('central coercivity (mT)')
+    return table.reset_index(drop=True)
+
+
+def plot_coercivity_prior_library(minerals=None, field_range=(1.0, 5e3),
+                                  n_grid=400, figsize=None, ax=None):
+    """
+    Visualize the coercivity-component prior library.
+
+    Draws, for each named mineral component, the skew-normal coercivity
+    distribution implied by the centre of its library windows (mean
+    coercivity, dispersion, and skew) as a ridgeline over a shared log field
+    axis, with the mean-coercivity window drawn as a bar at the baseline and
+    a dot at its centre. Components are coloured by mineral family and ordered
+    by central coercivity, so the coercivity ranges of the different minerals,
+    their characteristic widths and skews, and -- importantly -- their
+    overlaps (the reason a coercivity prior constrains a window rather than
+    identifying a mineral) are all legible at a glance.
+
+    Parameters
+    ----------
+    minerals : list of str, optional
+        Component names to show (default: the whole library).
+    field_range : tuple
+        (min, max) field in mT for the coercivity axis (default 1-5000).
+    n_grid : int
+        Number of points for the density curves.
+    figsize : tuple, optional
+        Figure size; a default is chosen from the number of components.
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw on; a new figure is created if omitted.
+
+    Returns
+    -------
+    tuple
+        (fig, ax).
+    """
+    from matplotlib.patches import Patch
+    names = list(minerals) if minerals is not None \
+        else list(COERCIVITY_COMPONENT_LIBRARY)
+    rows = []
+    for name in names:
+        entry = COERCIVITY_COMPONENT_LIBRARY[name]
+        b_lo, b_hi = entry['B_median_mT']
+        dp_c = 0.5 * (entry['dp'][0] + entry['dp'][1])
+        sk_c = 0.5 * (entry['skew'][0] + entry['skew'][1])
+        rows.append((name, b_lo, b_hi, float(np.sqrt(b_lo * b_hi)), dp_c,
+                     sk_c, _coercivity_family(name)))
+    rows.sort(key=lambda r: r[3])
+
+    x_grid = np.linspace(np.log10(field_range[0]), np.log10(field_range[1]),
+                         n_grid)
+    if figsize is None:
+        figsize = (8.5, 0.7 * len(rows) + 1.2)
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+    for i, (name, b_lo, b_hi, b_c, dp_c, sk_c, family) in enumerate(rows):
+        color = _COERCIVITY_FAMILY_COLORS.get(family, 'grey')
+        # representative shape: centre coercivity is the MEAN, so derive the
+        # skew-normal location from the central dp and skew
+        delta = sk_c / np.sqrt(1.0 + sk_c ** 2)
+        loc = np.log10(b_c) - dp_c * delta * np.sqrt(2.0 / np.pi)
+        density = skewnormal_pdf(x_grid, loc, dp_c, sk_c)
+        density = density / density.max() * 0.85
+        ax.fill_between(x_grid, i, i + density, color=color, alpha=0.5, lw=0)
+        ax.plot(x_grid, i + density, color=color, lw=1)
+        ax.plot([np.log10(b_lo), np.log10(b_hi)], [i, i], color=color,
+                lw=3.5, solid_capstyle='butt')
+        ax.plot(np.log10(b_c), i, 'o', color=color, ms=4, zorder=5)
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels([r[0] for r in rows], fontsize=8.5)
+    _format_mT_axis(ax)
+    decades = range(int(np.floor(np.log10(field_range[0]))),
+                    int(np.ceil(np.log10(field_range[1]))) + 1)
+    ax.set_xticks([d for d in decades])
+    ax.set_xticks([np.log10(m * 10.0 ** d) for d in decades
+                   for m in range(2, 10)], minor=True)
+    ax.set_xlabel('coercivity (mT)')
+    ax.set_xlim(np.log10(field_range[0]), np.log10(field_range[1]))
+    ax.set_ylim(-0.6, len(rows) + 0.2)
+    ax.grid(axis='x', alpha=0.25)
+    families_present = [f for f in _COERCIVITY_FAMILY_COLORS
+                        if any(r[6] == f for r in rows)]
+    ax.legend(handles=[Patch(color=_COERCIVITY_FAMILY_COLORS[f], label=f)
+                       for f in families_present],
+              fontsize=8, loc='lower right', framealpha=0.9,
+              title='mineral family')
+    fig.tight_layout()
+    return fig, ax
 
 
 def _unmixing_component_colors(b_means_mT, color_by, class_boundaries,
@@ -7831,6 +8296,29 @@ def _unmixing_component_colors(b_means_mT, color_by, class_boundaries,
     class_index = np.searchsorted(boundaries, np.asarray(b_means_mT),
                                   side='left')
     return [class_colors[k] for k in class_index]
+
+
+def _result_is_spectrum(result):
+    """
+    Whether result['x']/result['y'] hold the coercivity spectrum rather than
+    the measured curve, i.e. the fit was done in spectrum space. Plot helpers
+    use this so they do not differentiate an already-differentiated spectrum.
+    """
+    method = result.get('method')
+    if method in ('spectrum', 'maxunmix'):
+        return True
+    if method == 'bayes':
+        return result.get('space') == 'spectrum'
+    return False
+
+
+def _result_spectrum(result):
+    """Return (x_mid, spectrum) for a result, without double-differentiating a
+    spectrum-space fit whose x/y are already the spectrum."""
+    x, y = result['x'], result['y']
+    if _result_is_spectrum(result):
+        return x, y
+    return coercivity_spectrum_from_curve(x, y, result['curve_type'])
 
 
 def plot_coercivity_unmixing(result, show_components=True,
@@ -7903,7 +8391,8 @@ def plot_coercivity_unmixing(result, show_components=True,
             boot = result['bayes']
             band_label = '95% credible band'
 
-    plot_as_curve = method in ('curve', 'bayes')
+    plot_as_curve = (method in ('curve', 'bayes')
+                     and result.get('space', 'curve') != 'spectrum')
     n_panels = 2 if plot_as_curve else 1
     if figsize is None:
         figsize = (8, 4.5 * n_panels)
@@ -8205,7 +8694,7 @@ def plot_unmixing_ensemble(result, space='spectrum', n_draws=200, n_grid=300,
     fig, ax = plt.subplots(figsize=figsize)
     # data
     if space == 'spectrum':
-        x_mid, spectrum = coercivity_spectrum_from_curve(x, y, curve_type)
+        x_mid, spectrum = _result_spectrum(result)
         ax.scatter(x_mid, spectrum, s=10, c='grey', alpha=0.5, zorder=3,
                    label='data spectrum')
     else:
@@ -8312,7 +8801,7 @@ def plot_multistart_solutions(result, max_solutions=6, space='spectrum',
     axes_flat = axes.ravel()
 
     if space == 'spectrum':
-        x_data, y_data = coercivity_spectrum_from_curve(x, y, curve_type)
+        x_data, y_data = _result_spectrum(result)
     else:
         x_data, y_data = x, y
 

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -2340,6 +2340,51 @@ def split_hysteresis_loop(field, magnetization):
 
     return upper_branch, lower_branch
 
+def measured_descending_first(field):
+    """Whether the first-measured branch sweeps downward from positive field.
+
+    Gridding canonicalizes a loop to descending-upper-branch-first array
+    order regardless of how it was measured, so the original sweep order must
+    be detected from the raw field values before gridding and passed to the
+    time-order-sensitive drift corrections.
+
+    Parameters
+    ----------
+    field : array_like
+        Raw (ungridded) applied field values in measurement order.
+
+    Returns
+    -------
+    bool
+        True if the sweep starts at the positive field extreme (descending
+        branch measured first), False if it starts at the negative extreme.
+    """
+    field = np.asarray(field, dtype=float)
+    turning_point = find_hysteresis_turning_point(field)
+    return bool(field[0] > field[turning_point])
+
+def _correct_in_measurement_order(H, M, correction):
+    """Apply a time-order-sensitive drift correction to a canonically ordered
+    loop that was measured ascending-first.
+
+    The corrections assume array order equals measurement-time order with the
+    descending upper branch first. For a loop measured ascending-first the
+    canonical (gridded) arrays violate that, so the loop is mapped onto its
+    equivalent descending-first loop in true time order -- a hysteresis loop
+    is odd under (H, M) -> (-H, -M), and the corrections estimate the drift
+    from the branch mismatch without assuming its sign -- corrected there,
+    and mapped back to canonical order.
+    """
+    H = np.asarray(H, dtype=float)
+    M = np.asarray(M, dtype=float)
+    boundary = find_hysteresis_turning_point(H) + 1
+    H_equivalent = np.concatenate([-H[boundary:], -H[:boundary]])
+    M_equivalent = np.concatenate([-M[boundary:], -M[:boundary]])
+    M_cor_equivalent = np.asarray(correction(H_equivalent, M_equivalent))
+    n_second = len(H) - boundary
+    return np.concatenate([-M_cor_equivalent[n_second:],
+                           -M_cor_equivalent[:n_second]])
+
 def grid_hysteresis_loop(field, magnetization):
     '''
     function to grid a hysteresis loop into a regular grid
@@ -3114,7 +3159,26 @@ def calc_Mr_Mrh_Mih_Brh(grid_field, grid_magnetization):
     neg_Mrh = Mrh[np.where(H < 0)]
     Brh_pos = find_y_crossing(pos_H, pos_Mrh, Mr/2)
     Brh_neg = find_y_crossing(neg_H, neg_Mrh, Mr/2)
-    Brh = np.abs((Brh_pos - Brh_neg)/2)
+    # Mrh may never fall to Mr/2 within the measured field range (e.g. a loop
+    # dominated by an unsaturated high-coercivity phase such as hematite);
+    # report Brh as NaN rather than failing, so such loops still process and
+    # the closure test downstream can flag them as open
+    if Brh_pos is None and Brh_neg is None:
+        warnings.warn(
+            'Mrh does not fall to Mr/2 within the measured field range, so '
+            'the median remanent field Brh cannot be determined (NaN); the '
+            'loop likely contains an unsaturated high-coercivity component',
+            RuntimeWarning, stacklevel=2)
+        Brh = np.nan
+    elif Brh_pos is None or Brh_neg is None:
+        found = Brh_pos if Brh_pos is not None else Brh_neg
+        warnings.warn(
+            'the Mr/2 crossing of Mrh was found for only one field polarity; '
+            'Brh is taken from that crossing alone',
+            RuntimeWarning, stacklevel=2)
+        Brh = float(np.abs(found))
+    else:
+        Brh = np.abs((Brh_pos - Brh_neg)/2)
 
     return H, Mr, Mrh, Mih, Me, Brh
 
@@ -3139,6 +3203,22 @@ def calc_Bc(H, M):
 
     upper_Bc = find_y_crossing(upper_branch[0], upper_branch[1])
     lower_Bc = find_y_crossing(lower_branch[0], lower_branch[1])
+    # a branch that never crosses zero within the measured field range (a
+    # loop measured far below the coercivity of a hard component) has no
+    # defined Bc; report NaN rather than failing
+    if upper_Bc is None and lower_Bc is None:
+        warnings.warn(
+            'neither loop branch crosses zero magnetization within the '
+            'measured field range, so Bc cannot be determined (NaN)',
+            RuntimeWarning, stacklevel=2)
+        return np.nan
+    if upper_Bc is None or lower_Bc is None:
+        found = upper_Bc if upper_Bc is not None else lower_Bc
+        warnings.warn(
+            'only one loop branch crosses zero magnetization; Bc is taken '
+            'from that crossing alone',
+            RuntimeWarning, stacklevel=2)
+        return float(np.abs(found))
     Bc = np.abs((upper_Bc - lower_Bc) / 2)
 
     return Bc
@@ -3272,26 +3352,37 @@ def hyst_loop_saturation_test(grid_field, grid_magnetization, max_field_cutoff=0
     0.8 False
     """
     
-    FNL60 = loop_saturation_stats(grid_field, grid_magnetization, HF_cutoff=0.6, max_field_cutoff = max_field_cutoff)['FNL']
-    FNL70 = loop_saturation_stats(grid_field, grid_magnetization, HF_cutoff=0.7, max_field_cutoff = max_field_cutoff)['FNL']
-    FNL80 = loop_saturation_stats(grid_field, grid_magnetization, HF_cutoff=0.8, max_field_cutoff = max_field_cutoff)['FNL']
+    # a window with too few high-field pairs for the lack-of-fit test (sparse
+    # quick-scan loops) reports FNL as NaN with a warning rather than aborting
+    # the whole processing pipeline
+    FNL_by_cutoff = {}
+    for HF_cutoff in (0.6, 0.7, 0.8):
+        try:
+            FNL_by_cutoff[HF_cutoff] = loop_saturation_stats(
+                grid_field, grid_magnetization, HF_cutoff=HF_cutoff,
+                max_field_cutoff=max_field_cutoff)['FNL']
+        except ValueError as error:
+            warnings.warn(
+                f'saturation test window starting at {HF_cutoff:.0%} of the '
+                f'maximum field skipped ({error}); its FNL is NaN',
+                RuntimeWarning, stacklevel=2)
+            FNL_by_cutoff[HF_cutoff] = np.nan
+    FNL60, FNL70, FNL80 = (FNL_by_cutoff[c] for c in (0.6, 0.7, 0.8))
 
-    saturation_cutoff = 0
-    if (FNL80 > 2.5) & (FNL70 > 2.5) & (FNL60 > 2.5):
-        saturation_cutoff = 0.92 # IRM default
-    else:
-        if FNL80 < 2.5:  #saturated at 80%
-            saturation_cutoff = 0.8
-        if FNL70 < 2.5:  #saturated at 70%
-            saturation_cutoff = 0.7
-        if FNL60 < 2.5:  #saturated at 60%
-            saturation_cutoff = 0.6
+    # lowest tested window with statistically linear (FNL < 2.5) high-field
+    # behavior; 0.92 (the IRM default nonlinear-fit window) if none is linear
+    # or no window could be tested
+    saturation_cutoff = 0.92
+    for HF_cutoff in (0.8, 0.7, 0.6):
+        FNL = FNL_by_cutoff[HF_cutoff]
+        if np.isfinite(FNL) and FNL < 2.5:
+            saturation_cutoff = HF_cutoff
     results = {'FNL60':FNL60, 'FNL70':FNL70, 'FNL80':FNL80, 'saturation_cutoff':saturation_cutoff, 'loop_is_saturated':(saturation_cutoff != 0.92)}
     results_dict = dict_in_native_python(results)
     return results_dict
 
 
-def loop_closure_test(H, Mrh, Me=None, HF_cutoff=0.8, max_field_cutoff=0.99):
+def loop_closure_test(H, Mrh, HF_cutoff=0.8, *, Me=None, max_field_cutoff=0.99):
     '''
     function for testing whether a hysteresis loop is closed at high fields
 
@@ -3314,12 +3405,12 @@ def loop_closure_test(H, Mrh, Me=None, HF_cutoff=0.8, max_field_cutoff=0.99):
         field values of the upper branch (ascending)
     Mrh: array-like
         remanent hysteretic magnetization Mrh(H)
-    Me: array-like, optional
-        error curve err(H) on the same field axis (as returned by
-        calc_Mr_Mrh_Mih_Brh); used as the noise estimate when provided
     HF_cutoff: float
         high field cutoff value taken as fraction of the max field value
-    max_field_cutoff: float
+    Me: array-like, optional, keyword-only
+        error curve err(H) on the same field axis (as returned by
+        calc_Mr_Mrh_Mih_Brh); used as the noise estimate when provided
+    max_field_cutoff: float, keyword-only
         upper trim of the high-field windows as fraction of the max field
 
     Returns
@@ -3383,7 +3474,7 @@ def loop_closure_test(H, Mrh, Me=None, HF_cutoff=0.8, max_field_cutoff=0.99):
     return results
 
 
-def drift_correction_Me(H, M):
+def drift_correction_Me(H, M, descending_first=True):
     """
     Perform default IRM drift correction for a hysteresis loop based on the Me method.
 
@@ -3392,12 +3483,24 @@ def drift_correction_Me(H, M):
     which is the sum of the upper and reversed lower branches of the hysteresis loop.
     The correction method adapts depending on whether significant drift is detected in the high-field region.
 
+    The drift estimate depends on measurement-time order, and the arrays are
+    expected in canonical order (descending upper branch first, as produced
+    by `grid_hysteresis_loop`). For a loop originally measured from negative
+    saturation, pass descending_first=False (detected from the raw field
+    values with `measured_descending_first`) so the correction is applied in
+    true time order rather than with the opposite time sense.
+
     Parameters
     ----------
     H : numpy.ndarray
-        Array of magnetic field values.
+        Array of magnetic field values, in canonical (descending-upper-
+        branch-first) order.
     M : numpy.ndarray
         Array of measured magnetization values corresponding to `H`.
+    descending_first : bool, optional
+        Whether the loop was originally measured with the descending branch
+        first (default True). Use `measured_descending_first` on the raw
+        field values to determine this for a gridded loop.
 
     Returns
     -------
@@ -3412,6 +3515,8 @@ def drift_correction_Me(H, M):
     >>> plot(H, M, label='Original')
     >>> plot(H, M_cor, label='Drift Corrected')
     """
+    if not descending_first:
+        return _correct_in_measurement_order(H, M, drift_correction_Me)
     # split loop branches
     upper_branch, lower_branch = split_hysteresis_loop(H, M)
     # calculate Me
@@ -3449,31 +3554,39 @@ def drift_correction_Me(H, M):
             M_cor[i] = M[i] - Me_running_mean[i]
         return M_cor
     
-def prorated_drift_correction(field, magnetization):
+def prorated_drift_correction(field, magnetization, descending_first=True):
     '''
     function to correct for the linear drift of a hysteresis loop
         take the difference between the magnetization measured at the maximum field on the upper and lower branches
         apply linearly prorated correction of M(H)
         this should be applied to the gridded data
 
-    Note: the prorated ramp assumes the array order corresponds to measurement
-    time with the upper (descending) branch first, which is the order produced
-    by `grid_hysteresis_loop`. For loops originally measured in the opposite
-    sweep order the correction still closes the loop but attributes the drift
-    with the opposite sense.
+    The prorated ramp runs in measurement-time order, and the arrays are
+    expected in canonical order (descending upper branch first, as produced
+    by `grid_hysteresis_loop`). For a loop originally measured from negative
+    saturation, pass descending_first=False (detected from the raw field
+    values with `measured_descending_first`) so the ramp is applied in true
+    time order rather than with the opposite time sense.
 
     Parameters
     ----------
     field : numpy array
-        field values
+        field values, in canonical (descending-upper-branch-first) order
     magnetization : numpy array
         magnetization values
+    descending_first : bool, optional
+        Whether the loop was originally measured with the descending branch
+        first (default True). Use `measured_descending_first` on the raw
+        field values to determine this for a gridded loop.
 
     Returns
     -------
     corrected_magnetization : numpy array
         corrected magnetization values
     '''
+    if not descending_first:
+        return _correct_in_measurement_order(field, magnetization,
+                                             prorated_drift_correction)
 
     field = np.array(field)
     magnetization = np.array(magnetization)
@@ -3837,6 +3950,11 @@ def process_hyst_loop(field, magnetization, specimen_name='', show_results_table
     # pairs, warns on apparent non-tesla field units)
     field, magnetization = sanitize_hysteresis_inputs(field, magnetization)
 
+    # record the original sweep order before gridding canonicalizes it: the
+    # drift correction is time-order sensitive and needs to know whether the
+    # loop was measured from positive or negative saturation
+    descending_first = measured_descending_first(field)
+
     # first grid the data into symmetric field values
     grid_fields, grid_magnetizations = grid_hysteresis_loop(field, magnetization)
 
@@ -3860,14 +3978,15 @@ def process_hyst_loop(field, magnetization, specimen_name='', show_results_table
 
     centered_H, centered_M = loop_centering_results['centered_H'], loop_centering_results['centered_M']
 
-    # drift correction
-    drift_corr_M = drift_correction_Me(centered_H, centered_M)
+    # drift correction, applied in the loop's true measurement-time order
+    drift_corr_M = drift_correction_Me(centered_H, centered_M,
+                                       descending_first=descending_first)
 
     # calculate Mr, Mrh, Mih, Me, Brh
     H, Mr, Mrh, Mih, Me, Brh = calc_Mr_Mrh_Mih_Brh(centered_H, drift_corr_M)
 
     # check if the loop is closed
-    loop_closure_test_results = loop_closure_test(H, Mrh, Me)
+    loop_closure_test_results = loop_closure_test(H, Mrh, Me=Me)
 
     # check if the loop is saturated (high field linearity test)
     loop_saturation_stats = hyst_loop_saturation_test(centered_H, drift_corr_M)
@@ -3917,8 +4036,9 @@ def process_hyst_loop(field, magnetization, specimen_name='', show_results_table
         p_slope_corr.line(H, Me, line_color='brown', legend_label='Me', line_width=1)
         if show_plot:
             show(p_slope_corr)
-    results = {'gridded_H': grid_fields, 
-               'gridded_M': grid_magnetizations, 
+    results = {'gridded_H': grid_fields,
+               'gridded_M': grid_magnetizations,
+               'measured_descending_first': descending_first,
                'linearity_test_results': loop_linearity_test_results,
                'loop_is_linear': loop_linearity_test_results['loop_is_linear'],
                'FNL': loop_linearity_test_results['FNL'],
@@ -4092,7 +4212,10 @@ def add_hyst_stats_to_specimens_table(specimens_df, hyst_results, overwrite=True
     for _, row in hyst_results.iterrows():
         specimen_name = row['specimen']
         experiment_name = row['experiment']
-        mask = specimens_df['experiments'] == experiment_name
+        # colon-delimited 'experiments' cells (several experiments per row)
+        # must match the single experiment name, so use the shared token
+        # matching rather than exact equality
+        mask = _match_specimen_rows(specimens_df, experiment_name, None)
 
         if overwrite:
             if not mask.any():
@@ -4108,7 +4231,8 @@ def add_hyst_stats_to_specimens_table(specimens_df, hyst_results, overwrite=True
                     [specimens_df, new_row.to_frame().T],
                     ignore_index=True,
                 )
-                mask = specimens_df['experiments'] == experiment_name
+                mask = _match_specimen_rows(specimens_df, experiment_name,
+                                            None)
             ipos = mask.values.nonzero()[0][0]
         else:
             # overwrite=False: leave existing row alone, always add a new row
@@ -4129,24 +4253,19 @@ def add_hyst_stats_to_specimens_table(specimens_df, hyst_results, overwrite=True
         for result_key, col in zip(result_keys_MagIC, MagIC_columns):
             specimens_df.iloc[ipos, specimens_df.columns.get_loc(col)] = row[result_key]
 
-        # build and write additional stats into description
+        # merge the additional stats into the description cell using the
+        # shared 'free text | JSON' convention, so hysteresis and unmixing
+        # writers can round-trip each other's cells. parse_specimen_description
+        # also reads legacy Python-dict cells written by older versions.
         additional_stats_dict = {key: row[key] for key in additional_keys
                                  if key in row.index}
         desc_col = specimens_df.columns.get_loc('description')
-        desc = specimens_df.iloc[ipos, desc_col]
-        if isinstance(desc, str):
-            try:
-                description_dict = eval(desc)
-                if isinstance(description_dict, dict):
-                    description_dict.update(additional_stats_dict)
-                    specimens_df.iloc[ipos, desc_col] = str(description_dict)
-                else:
-                    raise ValueError
-            except (SyntaxError, ValueError, NameError):
-                additional_stats_dict['description'] = desc
-                specimens_df.iloc[ipos, desc_col] = str(additional_stats_dict)
-        else:
-            specimens_df.iloc[ipos, desc_col] = str(additional_stats_dict)
+        text, description_dict = parse_specimen_description(
+            specimens_df.iloc[ipos, desc_col])
+        description_dict.update(dict_in_native_python(additional_stats_dict))
+        payload = json.dumps(description_dict)
+        specimens_df.iloc[ipos, desc_col] = (f'{text} | {payload}' if text
+                                             else payload)
 
     return specimens_df
 
@@ -9463,10 +9582,16 @@ _UNMIXING_ROW_MARKER = 'coercivity_unmixing_component_row'
 
 
 def _match_specimen_rows(specimens_df, experiment_name, specimen_name):
-    """Boolean mask of specimens rows matching an experiment (or specimen)."""
+    """Boolean mask of specimens rows matching an experiment (or specimen).
+
+    An 'experiments' cell may hold a single name or a colon-delimited list,
+    so cells are split on ':' and each token compared exactly -- a substring
+    match would let experiment 'EXP1' also claim 'EXP10'.
+    """
+    name = str(experiment_name)
     if 'experiments' in specimens_df.columns:
-        mask = specimens_df['experiments'].astype(str).str.contains(
-            str(experiment_name), na=False, regex=False)
+        mask = specimens_df['experiments'].apply(
+            lambda cell: name in str(cell).split(':'))
     else:
         mask = pd.Series(False, index=specimens_df.index)
     if not mask.any() and 'specimen' in specimens_df.columns:

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -9151,10 +9151,18 @@ def unmix_backfield_experiments(measurements, experiments=None,
             if initial is not None:
                 initial = initial.copy()
 
-            # methods operating on the derivative use the (optionally
-            # smoothed) curve; the measurement-space method always fits
-            # the unsmoothed data
-            x_fit, M_fit = (x, M) if method == 'curve' else (x_s, M_s)
+            # The finite-difference least-squares methods ('spectrum',
+            # 'maxunmix') fit the optionally smoothed curve, because
+            # differentiating the raw curve amplifies its noise. The
+            # measurement-space ('curve') and Bayesian methods fit the
+            # unsmoothed data so their noise models -- the Bayesian methods
+            # infer an explicit noise level -- see the true measurement noise;
+            # feeding them the denoised curve would understate the noise and
+            # yield overconfident credible intervals. (A Bayesian fit with
+            # space='spectrum' differentiates the curve it is given
+            # internally, so it too must receive the unsmoothed data.)
+            x_fit, M_fit = ((x_s, M_s) if method in ('spectrum', 'maxunmix')
+                            else (x, M))
             if method == 'maxunmix':
                 method_kwargs.setdefault('n_boot', n_boot if n_boot > 0
                                          else 100)

--- a/pmagpy/test/test_rockmag_hysteresis.py
+++ b/pmagpy/test/test_rockmag_hysteresis.py
@@ -1,0 +1,456 @@
+"""
+Tests for the hysteresis loop processing suite in rockmag.py.
+
+The processing follows the protocol of Jackson and Solheid (2010,
+doi:10.1029/2009GC002932): loop gridding, symmetry-based centering, the Q
+signal-to-noise quality factor, drift correction, whole-loop and high-field
+linearity F tests, loop closure testing, and linear vs. nonlinear
+(approach-to-saturation) high-field fitting. Synthetic loops with known
+parameters (Ms, Mr, Bc, chi_HF) provide analytical expectations.
+"""
+import numpy as np
+import pytest
+
+from pmagpy import rockmag as rmag
+
+
+RNG = np.random.default_rng(2026)
+
+
+def synthetic_loop(n_half=200, Hmax=1.0, Ms=1.0, Bc=0.05, w=0.03, chi=0.0,
+                   noise=0.0, H_offset=0.0, M_offset=0.0, drift=0.0,
+                   hard_Ms=0.0, hard_Bc=0.7, hard_w=0.5,
+                   ats_alpha=0.0, rng=RNG):
+    """Two-branch synthetic loop measured +Hmax -> -Hmax -> +Hmax.
+
+    The ferromagnetic component is Ms*tanh((H +/- Bc)/w), so the remanence is
+    Mr = Ms*tanh(Bc/w) and the branch zero crossings are at -/+Bc when no
+    other contributions are added. Optional contributions:
+      chi       linear (paramagnetic) slope in raw slope units (M per T)
+      noise     gaussian measurement noise
+      H_offset  horizontal loop shift (e.g. sensor offset)
+      M_offset  vertical loop shift
+      drift     linear-in-time drift amplitude accumulated over the loop
+      hard_Ms   wide-coercivity component that stays open at Hmax
+      ats_alpha approach-to-saturation curvature -alpha/H applied smoothly
+                above 0.3*Hmax (unsaturated ferromagnetic moment)
+    """
+    H_upper = np.linspace(Hmax, -Hmax, n_half)
+    H_lower = np.linspace(-Hmax, Hmax, n_half)
+
+    def branch(H, sign):
+        M = Ms * np.tanh((H + sign * Bc) / w)
+        if hard_Ms != 0.0:
+            M = M + hard_Ms * np.tanh((H + sign * hard_Bc) / hard_w)
+        if ats_alpha != 0.0:
+            # curvature only where the tanh is saturated, tapering smoothly
+            # to zero below 0.3*Hmax so low fields are not distorted
+            taper = 0.5 * (1 + np.tanh((np.abs(H) - 0.3 * Hmax) / (0.1 * Hmax)))
+            M = M - ats_alpha * taper * np.sign(H) / np.maximum(np.abs(H), 0.3 * Hmax)
+        return M + chi * H
+
+    H = np.concatenate([H_upper, H_lower]) + H_offset
+    M = np.concatenate([branch(H_upper, +1), branch(H_lower, -1)]) + M_offset
+    M = M + drift * np.linspace(0, 1, M.size)
+    if noise:
+        M = M + noise * rng.standard_normal(M.size)
+    return H, M
+
+
+class TestTurningPointAndPlateaus:
+    """Robust branch splitting (issue #876): plateaus, glitches, and the
+    plateau-collapse helper."""
+
+    def test_turning_point_simple(self):
+        H, M = synthetic_loop()
+        tp = rmag.find_hysteresis_turning_point(H)
+        assert H[tp] == pytest.approx(np.min(H))
+        assert np.all(np.diff(H[:tp + 1]) <= 0)
+        assert np.all(np.diff(H[tp + 1:]) >= 0)
+
+    def test_turning_point_with_tip_plateaus(self):
+        # repeated field readings at the loop tips, as recorded by a VSM
+        # holding the field while averaging
+        H, M = synthetic_loop()
+        H_rep = np.concatenate([[H[0]] * 3, H, [H[-1]] * 3])
+        M_rep = np.concatenate([[M[0]] * 3, M, [M[-1]] * 3])
+        tp = rmag.find_hysteresis_turning_point(H_rep)
+        assert H_rep[tp] == pytest.approx(np.min(H_rep))
+        upper, lower = rmag.split_hysteresis_loop(H_rep, M_rep)
+        assert np.max(upper[0]) == pytest.approx(np.max(H_rep))
+        assert np.max(lower[0]) == pytest.approx(np.max(H_rep))
+
+    def test_turning_point_with_field_glitch(self):
+        # a small non-monotonic field glitch away from the reversal must not
+        # be mistaken for the turning point
+        H, M = synthetic_loop()
+        H_glitch = H.copy()
+        H_glitch[50] = H_glitch[49] + 1e-4  # brief backwards step mid-branch
+        tp = rmag.find_hysteresis_turning_point(H_glitch)
+        assert abs(H_glitch[tp] - np.min(H_glitch)) < 0.02
+
+    def test_monotonic_field_raises(self):
+        with pytest.raises(ValueError):
+            rmag.find_hysteresis_turning_point(np.linspace(1, -1, 50))
+        with pytest.raises(ValueError):
+            rmag.find_hysteresis_turning_point(np.ones(50))
+
+    def test_collapse_plateaus_averages_moments(self):
+        field = np.array([1.0, 1.0, 1.0, 0.5, 0.0, 0.0])
+        moment = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 7.0])
+        cf, cm = rmag.collapse_hysteresis_field_plateaus(field, moment)
+        assert np.allclose(cf, [1.0, 0.5, 0.0])
+        assert np.allclose(cm, [2.0, 4.0, 6.0])
+
+    def test_gridding_with_plateaus_recovers_parameters(self):
+        # full pipeline entry: plateaus at the tips should not degrade
+        # gridding or the recovered parameters
+        Ms, Bc, w = 1.0, 0.05, 0.03
+        H, M = synthetic_loop(Ms=Ms, Bc=Bc, w=w, noise=2e-4)
+        H_rep = np.concatenate([[H[0]] * 3, H, [H[-1]] * 3])
+        M_rep = np.concatenate([[M[0]] * 3, M, [M[-1]] * 3])
+        gH, gM = rmag.grid_hysteresis_loop(H_rep, M_rep)
+        upper, lower = rmag.split_hysteresis_loop(gH, gM)
+        assert np.allclose(upper[0], lower[0])
+        Hu, Mr, Mrh, Mih, Me, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
+        assert Mr == pytest.approx(Ms * np.tanh(Bc / w), rel=0.01)
+        assert rmag.calc_Bc(gH, gM) == pytest.approx(Bc, abs=1e-3)
+
+
+class TestInputHandling:
+    """The processing functions must accept data from any stream, not just
+    MagIC measurement tables: plain lists, numeric strings, either field
+    sweep order, and files containing non-finite rows."""
+
+    def test_plain_lists_and_numeric_strings(self):
+        H, M = synthetic_loop(noise=5e-4, chi=0.2)
+        from_arrays = rmag.process_hyst_loop(H, M, show_results_table=False,
+                                             show_plot=False)
+        from_lists = rmag.process_hyst_loop(list(H), list(M),
+                                            show_results_table=False,
+                                            show_plot=False)
+        from_strings = rmag.process_hyst_loop([str(x) for x in H],
+                                              [str(x) for x in M],
+                                              show_results_table=False,
+                                              show_plot=False)
+        assert from_lists['Ms'] == pytest.approx(from_arrays['Ms'])
+        assert from_strings['Ms'] == pytest.approx(from_arrays['Ms'])
+
+    def test_ascending_first_sweep_order(self):
+        # a loop measured from negative saturation upward must give the same
+        # parameters as the same loop measured from positive saturation down
+        H, M = synthetic_loop(noise=5e-4, chi=0.2)
+        half = len(H) // 2
+        H_asc = np.concatenate([H[half:], H[:half]])
+        M_asc = np.concatenate([M[half:], M[:half]])
+        r_desc = rmag.process_hyst_loop(H, M, show_results_table=False,
+                                        show_plot=False)
+        r_asc = rmag.process_hyst_loop(H_asc, M_asc, show_results_table=False,
+                                       show_plot=False)
+        assert r_asc['Mr'] == pytest.approx(r_desc['Mr'], rel=0.01)
+        assert r_asc['Ms'] == pytest.approx(r_desc['Ms'], rel=0.01)
+        assert r_asc['Bc'] == pytest.approx(r_desc['Bc'], rel=0.02)
+        assert r_asc['Mr'] > 0
+
+    def test_nonfinite_pairs_dropped(self, capsys):
+        H, M = synthetic_loop(noise=5e-4, chi=0.2)
+        M_bad = M.copy()
+        M_bad[[10, 200]] = np.nan
+        r_bad = rmag.process_hyst_loop(H, M_bad, show_results_table=False,
+                                       show_plot=False)
+        r_clean = rmag.process_hyst_loop(H, M, show_results_table=False,
+                                         show_plot=False)
+        assert 'dropping 2 measurement(s)' in capsys.readouterr().out
+        assert r_bad['Ms'] == pytest.approx(r_clean['Ms'], rel=0.01)
+
+    def test_sanitize_errors(self):
+        with pytest.raises(ValueError):
+            rmag.sanitize_hysteresis_inputs([1.0, 'not a number'], [0.0, 0.0])
+        with pytest.raises(ValueError):
+            rmag.sanitize_hysteresis_inputs([1.0] * 5, [0.0] * 5)  # too few
+        with pytest.raises(ValueError):
+            rmag.sanitize_hysteresis_inputs([1.0, np.nan] * 10, [0.0] * 20,
+                                            drop_nonfinite=False)
+
+    def test_non_tesla_field_warning(self, capsys):
+        H, M = synthetic_loop(noise=5e-4)
+        rmag.sanitize_hysteresis_inputs(H * 1000, M)  # fields in mT
+        assert 'not in tesla' in capsys.readouterr().out
+
+    def test_grid_rejects_nonfinite(self):
+        H, M = synthetic_loop()
+        M[5] = np.nan
+        with pytest.raises(ValueError):
+            rmag.grid_hysteresis_loop(H, M)
+
+
+class TestLoopGeometry:
+    def test_split_branches(self):
+        H, M = synthetic_loop()
+        upper, lower = rmag.split_hysteresis_loop(H, M)
+        # upper branch is returned in ascending field order
+        assert np.all(np.diff(upper[0]) > 0)
+        assert np.all(np.diff(lower[0]) > 0)
+        # at a given field the upper (descending) branch moment is higher
+        mid = len(upper[0]) // 2
+        interp_lower = np.interp(upper[0][mid], lower[0], lower[1])
+        assert upper[1][mid] > interp_lower
+
+    def test_gridding_symmetric_fields(self):
+        H, M = synthetic_loop(noise=1e-4)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        upper, lower = rmag.split_hysteresis_loop(gH, gM)
+        # the two branches share a field grid that is symmetric about zero
+        assert np.allclose(upper[0], lower[0])
+        assert np.allclose(np.sort(upper[0]), np.sort(-upper[0]))
+
+    def test_gridding_preserves_moments(self):
+        H, M = synthetic_loop()
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        upper, _ = rmag.split_hysteresis_loop(gH, gM)
+        expected = np.tanh((upper[0] + 0.05) / 0.03)
+        assert np.allclose(upper[1], expected, atol=2e-3)
+
+
+class TestQualityFactor:
+    def test_Q_matches_hystlab_convention(self):
+        # Q = log10(1/sqrt(1 - R^2)) of the branch-symmetry regression --
+        # the convention of the IRM software and HystLab (Paterson et al.,
+        # 2018, eq. 4), which those authors document as the definition used
+        # for the values reported in Jackson and Solheid (2010) even though
+        # the equation printed in that paper omits the square root
+        H, M = synthetic_loop(noise=1e-3)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        _, Q = rmag.calc_Q(gH, gM)
+        r2 = rmag.loop_H_off(gH, gM, 0.0)['r2']
+        Q_expected = np.log10(1.0 / np.sqrt(1.0 - r2))
+        assert Q == pytest.approx(Q_expected, abs=0.05)
+
+    def test_Q_decreases_with_noise(self):
+        Qs = []
+        for noise in [1e-4, 1e-3, 1e-2]:
+            H, M = synthetic_loop(noise=noise)
+            gH, gM = rmag.grid_hysteresis_loop(H, M)
+            Qs.append(rmag.calc_Q(gH, gM)[1])
+        assert Qs[0] > Qs[1] > Qs[2]
+        # tenfold noise increase lowers the amplitude-ratio Q by ~1
+        assert Qs[0] - Qs[1] == pytest.approx(1.0, abs=0.15)
+
+
+class TestCentering:
+    def test_recovers_known_offsets(self):
+        H, M = synthetic_loop(noise=5e-4, H_offset=0.004, M_offset=0.02)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        results = rmag.hyst_loop_centering(gH, gM)
+        assert results['opt_H_offset'] == pytest.approx(0.004, abs=5e-4)
+        assert results['opt_M_offset'] == pytest.approx(0.02, abs=2e-3)
+
+    def test_Q_reflects_post_centering_quality(self):
+        # Q must be computed after offset correction (Jackson and Solheid,
+        # 2010, section 3; HystLab computes Q on offset-corrected curves) --
+        # otherwise a loop offset depresses Q below the decision gate that
+        # controls whether the offset correction is applied at all
+        H, M = synthetic_loop(noise=5e-4)
+        H_off, M_off = synthetic_loop(noise=5e-4, H_offset=0.002, M_offset=0.01)
+        Q_clean = rmag.hyst_loop_centering(*rmag.grid_hysteresis_loop(H, M))['Q']
+        Q_offset = rmag.hyst_loop_centering(*rmag.grid_hysteresis_loop(H_off, M_off))['Q']
+        assert Q_offset == pytest.approx(Q_clean, abs=0.3)
+        assert Q_offset > 2
+
+    def test_centered_loop_crossings(self):
+        H, M = synthetic_loop(noise=5e-4, H_offset=0.004, M_offset=0.02)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        results = rmag.hyst_loop_centering(gH, gM)
+        Bc = rmag.calc_Bc(results['centered_H'], results['centered_M'])
+        assert Bc == pytest.approx(0.05, abs=1e-3)
+
+
+class TestLinearityTest:
+    def test_paramagnet_is_linear(self):
+        # pure paramagnetic response with noise: no significant nonlinearity
+        H, M = synthetic_loop(Ms=0.0, Bc=0.0, chi=1.0, noise=5e-3)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        results = rmag.hyst_linearity_test(gH, gM)
+        assert results['loop_is_linear']
+
+    def test_ferromagnet_is_nonlinear(self):
+        H, M = synthetic_loop(noise=1e-3)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        results = rmag.hyst_linearity_test(gH, gM)
+        assert not results['loop_is_linear']
+        assert results['FNL'] > 1.25
+
+
+class TestSaturationTest:
+    def test_saturated_loop(self):
+        # tanh ferromagnet saturates well below 0.6*Hmax; FNL should be
+        # near 1 (pure noise) in all high-field windows
+        H, M = synthetic_loop(noise=5e-4, chi=0.2)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        results = rmag.hyst_loop_saturation_test(gH, gM)
+        assert results['loop_is_saturated']
+        for key in ['FNL60', 'FNL70', 'FNL80']:
+            assert results[key] < 2.5
+            assert results[key] > 0  # F statistics are non-negative
+
+    def test_unsaturated_loop(self):
+        H, M = synthetic_loop(noise=1e-4, chi=0.2, ats_alpha=0.1)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        results = rmag.hyst_loop_saturation_test(gH, gM)
+        assert not results['loop_is_saturated']
+        assert results['FNL60'] > 2.5
+        assert results['saturation_cutoff'] == 0.92
+
+
+class TestClosureTest:
+    @staticmethod
+    def _closure(H, M, use_Me=True):
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        Hu, Mr, Mrh, Mih, Me, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
+        return rmag.loop_closure_test(Hu, Mrh, Me if use_Me else None)
+
+    def test_closed_loop(self):
+        H, M = synthetic_loop(noise=2e-3)
+        results = self._closure(H, M)
+        assert results['loop_is_closed']
+
+    def test_open_loop(self):
+        # wide-coercivity (hematite-like) component keeps the loop open
+        H, M = synthetic_loop(noise=2e-3, hard_Ms=0.1)
+        results = self._closure(H, M)
+        assert not results['loop_is_closed']
+        assert results['SNR'] > 8
+        assert results['HAR'] > -48
+
+    def test_fallback_without_Me(self):
+        # without the err curve the odd part of Mrh serves as the noise;
+        # classifications should agree away from the decision boundary
+        H, M = synthetic_loop(noise=2e-3)
+        assert self._closure(H, M, use_Me=False)['loop_is_closed']
+        H, M = synthetic_loop(noise=2e-3, hard_Ms=0.1)
+        assert not self._closure(H, M, use_Me=False)['loop_is_closed']
+
+    def test_noise_convention_vs_odd_part(self):
+        # the err(H)-based noise (HystLab convention) sits ~3 dB below the
+        # odd-part fallback for white noise, so Me-based SNR is lower
+        H, M = synthetic_loop(noise=2e-3, hard_Ms=0.1)
+        snr_me = self._closure(H, M, use_Me=True)['SNR']
+        snr_odd = self._closure(H, M, use_Me=False)['SNR']
+        assert snr_me == pytest.approx(snr_odd - 3.0, abs=2.0)
+
+
+class TestDriftCorrection:
+    def test_prorated_removes_closure_error(self):
+        H, M = synthetic_loop(drift=0.02)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        corrected = rmag.prorated_drift_correction(gH, gM)
+        assert corrected[0] - corrected[-1] == pytest.approx(0.0, abs=1e-12)
+        # correction is distributed with zero mean (no net vertical shift)
+        assert np.mean(corrected - gM) == pytest.approx(0.0, abs=1e-12)
+
+    def test_symmetric_averaging_closes_loop(self):
+        H, M = synthetic_loop(drift=0.02)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        corrected = rmag.symmetric_averaging_drift_corr(gH, gM)
+        upper, lower = rmag.split_hysteresis_loop(gH, corrected)
+        # branches meet at both tips after correction
+        assert upper[1][0] == pytest.approx(lower[1][0], abs=1e-12)
+        assert upper[1][-1] == pytest.approx(lower[1][-1], abs=1e-12)
+
+
+class TestParameterRecovery:
+    def test_Mr_Bc_recovery(self):
+        Ms, Bc, w = 1.0, 0.05, 0.03
+        H, M = synthetic_loop(Ms=Ms, Bc=Bc, w=w, noise=2e-4)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        Hu, Mr, Mrh, Mih, Me, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
+        assert Mr == pytest.approx(Ms * np.tanh(Bc / w), rel=0.01)
+        assert rmag.calc_Bc(gH, gM) == pytest.approx(Bc, abs=1e-3)
+
+    def test_linear_HF_fit_recovers_chi_and_Ms(self):
+        chi = 0.2  # raw slope units (moment per Tesla)
+        H, M = synthetic_loop(chi=chi, noise=2e-4)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        chi_HF, Ms = rmag.linear_HF_fit(gH, gM, HF_cutoff=0.8)
+        # chi_HF is reported in SI units: raw slope times mu_0
+        assert chi_HF == pytest.approx(chi * 4 * np.pi / 1e7, rel=0.01)
+        assert Ms == pytest.approx(1.0, rel=0.01)
+
+    def test_slope_correction_roundtrip(self):
+        chi = 0.2
+        H, M = synthetic_loop(chi=chi, noise=0.0)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        chi_HF, _ = rmag.linear_HF_fit(gH, gM, HF_cutoff=0.8)
+        ferro = rmag.hyst_slope_correction(gH, gM, chi_HF)
+        expected_upper, _ = rmag.split_hysteresis_loop(gH, ferro)
+        assert np.allclose(
+            expected_upper[1],
+            np.tanh((expected_upper[0] + 0.05) / 0.03),
+            atol=5e-3,
+        )
+
+
+class TestNonlinearFit:
+    def test_ats_fit_beats_linear_fit(self):
+        # unsaturated loop: linear high-field fitting underestimates Ms
+        # while approach-to-saturation fitting recovers it
+        H, M = synthetic_loop(noise=1e-4, chi=0.2, ats_alpha=0.1)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        nl = rmag.hyst_HF_nonlinear_optimization(gH, gM, 0.6, 'IRM')
+        _, Ms_linear = rmag.linear_HF_fit(gH, gM, HF_cutoff=0.8)
+        assert abs(nl['Ms'] - 1.0) < abs(Ms_linear - 1.0)
+        assert nl['Ms'] == pytest.approx(1.0, rel=0.02)
+
+    def test_Fnl_lin_is_f_statistic(self):
+        # significant nonlinearity: Fnl_lin far above the ~3-3.5 critical value
+        H, M = synthetic_loop(noise=1e-4, chi=0.2, ats_alpha=0.1)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        nl = rmag.hyst_HF_nonlinear_optimization(gH, gM, 0.6, 'IRM')
+        assert nl['Fnl_lin'] > 3.5
+        # verify against a direct computation of eq. 21
+        HF = np.where((np.abs(gH) >= 0.6 * np.max(np.abs(gH))) &
+                      (np.abs(gH) <= 0.97 * np.max(np.abs(gH))))[0]
+        HF_field = np.abs(gH[HF])
+        HF_mag = np.where(gH[HF] >= 0, gM[HF], -gM[HF])
+        slope, intercept = np.polyfit(HF_field, HF_mag, 1)
+        SSD_lin = np.sum((HF_mag - (slope * HF_field + intercept)) ** 2)
+        pred = rmag.IRM_nonlinear_fit(HF_field, nl['chi_HF'], nl['Ms'],
+                                      nl['a_1'], nl['a_2'])
+        SSD_nl = np.sum((HF_mag - pred) ** 2)
+        n = len(HF_mag)
+        expected = ((SSD_lin - SSD_nl) / 2) / (SSD_nl / (n - 4))
+        assert nl['Fnl_lin'] == pytest.approx(expected, rel=1e-6)
+
+    def test_insignificant_when_saturated(self):
+        # saturated loop: nonlinear terms should not significantly improve fit
+        H, M = synthetic_loop(noise=5e-4, chi=0.2)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        nl = rmag.hyst_HF_nonlinear_optimization(gH, gM, 0.6, 'IRM')
+        assert nl['Fnl_lin'] < 3.5
+
+
+class TestProcessHystLoop:
+    def test_full_pipeline_saturated(self):
+        Ms, Bc, w, chi = 1.0, 0.05, 0.03, 0.2
+        H, M = synthetic_loop(Ms=Ms, Bc=Bc, w=w, chi=chi, noise=5e-4,
+                              H_offset=0.002, M_offset=0.01)
+        results = rmag.process_hyst_loop(H, M, 'synthetic',
+                                         show_results_table=False,
+                                         show_plot=False)
+        assert not results['loop_is_linear']
+        assert results['loop_is_closed']
+        assert results['loop_is_saturated']
+        assert results['Ms'] == pytest.approx(Ms, rel=0.02)
+        assert results['Mr'] == pytest.approx(Ms * np.tanh(Bc / w), rel=0.02)
+        assert results['Bc'] == pytest.approx(Bc, abs=2e-3)
+        assert results['chi_HF'] == pytest.approx(chi * 4 * np.pi / 1e7, rel=0.05)
+        assert results['Q'] > 2
+
+    def test_full_pipeline_unsaturated(self):
+        H, M = synthetic_loop(noise=1e-4, chi=0.2, ats_alpha=0.1)
+        results = rmag.process_hyst_loop(H, M, 'synthetic',
+                                         show_results_table=False,
+                                         show_plot=False)
+        assert not results['loop_is_saturated']
+        assert results['Fnl_lin'] is not None
+        assert results['Ms'] == pytest.approx(1.0, rel=0.03)

--- a/pmagpy/test/test_rockmag_hysteresis.py
+++ b/pmagpy/test/test_rockmag_hysteresis.py
@@ -9,6 +9,7 @@ linearity F tests, loop closure testing, and linear vs. nonlinear
 parameters (Ms, Mr, Bc, chi_HF) provide analytical expectations.
 """
 import numpy as np
+import pandas as pd
 import pytest
 
 from pmagpy import rockmag as rmag
@@ -54,6 +55,23 @@ def synthetic_loop(n_half=200, Hmax=1.0, Ms=1.0, Bc=0.05, w=0.03, chi=0.0,
     M = M + drift * np.linspace(0, 1, M.size)
     if noise:
         M = M + noise * rng.standard_normal(M.size)
+    return H, M
+
+
+def synthetic_loop_ascending_first(n_half=200, Hmax=1.0, Ms=1.0, Bc=0.05,
+                                   w=0.03, drift=0.0):
+    """Same physics as synthetic_loop but measured -Hmax -> +Hmax -> -Hmax.
+
+    The drift is the same linear-in-time law, so processing this loop and its
+    descending-first twin should recover the same loop parameters.
+    """
+    H_lower = np.linspace(-Hmax, Hmax, n_half)
+    H_upper = np.linspace(Hmax, -Hmax, n_half)
+    M_lower = Ms * np.tanh((H_lower - Bc) / w)
+    M_upper = Ms * np.tanh((H_upper + Bc) / w)
+    H = np.concatenate([H_lower, H_upper])
+    M = np.concatenate([M_lower, M_upper])
+    M = M + drift * np.linspace(0, 1, M.size)
     return H, M
 
 
@@ -307,7 +325,7 @@ class TestClosureTest:
     def _closure(H, M, use_Me=True):
         gH, gM = rmag.grid_hysteresis_loop(H, M)
         Hu, Mr, Mrh, Mih, Me, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
-        return rmag.loop_closure_test(Hu, Mrh, Me if use_Me else None)
+        return rmag.loop_closure_test(Hu, Mrh, Me=Me if use_Me else None)
 
     def test_closed_loop(self):
         H, M = synthetic_loop(noise=2e-3)
@@ -356,6 +374,77 @@ class TestDriftCorrection:
         # branches meet at both tips after correction
         assert upper[1][0] == pytest.approx(lower[1][0], abs=1e-12)
         assert upper[1][-1] == pytest.approx(lower[1][-1], abs=1e-12)
+
+    def test_measured_descending_first_detection(self):
+        H_desc, _ = synthetic_loop()
+        H_asc, _ = synthetic_loop_ascending_first()
+        assert rmag.measured_descending_first(H_desc)
+        assert not rmag.measured_descending_first(H_asc)
+
+    def test_prorated_time_order_aware(self):
+        # a linear-in-time drift is removed exactly (up to a constant and
+        # gridding interpolation error) when the prorated ramp runs in the
+        # loop's true measurement-time order -- for either sweep order
+        drift = 0.05
+        H_true, M_true = synthetic_loop()
+        gH, gM_true = rmag.grid_hysteresis_loop(H_true, M_true)
+        for loop_builder, descending_first in (
+                (synthetic_loop, True),
+                (synthetic_loop_ascending_first, False)):
+            H, M = loop_builder(drift=drift)
+            gH_d, gM_d = rmag.grid_hysteresis_loop(H, M)
+            corrected = rmag.prorated_drift_correction(
+                gH_d, gM_d, descending_first=descending_first)
+            residual = corrected - gM_true
+            # residual is a constant shift, not a branch-dependent ramp
+            assert np.std(residual) == pytest.approx(0.0, abs=drift / 50)
+
+    def test_prorated_wrong_order_leaves_ramp(self):
+        # applying the ramp with the wrong time sense leaves a residual of
+        # the drift's magnitude, confirming the flag changes the result
+        drift = 0.05
+        H_true, M_true = synthetic_loop()
+        gH, gM_true = rmag.grid_hysteresis_loop(H_true, M_true)
+        H, M = synthetic_loop_ascending_first(drift=drift)
+        gH_d, gM_d = rmag.grid_hysteresis_loop(H, M)
+        wrong = rmag.prorated_drift_correction(gH_d, gM_d,
+                                               descending_first=True)
+        assert np.std(wrong - gM_true) > drift / 10
+
+    def test_Me_correction_order_symmetric(self):
+        # identical physics and identical drift law measured in the two sweep
+        # orders: once the correction runs in true measurement-time order the
+        # two orders are treated identically (the equivalence mapping is
+        # exact) and both move the loop toward the drift-free truth, whereas
+        # the wrong time sense actively corrupts the loop
+        drift = 0.05
+        H_ref, M_ref = synthetic_loop()
+        gH_ref, gM_ref = rmag.grid_hysteresis_loop(H_ref, M_ref)
+
+        H_d, M_d = synthetic_loop(drift=drift)
+        gH_d, gM_d = rmag.grid_hysteresis_loop(H_d, M_d)
+        H_a, M_a = synthetic_loop_ascending_first(drift=drift)
+        gH_a, gM_a = rmag.grid_hysteresis_loop(H_a, M_a)
+        assert np.allclose(gH_d, gH_a)
+
+        def rms(x):
+            return float(np.sqrt(np.mean(np.square(x))))
+
+        rms_uncorrected = rms(gM_a - gM_ref)
+        corr_desc = rmag.drift_correction_Me(gH_d, gM_d,
+                                             descending_first=True)
+        corr_asc = rmag.drift_correction_Me(gH_a, gM_a,
+                                            descending_first=False)
+        wrong_asc = rmag.drift_correction_Me(gH_a, gM_a,
+                                             descending_first=True)
+
+        # both sweep orders receive the same (correct) treatment
+        assert rms(corr_asc - gM_ref) == pytest.approx(
+            rms(corr_desc - gM_ref), rel=1e-6)
+        # the correct time sense improves on the uncorrected loop; the wrong
+        # time sense makes it worse than not correcting at all
+        assert rms(corr_asc - gM_ref) < rms_uncorrected
+        assert rms(wrong_asc - gM_ref) > rms_uncorrected
 
 
 class TestParameterRecovery:
@@ -454,3 +543,149 @@ class TestProcessHystLoop:
         assert not results['loop_is_saturated']
         assert results['Fnl_lin'] is not None
         assert results['Ms'] == pytest.approx(1.0, rel=0.03)
+
+    def test_pipeline_ascending_first_matches_descending(self):
+        # the same loop physics with the same drift law, measured in the two
+        # sweep orders, must process to the same Mr and Bc now that the drift
+        # correction runs in true measurement-time order
+        H_d, M_d = synthetic_loop(drift=0.05)
+        H_a, M_a = synthetic_loop_ascending_first(drift=0.05)
+        res_d = rmag.process_hyst_loop(H_d, M_d, show_results_table=False,
+                                       show_plot=False)
+        res_a = rmag.process_hyst_loop(H_a, M_a, show_results_table=False,
+                                       show_plot=False)
+        assert res_d['measured_descending_first']
+        assert not res_a['measured_descending_first']
+        assert res_a['Mr'] == pytest.approx(res_d['Mr'], rel=0.03)
+        assert res_a['Bc'] == pytest.approx(res_d['Bc'], rel=0.05)
+
+
+class TestOpenLoopBrh:
+    def test_Brh_nan_when_Mrh_stays_high(self):
+        # hematite-like loop measured far short of saturation: Mrh never
+        # falls to Mr/2 in the measured range, so Brh is NaN with a warning
+        # rather than a TypeError (None arithmetic)
+        H, M = synthetic_loop(Ms=1.0, Bc=1.5, w=1.0)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        with pytest.warns(RuntimeWarning, match='Brh'):
+            Hu, Mr, Mrh, Mih, Me, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
+        assert np.isnan(Brh)
+        assert np.isfinite(Mr) and Mr > 0
+        assert np.all(np.isfinite(Mrh))
+
+    def test_closed_loop_Brh_unchanged(self):
+        # well-behaved loop: Brh is still computed from both crossings
+        H, M = synthetic_loop()
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        *_, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
+        assert np.isfinite(Brh) and Brh > 0
+
+    def test_Bc_nan_when_no_zero_crossing(self):
+        # loop measured far below the coercivity of its hard component:
+        # neither branch crosses zero, so Bc is NaN with a warning
+        H, M = synthetic_loop(Ms=1.0, Bc=1.5, w=1.0)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        with pytest.warns(RuntimeWarning, match='Bc'):
+            Bc = rmag.calc_Bc(gH, gM)
+        assert np.isnan(Bc)
+
+    def test_pipeline_survives_open_loops(self):
+        # process_hyst_loop must complete on exactly the open-loop specimens
+        # the closure test is designed to flag, reporting NaN for the
+        # undefined parameters rather than crashing
+        import warnings as _warnings
+        # realistic: soft magnetite plus a dominant unsaturated hard phase
+        H1, M1 = synthetic_loop(Ms=0.65, Bc=0.05, w=0.03, hard_Ms=1.0,
+                                hard_Bc=2.0, hard_w=1.5, noise=2e-4)
+        # extreme: single hard phase, magnetization never reverses
+        H2, M2 = synthetic_loop(Ms=1.0, Bc=1.5, w=1.0)
+        for H, M in ((H1, M1), (H2, M2)):
+            with _warnings.catch_warnings():
+                _warnings.simplefilter('ignore')
+                results = rmag.process_hyst_loop(H, M,
+                                                 show_results_table=False,
+                                                 show_plot=False)
+            assert not results['loop_is_closed']
+            assert np.isnan(results['Brh'])
+
+
+class TestSparseLoopSaturation:
+    def test_sparse_loop_does_not_abort(self):
+        # a coarse quick-scan loop passes the >=10-point gate but leaves too
+        # few high-field pairs for some lack-of-fit windows; those windows
+        # now report NaN with a warning instead of aborting the pipeline
+        H, M = synthetic_loop(n_half=12)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        with pytest.warns(RuntimeWarning, match='saturation test window'):
+            results = rmag.hyst_loop_saturation_test(gH, gM)
+        assert 'saturation_cutoff' in results
+        # at least one window was skipped -> its FNL is NaN
+        fnls = [results['FNL60'], results['FNL70'], results['FNL80']]
+        assert any(np.isnan(v) for v in fnls)
+
+    def test_direct_call_still_raises(self):
+        # loop_saturation_stats itself keeps its informative error for
+        # direct callers
+        H, M = synthetic_loop(n_half=12)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        with pytest.raises(ValueError, match='high-field'):
+            rmag.loop_saturation_stats(gH, gM, HF_cutoff=0.8)
+
+
+class TestClosureTestSignature:
+    def test_third_positional_is_HF_cutoff(self):
+        # pre-existing (master) signature was (H, Mrh, HF_cutoff=0.8): the
+        # third positional argument must still bind to HF_cutoff
+        H, M = synthetic_loop(noise=2e-3, hard_Ms=0.1)
+        gH, gM = rmag.grid_hysteresis_loop(H, M)
+        Hu, Mr, Mrh, Mih, Me, Brh = rmag.calc_Mr_Mrh_Mih_Brh(gH, gM)
+        positional = rmag.loop_closure_test(Hu, Mrh, 0.7)
+        keyword = rmag.loop_closure_test(Hu, Mrh, HF_cutoff=0.7)
+        assert positional == keyword
+
+
+class TestHystStatsDescriptionJSON:
+    @staticmethod
+    def _hyst_results():
+        return pd.DataFrame([{
+            'specimen': 'spec1', 'experiment': 'spec1-HYS1',
+            'Ms': 1.0, 'Mr': 0.4, 'Bc': 0.05, 'chi_HF': 1e-7,
+            'Q': 5.0, 'Qf': 6.0, 'sigma': 0.5, 'Brh': 0.08,
+            'FNL': 1.0, 'FNL60': 1.1, 'FNL70': 1.2, 'FNL80': 1.3,
+            'Fnl_lin': None, 'loop_is_linear': False,
+            'loop_is_closed': True, 'loop_is_saturated': True,
+            'processed_by': 'test',
+        }])
+
+    def test_round_trip_with_unmixing_payload(self):
+        # a cell already holding the unmixing writer's 'text | JSON' payload
+        # must survive the hysteresis writer: both structured payloads and
+        # the free text are preserved and re-parseable
+        import json
+        unmix_payload = json.dumps({'coercivity_unmixing': {'B1': 30.0}})
+        specimens = pd.DataFrame([{
+            'specimen': 'spec1', 'experiments': 'spec1-HYS1:spec1-BF1',
+            'description': f'sample notes | {unmix_payload}',
+        }])
+        out = rmag.add_hyst_stats_to_specimens_table(specimens,
+                                                     self._hyst_results())
+        text, data = rmag.parse_specimen_description(
+            out.loc[0, 'description'])
+        assert text == 'sample notes'
+        assert data['coercivity_unmixing'] == {'B1': 30.0}
+        assert data['Q'] == pytest.approx(5.0)
+        assert data['loop_is_closed'] is True
+
+    def test_legacy_dict_cell_migrated(self):
+        # legacy str(dict) cells written by older versions are parsed and
+        # migrated to the JSON convention rather than corrupted
+        specimens = pd.DataFrame([{
+            'specimen': 'spec1', 'experiments': 'spec1-HYS1',
+            'description': str({'old_stat': 1.5}),
+        }])
+        out = rmag.add_hyst_stats_to_specimens_table(specimens,
+                                                     self._hyst_results())
+        text, data = rmag.parse_specimen_description(
+            out.loc[0, 'description'])
+        assert data['old_stat'] == pytest.approx(1.5)
+        assert data['Brh'] == pytest.approx(0.08)

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -1,0 +1,1012 @@
+"""
+Tests for the coercivity spectrum unmixing suite in rockmag.py.
+
+Covers the skew-normal component model (against analytical solutions),
+spectrum- and measurement-space fitting (parameter recovery on synthetic
+data with known components), model selection, bootstrap uncertainty
+estimation, batch processing of MagIC measurement tables, and recording of
+results in MagIC specimens tables.
+"""
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.integrate import quad
+
+from pmagpy import rockmag as rmag
+
+
+RNG = np.random.default_rng(2026)
+
+# a two-component reference model resembling red bed hematite spectra:
+# a broad lower-coercivity component and a narrow high-coercivity one
+TWO_COMPONENT_TRUTH = pd.DataFrame({
+    'contribution': [0.4, 0.6],
+    'location': [np.log10(250.0), np.log10(750.0)],
+    'dp': [0.50, 0.12],
+    'skew': [0.0, 0.0],
+})
+
+
+def synthetic_spectrum(noise=0.0, n=120, rng=None):
+    """Synthetic coercivity spectrum from the reference two-component model.
+
+    Uses a fresh seeded generator by default so that each call is
+    deterministic and independent of test execution order (important for
+    reproducible CI runs).
+    """
+    if rng is None:
+        rng = np.random.default_rng(1234)
+    x = np.linspace(0.5, 3.2, n)
+    spectrum = rmag.coercivity_spectrum_model(x, TWO_COMPONENT_TRUTH)
+    if noise > 0:
+        spectrum = spectrum + rng.normal(0, noise * spectrum.max(), size=n)
+    return x, spectrum
+
+
+def synthetic_curve(noise=0.0, n=120, rng=None):
+    """Synthetic backfield curve (decaying, shifted-positive convention).
+
+    Uses a fresh seeded generator by default so that each call is
+    deterministic and independent of test execution order.
+    """
+    if rng is None:
+        rng = np.random.default_rng(5678)
+    x = np.linspace(0.5, 3.2, n)
+    curve = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
+                                        curve_type='backfield')
+    if noise > 0:
+        curve = curve + rng.normal(0, noise, size=n)
+    return x, curve
+
+
+# Fast nested-sampling settings for the Bayesian tests: fewer live points, a
+# looser evidence tolerance, and fewer data points keep the (otherwise slow)
+# dynesty runs to a few seconds each so the suite stays CI-friendly, while
+# still recovering the known synthetic parameters within test tolerances.
+FAST_BAYES = dict(nlive=50, dlogz=1.0)
+BAYES_N = 80
+
+
+# ---------------------------------------------------------------------------
+# skew-normal component model: analytical solutions
+# ---------------------------------------------------------------------------
+
+class TestSkewNormalModel:
+    """The component basis functions against closed-form expectations."""
+
+    def test_pdf_reduces_to_gaussian_when_symmetric(self):
+        """With skew=0 the pdf equals the Gaussian density exactly."""
+        x = np.linspace(-1, 5, 50)
+        location, dp = 1.8, 0.3
+        expected = (np.exp(-0.5 * ((x - location) / dp) ** 2)
+                    / (dp * np.sqrt(2 * np.pi)))
+        assert np.allclose(rmag.skewnormal_pdf(x, location, dp, 0.0),
+                           expected)
+
+    @pytest.mark.parametrize('skew', [0.0, -3.0, 2.5, 8.0])
+    def test_pdf_integrates_to_unit_area(self, skew):
+        """The pdf has unit area for any skew."""
+        area, _err = quad(lambda t: rmag.skewnormal_pdf(t, 1.5, 0.3, skew),
+                          -10, 10)
+        assert area == pytest.approx(1.0, abs=1e-8)
+
+    @pytest.mark.parametrize('skew', [0.0, -3.0, 2.5])
+    def test_cdf_matches_integrated_pdf(self, skew):
+        """The analytic CDF (Owen's T) equals the numerically integrated pdf."""
+        for x_eval in [0.9, 1.5, 2.1]:
+            integral, _err = quad(
+                lambda t: rmag.skewnormal_pdf(t, 1.5, 0.3, skew), -10, x_eval)
+            assert rmag.skewnormal_cdf(x_eval, 1.5, 0.3, skew) == \
+                pytest.approx(integral, abs=1e-8)
+
+    def test_stats_symmetric_case(self):
+        """For skew=0, mean = median = mode = location and std = dp."""
+        stats = rmag.skewnormal_stats(2.0, 0.4, 0.0)
+        assert stats['mean'] == pytest.approx(2.0)
+        assert stats['median'] == pytest.approx(2.0)
+        assert stats['mode'] == pytest.approx(2.0)
+        assert stats['std'] == pytest.approx(0.4)
+
+    def test_stats_match_numerical_moments(self):
+        """Mean/std formulas agree with numerical moments of the pdf."""
+        location, dp, skew = 1.5, 0.3, -2.0
+        mean_num, _ = quad(
+            lambda t: t * rmag.skewnormal_pdf(t, location, dp, skew), -10, 10)
+        var_num, _ = quad(
+            lambda t: (t - mean_num) ** 2
+            * rmag.skewnormal_pdf(t, location, dp, skew), -10, 10)
+        stats = rmag.skewnormal_stats(location, dp, skew)
+        assert stats['mean'] == pytest.approx(mean_num, abs=1e-8)
+        assert stats['std'] == pytest.approx(np.sqrt(var_num), abs=1e-8)
+        # median has CDF exactly 0.5
+        assert rmag.skewnormal_cdf(stats['median'], location, dp, skew) == \
+            pytest.approx(0.5, abs=1e-10)
+
+    def test_negative_skew_shifts_mean_below_location(self):
+        """Negative skew produces a tail (and mean) toward low coercivity."""
+        stats = rmag.skewnormal_stats(2.0, 0.4, -5.0)
+        assert stats['mean'] < 2.0
+
+    def test_spectrum_component_area_equals_contribution(self):
+        """Component area in spectrum space equals its contribution."""
+        params = pd.DataFrame({'contribution': [0.37], 'location': [2.0],
+                               'dp': [0.3], 'skew': [-1.5]})
+        area, _err = quad(
+            lambda t: rmag.coercivity_spectrum_model(np.array([t]),
+                                                     params)[0], -10, 10)
+        assert area == pytest.approx(0.37, abs=1e-6)
+
+    def test_curve_model_is_integral_of_spectrum_model(self):
+        """The measurement-space model is the cumulative of the spectrum model."""
+        x = np.linspace(0.5, 3.2, 400)
+        spectrum = rmag.coercivity_spectrum_model(x, TWO_COMPONENT_TRUTH)
+        curve = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
+                                            curve_type='backfield')
+        # -dM/dx of the curve model equals the spectrum model
+        derivative = -np.gradient(curve, x)
+        assert np.allclose(derivative[5:-5], spectrum[5:-5], atol=2e-3)
+
+
+# ---------------------------------------------------------------------------
+# spectrum utilities
+# ---------------------------------------------------------------------------
+
+class TestSpectrumFromCurve:
+    """coercivity_spectrum_from_curve finite differences."""
+
+    def test_backfield_spectrum_is_positive(self):
+        x, curve = synthetic_curve()
+        x_mid, spectrum = rmag.coercivity_spectrum_from_curve(x, curve)
+        assert len(x_mid) == len(x) - 1
+        assert (spectrum > -1e-12).all()
+
+    def test_acquisition_sign_convention(self):
+        x = np.linspace(0.5, 3.2, 80)
+        acquisition = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
+                                                  curve_type='acquisition')
+        _x_mid, spectrum = rmag.coercivity_spectrum_from_curve(
+            x, acquisition, curve_type='acquisition')
+        assert (spectrum > -1e-12).all()
+
+
+class TestEstimateComponents:
+    """Automatic initial-guess estimation."""
+
+    def test_finds_two_well_separated_peaks(self):
+        x, spectrum = synthetic_spectrum(noise=0.01)
+        initial = rmag.estimate_coercivity_components(x, spectrum, 2)
+        assert len(initial) == 2
+        # locations near the true peaks (within a quarter decade)
+        assert initial['location'].iloc[0] == pytest.approx(
+            TWO_COMPONENT_TRUTH['location'].iloc[0], abs=0.25)
+        assert initial['location'].iloc[1] == pytest.approx(
+            TWO_COMPONENT_TRUTH['location'].iloc[1], abs=0.25)
+
+    def test_fills_missing_components(self):
+        """Requesting more components than peaks still returns a full table."""
+        x, spectrum = synthetic_spectrum()
+        initial = rmag.estimate_coercivity_components(x, spectrum, 4)
+        assert len(initial) == 4
+        assert initial['contribution'].gt(0).all()
+
+
+# ---------------------------------------------------------------------------
+# fitting: parameter recovery on synthetic data
+# ---------------------------------------------------------------------------
+
+class TestSpectrumFitting:
+    """unmix_coercivity_spectrum parameter recovery."""
+
+    def test_exact_recovery_on_noise_free_data(self):
+        x, spectrum = synthetic_spectrum(noise=0.0)
+        result = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2,
+                                                vary_skew=False)
+        assert result['success']
+        params = result['params']
+        assert np.allclose(params['location'],
+                           TWO_COMPONENT_TRUTH['location'], atol=1e-3)
+        assert np.allclose(params['dp'], TWO_COMPONENT_TRUTH['dp'],
+                           atol=1e-3)
+        assert np.allclose(params['contribution'],
+                           TWO_COMPONENT_TRUTH['contribution'], rtol=1e-2)
+        assert result['stats']['r_squared'] > 0.99999
+
+    def test_recovery_with_noise(self):
+        x, spectrum = synthetic_spectrum(noise=0.02)
+        result = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2,
+                                                vary_skew=False)
+        params = result['params']
+        assert np.allclose(params['location'],
+                           TWO_COMPONENT_TRUTH['location'], atol=0.1)
+        assert np.allclose(params['proportion'], [0.4, 0.6], atol=0.08)
+
+    def test_skewed_component_recovery(self):
+        """A skewed synthetic component is recovered including its skew."""
+        truth = pd.DataFrame({'contribution': [1.0], 'location': [2.5],
+                              'dp': [0.4], 'skew': [-3.0]})
+        x = np.linspace(0.5, 3.2, 150)
+        spectrum = rmag.coercivity_spectrum_model(x, truth)
+        result = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=1,
+                                                vary_skew=True)
+        params = result['params']
+        assert params['location'].iloc[0] == pytest.approx(2.5, abs=0.05)
+        assert params['dp'].iloc[0] == pytest.approx(0.4, abs=0.05)
+        assert params['skew'].iloc[0] == pytest.approx(-3.0, abs=0.5)
+
+    def test_components_sorted_by_mean_coercivity(self):
+        x, spectrum = synthetic_spectrum()
+        # initial parameters deliberately in reversed order
+        initial = TWO_COMPONENT_TRUTH.iloc[::-1].reset_index(drop=True)
+        result = rmag.unmix_coercivity_spectrum(x, spectrum,
+                                                initial_parameters=initial,
+                                                vary_skew=False)
+        means = result['params']['B_mean_mT'].to_numpy()
+        assert (np.diff(means) > 0).all()
+
+    def test_proportions_sum_to_one(self):
+        x, spectrum = synthetic_spectrum(noise=0.01)
+        result = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2)
+        assert result['params']['proportion'].sum() == pytest.approx(1.0)
+
+    def test_requires_n_components_or_initial(self):
+        x, spectrum = synthetic_spectrum()
+        with pytest.raises(ValueError):
+            rmag.unmix_coercivity_spectrum(x, spectrum)
+
+    def test_too_few_points_raises(self):
+        with pytest.raises(ValueError):
+            rmag.unmix_coercivity_spectrum(np.array([1.0, 2.0, 3.0]),
+                                           np.array([0.1, 0.5, 0.1]),
+                                           n_components=2)
+
+
+class TestCurveFitting:
+    """unmix_backfield_curve parameter recovery."""
+
+    def test_exact_recovery_on_noise_free_data(self):
+        x, curve = synthetic_curve(noise=0.0)
+        result = rmag.unmix_backfield_curve(x, curve, n_components=2,
+                                            vary_skew=False)
+        assert result['success']
+        params = result['params']
+        assert np.allclose(params['location'],
+                           TWO_COMPONENT_TRUTH['location'], atol=1e-3)
+        assert np.allclose(params['contribution'],
+                           TWO_COMPONENT_TRUTH['contribution'], rtol=1e-2)
+        assert abs(result['offset']) < 1e-3
+
+    def test_recovery_with_noise(self):
+        x, curve = synthetic_curve(noise=0.005)
+        result = rmag.unmix_backfield_curve(x, curve, n_components=2,
+                                            vary_skew=False)
+        params = result['params']
+        assert np.allclose(params['location'],
+                           TWO_COMPONENT_TRUTH['location'], atol=0.1)
+        assert np.allclose(params['proportion'], [0.4, 0.6], atol=0.08)
+
+    def test_acquisition_curve(self):
+        """IRM acquisition (growing) curves fit with the same machinery."""
+        x = np.linspace(0.5, 3.2, 120)
+        acquisition = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
+                                                  curve_type='acquisition')
+        result = rmag.unmix_backfield_curve(x, acquisition, n_components=2,
+                                            curve_type='acquisition',
+                                            vary_skew=False)
+        assert np.allclose(result['params']['location'],
+                           TWO_COMPONENT_TRUTH['location'], atol=0.02)
+
+    def test_offset_recovery(self):
+        """A constant baseline offset is recovered by the fit."""
+        x, curve = synthetic_curve(noise=0.0)
+        result = rmag.unmix_backfield_curve(x, curve + 0.05, n_components=2,
+                                            vary_skew=False, fit_offset=True)
+        assert result['offset'] == pytest.approx(0.05, abs=5e-3)
+
+
+class TestMethodDispatch:
+    """unmix_coercivity and the method registry."""
+
+    def test_spectrum_and_curve_methods_agree(self):
+        """Both built-in approaches recover the same components when
+        started from the same initial parameters. (With automatic seeding
+        on noisy data the spectrum method is more sensitive to derivative
+        noise -- a documented limitation, not tested here.)"""
+        x, curve = synthetic_curve(noise=0.001)
+        initial = TWO_COMPONENT_TRUTH.copy()
+        spectrum_fit = rmag.unmix_coercivity(x, curve, method='spectrum',
+                                             initial_parameters=initial,
+                                             vary_skew=False)
+        curve_fit = rmag.unmix_coercivity(x, curve, method='curve',
+                                          initial_parameters=initial,
+                                          vary_skew=False)
+        # the broad low-coercivity component is the more space-sensitive one
+        # (the spectrum method fits the noisy derivative), so it is compared
+        # with a looser tolerance than the well-constrained narrow component
+        assert np.allclose(spectrum_fit['params']['B_mean_mT'],
+                           curve_fit['params']['B_mean_mT'], rtol=0.15)
+        assert np.allclose(spectrum_fit['params']['proportion'],
+                           curve_fit['params']['proportion'], atol=0.05)
+
+    def test_maxunmix_method_returns_bootstrap(self):
+        x, curve = synthetic_curve(noise=0.002)
+        result = rmag.unmix_coercivity(x, curve, method='maxunmix',
+                                       n_components=2, vary_skew=False,
+                                       n_boot=30, random_seed=7)
+        assert 'bootstrap' in result
+        assert result['bootstrap']['resample'] == 'cases'
+        assert result['bootstrap']['proportion'] == 0.95
+        assert result['bootstrap']['noise_level'] == 0.02
+
+    def test_unknown_method_raises(self):
+        x, curve = synthetic_curve()
+        with pytest.raises(ValueError, match='unknown unmixing method'):
+            rmag.unmix_coercivity(x, curve, method='not_a_method',
+                                  n_components=2)
+
+    def test_register_custom_method(self):
+        def custom(x, magnetization, n_components=None,
+                   initial_parameters=None, curve_type='backfield',
+                   vary_skew=True, **kwargs):
+            return rmag.unmix_backfield_curve(
+                x, magnetization, n_components=n_components,
+                initial_parameters=initial_parameters,
+                curve_type=curve_type, vary_skew=False, **kwargs)
+
+        rmag.register_unmixing_method('test_custom', custom)
+        try:
+            x, curve = synthetic_curve(noise=0.002)
+            result = rmag.unmix_coercivity(x, curve, method='test_custom',
+                                           n_components=2)
+            assert result['n_components'] == 2
+            # the custom method forces symmetric components
+            assert (result['params']['skew'] == 0).all()
+        finally:
+            del rmag.UNMIXING_METHODS['test_custom']
+
+    def test_register_non_callable_raises(self):
+        with pytest.raises(TypeError):
+            rmag.register_unmixing_method('bad', 'not callable')
+
+
+# ---------------------------------------------------------------------------
+# model selection
+# ---------------------------------------------------------------------------
+
+class TestModelComparison:
+    """compare_unmixing_models information criteria and F-tests."""
+
+    def test_bic_prefers_true_component_count(self):
+        x, spectrum = synthetic_spectrum(noise=0.01)
+        results = [rmag.unmix_coercivity_spectrum(x, spectrum,
+                                                  n_components=n,
+                                                  vary_skew=False)
+                   for n in (1, 2, 3)]
+        table = rmag.compare_unmixing_models(results)
+        best = table.loc[table['bic'].idxmin(), 'n_components']
+        assert best == 2
+
+    def test_f_test_significant_for_second_component(self):
+        x, spectrum = synthetic_spectrum(noise=0.01)
+        results = [rmag.unmix_coercivity_spectrum(x, spectrum,
+                                                  n_components=n,
+                                                  vary_skew=False)
+                   for n in (1, 2)]
+        table = rmag.compare_unmixing_models(results)
+        assert table['p_value'].iloc[1] < 1e-6
+
+    def test_mixed_methods_raise(self):
+        x, curve = synthetic_curve()
+        spectrum_fit = rmag.unmix_coercivity(x, curve, method='spectrum',
+                                             n_components=1)
+        curve_fit = rmag.unmix_coercivity(x, curve, method='curve',
+                                          n_components=1)
+        with pytest.raises(ValueError):
+            rmag.compare_unmixing_models([spectrum_fit, curve_fit])
+
+
+class TestNoiseEstimate:
+    """estimate_measurement_noise."""
+
+    def test_recovers_known_noise(self):
+        x, curve = synthetic_curve(noise=0.0)
+        rng = np.random.default_rng(0)
+        noisy = curve + rng.normal(0, 0.01, size=len(curve))
+        estimate = rmag.estimate_measurement_noise(x, noisy)
+        assert estimate == pytest.approx(0.01, rel=0.3)
+
+    def test_low_on_clean_data(self):
+        x, curve = synthetic_curve(noise=0.0)
+        estimate = rmag.estimate_measurement_noise(x, curve)
+        assert estimate < 0.01 * np.ptp(curve)
+
+
+class TestSelectNComponents:
+    """select_n_components parsimony selection."""
+
+    def test_parsimony_selects_true_count_on_low_noise(self):
+        """The parsimony rule stops at the true component count even when
+        the data are clean enough that reduced chi-square keeps improving."""
+        x, curve = synthetic_curve(noise=0.001)
+        selected, table, results = rmag.select_n_components(
+            x, curve, method='curve', max_components=4)
+        assert selected == 2
+        assert table.loc[table['selected'], 'n_components'].iloc[0] == 2
+        assert set(results) == {1, 2, 3, 4}
+
+    def test_parsimony_beats_chi2_overselection(self):
+        """On the same low-noise data, a strict chi-square target
+        over-selects while parsimony does not."""
+        x, curve = synthetic_curve(noise=0.001)
+        parsimony, _t, _r = rmag.select_n_components(x, curve, method='curve',
+                                                     max_components=4)
+        chi2, _t2, _r2 = rmag.select_n_components(
+            x, curve, method='curve', criterion='chi2',
+            reduced_chi2_target=1.0, max_components=4)
+        assert parsimony <= chi2
+
+    def test_improvement_fraction_decreasing(self):
+        x, curve = synthetic_curve(noise=0.002)
+        _s, table, _r = rmag.select_n_components(x, curve, method='curve',
+                                                 max_components=4)
+        # the second component explains most of the baseline misfit
+        assert table['rss_improvement_fraction'].iloc[1] > 0.5
+        # the fourth explains almost none
+        assert table['rss_improvement_fraction'].iloc[3] < 0.05
+
+    def test_min_improvement_threshold_effect(self):
+        x, curve = synthetic_curve(noise=0.001)
+        # a threshold above what even the (dominant) second component
+        # explains keeps the single-component model
+        strict, _t, _r = rmag.select_n_components(
+            x, curve, method='curve', max_components=4,
+            min_improvement=0.9999)
+        assert strict == 1
+        # the default threshold keeps two components
+        default, _t2, _r2 = rmag.select_n_components(
+            x, curve, method='curve', max_components=4)
+        assert default == 2
+
+    def test_chi2_with_explicit_noise(self):
+        x, curve = synthetic_curve(noise=0.01)
+        selected, table, _r = rmag.select_n_components(
+            x, curve, method='curve', criterion='chi2', noise_level=0.01,
+            max_components=3)
+        assert 'reduced_chi2' in table.columns
+        assert selected >= 1
+
+    def test_unknown_method_raises(self):
+        x, curve = synthetic_curve()
+        with pytest.raises(ValueError):
+            rmag.select_n_components(x, curve, method='nope')
+
+
+# ---------------------------------------------------------------------------
+# bootstrap uncertainty
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='module')
+def fitted():
+    """A converged two-component spectrum fit shared by bootstrap tests."""
+    x, spectrum = synthetic_spectrum(noise=0.02)
+    return rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2,
+                                          vary_skew=False)
+
+
+class TestBootstrap:
+    """unmixing_bootstrap behavior."""
+
+    def test_intervals_cover_truth(self, fitted):
+        """95% intervals from the bootstrap contain the true parameters."""
+        boot = rmag.unmixing_bootstrap(fitted, n_boot=100, random_seed=3)
+        summary = boot['bootstrap']['param_summary']
+        for comp in (1, 2):
+            true_B = 10 ** TWO_COMPONENT_TRUTH['location'].iloc[comp - 1]
+            assert summary.loc[comp, 'B_mean_mT_p2_5'] < true_B
+            assert summary.loc[comp, 'B_mean_mT_p97_5'] > true_B
+
+    def test_seed_reproducibility(self, fitted):
+        boot_a = rmag.unmixing_bootstrap(fitted, n_boot=40, random_seed=11)
+        boot_b = rmag.unmixing_bootstrap(fitted, n_boot=40, random_seed=11)
+        pd.testing.assert_frame_equal(boot_a['bootstrap']['param_summary'],
+                                      boot_b['bootstrap']['param_summary'])
+
+    def test_residual_resampling(self, fitted):
+        boot = rmag.unmixing_bootstrap(fitted, n_boot=40,
+                                       resample='residuals', random_seed=5)
+        assert boot['bootstrap']['n_success'] > 0
+
+    def test_input_result_not_mutated(self, fitted):
+        rmag.unmixing_bootstrap(fitted, n_boot=30, random_seed=1)
+        assert 'bootstrap' not in fitted
+
+    def test_curve_bands_shape(self, fitted):
+        boot = rmag.unmixing_bootstrap(fitted, n_boot=30, random_seed=1,
+                                       n_grid=150)
+        curves = boot['bootstrap']['curves']
+        assert curves['x_grid'].shape == (150,)
+        assert curves['total_p97_5'].shape == (150,)
+        assert (curves['total_p97_5'] >= curves['total_p2_5']).all()
+
+
+# ---------------------------------------------------------------------------
+# MagIC batch processing and specimens export
+# ---------------------------------------------------------------------------
+
+def make_magic_measurements(experiment='synthetic-LP-BCR-BF-1',
+                            specimen='spec1', noise=0.002, rng=RNG):
+    """Build a minimal MagIC-style measurements table with a backfield
+    experiment generated from the reference two-component model."""
+    x = np.linspace(0.5, 3.2, 90)
+    curve_shifted = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
+                                                curve_type='backfield')
+    curve_shifted = curve_shifted + rng.normal(0, noise, size=len(x))
+    # convert the shifted curve back to the measured convention:
+    # M measured runs from +Mrs down to -Mrs with negative applied fields
+    total = TWO_COMPONENT_TRUTH['contribution'].sum()
+    magn_mass = curve_shifted - total / 2
+    treat_dc_field = -(10 ** x) * 1e-3  # tesla, negative back fields
+    return pd.DataFrame({
+        'experiment': experiment,
+        'specimen': specimen,
+        'method_codes': 'LP-BCR-BF',
+        'treat_dc_field': treat_dc_field,
+        'magn_mass': magn_mass,
+    })
+
+
+class TestBatchProcessing:
+    """unmix_backfield_experiments on MagIC-style tables."""
+
+    def test_batch_recovers_components(self):
+        measurements = make_magic_measurements()
+        components_df, results = rmag.unmix_backfield_experiments(
+            measurements, n_components=2, method='spectrum',
+            vary_skew=False, verbose=False)
+        assert len(components_df) == 2
+        assert components_df['B_mean_mT'].iloc[0] == pytest.approx(250,
+                                                                   rel=0.15)
+        assert components_df['B_mean_mT'].iloc[1] == pytest.approx(750,
+                                                                   rel=0.10)
+        assert components_df['proportion'].to_numpy() == pytest.approx(
+            [0.4, 0.6], abs=0.08)
+        assert 'synthetic-LP-BCR-BF-1' in results
+
+    def test_batch_with_bootstrap_adds_interval_columns(self):
+        measurements = make_magic_measurements()
+        components_df, _results = rmag.unmix_backfield_experiments(
+            measurements, n_components=2, method='spectrum',
+            vary_skew=False, n_boot=30, random_seed=4, verbose=False)
+        assert 'B_mean_mT_p2_5' in components_df.columns
+        assert components_df['B_mean_mT_p2_5'].notna().all()
+
+    def test_batch_reports_bcr(self):
+        measurements = make_magic_measurements()
+        components_df, _results = rmag.unmix_backfield_experiments(
+            measurements, n_components=2, vary_skew=False, verbose=False)
+        # Bcr should fall between the two component coercivities
+        bcr = components_df['Bcr_mT'].iloc[0]
+        assert 250 < bcr < 750
+
+    def test_failed_experiment_is_skipped(self):
+        measurements = make_magic_measurements()
+        components_df, results = rmag.unmix_backfield_experiments(
+            measurements,
+            experiments=['synthetic-LP-BCR-BF-1', 'missing-experiment'],
+            n_components=2, vary_skew=False, verbose=False)
+        assert list(results) == ['synthetic-LP-BCR-BF-1']
+        assert components_df['experiment'].nunique() == 1
+
+
+class TestSpecimensExport:
+    """unmixing_to_specimens_table in both recording modes."""
+
+    @pytest.fixture()
+    def batch_output(self):
+        measurements = make_magic_measurements()
+        components_df, _results = rmag.unmix_backfield_experiments(
+            measurements, n_components=2, vary_skew=False, verbose=False)
+        specimens = pd.DataFrame({
+            'specimen': ['spec1'],
+            'sample': ['samp1'],
+            'experiments': ['synthetic-LP-BCR-BF-1'],
+            'description': ['rock chip'],
+        })
+        return components_df, specimens
+
+    def test_rows_mode_adds_component_rows(self, batch_output):
+        components_df, specimens = batch_output
+        updated = rmag.unmixing_to_specimens_table(specimens, components_df,
+                                                   mode='rows')
+        new_rows = updated[updated['rem_cmf'].notna()]
+        assert len(new_rows) == 2
+        # rem_cmf is in tesla
+        assert new_rows['rem_cmf'].iloc[0] == pytest.approx(0.25, rel=0.15)
+        assert (new_rows['rem_n_comp'] == 2).all()
+        assert (new_rows['method_codes'] == 'LP-BCR-BF').all()
+        # identity columns copied from the matching row
+        assert (new_rows['sample'] == 'samp1').all()
+
+    def test_rows_mode_is_idempotent(self, batch_output):
+        components_df, specimens = batch_output
+        once = rmag.unmixing_to_specimens_table(specimens, components_df,
+                                                mode='rows')
+        twice = rmag.unmixing_to_specimens_table(once, components_df,
+                                                 mode='rows')
+        assert len(once) == len(twice)
+
+    def test_description_mode_preserves_text(self, batch_output):
+        components_df, specimens = batch_output
+        rmag.unmixing_to_specimens_table(specimens, components_df,
+                                         mode='description')
+        text, data = rmag.parse_specimen_description(
+            specimens['description'].iloc[0])
+        assert text == 'rock chip'
+        assert data['coercivity_unmixing']['n_components'] == 2
+        assert len(data['coercivity_unmixing']['components']) == 2
+
+    def test_description_round_trip(self, batch_output):
+        components_df, specimens = batch_output
+        rmag.unmixing_to_specimens_table(specimens, components_df,
+                                         mode='description')
+        # a second call replaces rather than duplicates the record
+        rmag.unmixing_to_specimens_table(specimens, components_df,
+                                         mode='description')
+        text, data = rmag.parse_specimen_description(
+            specimens['description'].iloc[0])
+        assert text == 'rock chip'
+        assert list(data) == ['coercivity_unmixing']
+
+
+# ---------------------------------------------------------------------------
+# multi-start solution mapping
+# ---------------------------------------------------------------------------
+
+class TestMultistart:
+    """unmixing_multistart solution mapping."""
+
+    def test_best_solution_recovers_truth(self):
+        x, curve = synthetic_curve(noise=0.002)
+        result = rmag.unmixing_multistart(x, curve, method='spectrum',
+                                          n_components=2, n_starts=30,
+                                          vary_skew=False, random_seed=8)
+        assert np.allclose(result['params']['location'],
+                           TWO_COMPONENT_TRUTH['location'], atol=0.1)
+        multistart = result['multistart']
+        assert multistart['n_converged'] > 0
+        solutions = multistart['solutions']
+        # solutions are ranked: the first row is the best fit
+        assert solutions['delta_aic'].iloc[0] == 0
+        assert solutions['akaike_weight'].sum() == pytest.approx(1.0)
+        assert solutions['n_hits'].sum() == multistart['n_converged']
+        # per-component columns exist
+        assert 'B_mean_mT_c1' in solutions.columns
+        assert 'proportion_c2' in solutions.columns
+
+    def test_reproducible_with_seed(self):
+        x, curve = synthetic_curve(noise=0.002)
+        a = rmag.unmixing_multistart(x, curve, n_components=2, n_starts=15,
+                                     random_seed=4, vary_skew=False)
+        b = rmag.unmixing_multistart(x, curve, n_components=2, n_starts=15,
+                                     random_seed=4, vary_skew=False)
+        pd.testing.assert_frame_equal(a['multistart']['solutions'],
+                                      b['multistart']['solutions'])
+
+    def test_representative_results_align_with_table(self):
+        x, curve = synthetic_curve(noise=0.002)
+        result = rmag.unmixing_multistart(x, curve, n_components=2,
+                                          n_starts=15, random_seed=4,
+                                          vary_skew=False)
+        solutions = result['multistart']['solutions']
+        representatives = result['multistart']['results']
+        assert len(representatives) == len(solutions)
+        assert representatives[0]['stats']['rss'] == \
+            pytest.approx(solutions['rss'].iloc[0])
+
+    def test_unknown_method_raises(self):
+        x, curve = synthetic_curve()
+        with pytest.raises(ValueError, match='unknown unmixing method'):
+            rmag.unmixing_multistart(x, curve, method='nope', n_components=2)
+
+    def test_solution_plot(self):
+        x, curve = synthetic_curve(noise=0.01)
+        result = rmag.unmixing_multistart(x, curve, method='curve',
+                                          n_components=2, n_starts=20,
+                                          vary_skew=True, random_seed=5)
+        fig, axes = rmag.plot_multistart_solutions(result, max_solutions=4)
+        n_distinct = len(result['multistart']['results'])
+        # one panel per shown solution plus the parameter-space map
+        assert len(axes) == min(4, n_distinct) + 1
+        plt.close(fig)
+
+    def test_solution_plot_requires_multistart(self):
+        x, curve = synthetic_curve()
+        fit = rmag.unmix_coercivity(x, curve, method='curve', n_components=2)
+        with pytest.raises(ValueError):
+            rmag.plot_multistart_solutions(fit)
+
+
+# ---------------------------------------------------------------------------
+# Bayesian unmixing (requires dynesty)
+# ---------------------------------------------------------------------------
+
+try:
+    import dynesty  # noqa: F401
+    HAS_DYNESTY = True
+except ImportError:
+    HAS_DYNESTY = False
+
+needs_dynesty = pytest.mark.skipif(not HAS_DYNESTY,
+                                   reason='dynesty not installed')
+
+
+@pytest.fixture(scope='module')
+def bayes_result():
+    """A converged Bayesian fit of the two-component synthetic curve."""
+    x, curve = synthetic_curve(noise=0.005, n=BAYES_N)
+    return rmag.unmix_coercivity_bayes(x, curve, n_components=2,
+                                       random_seed=6, **FAST_BAYES)
+
+
+@needs_dynesty
+class TestBayesianUnmixing:
+    """unmix_coercivity_bayes nested-sampling posterior."""
+
+    def test_posterior_recovers_truth(self, bayes_result):
+        params = bayes_result['params'].sort_values('location')
+        # the narrow high-coercivity component is well constrained
+        assert params['location'].iloc[1] == pytest.approx(
+            TWO_COMPONENT_TRUTH['location'].iloc[1], abs=0.05)
+        # the broad low-coercivity component overlaps it and is only
+        # loosely constrained, so use a wider tolerance
+        assert params['location'].iloc[0] == pytest.approx(
+            TWO_COMPONENT_TRUTH['location'].iloc[0], abs=0.25)
+        assert np.allclose(params['proportion'].to_numpy()[::-1], [0.6, 0.4],
+                           atol=0.12)
+
+    def test_credible_intervals_cover_truth(self, bayes_result):
+        summary = bayes_result['bayes']['param_summary']
+        # the well-constrained narrow component's 95% interval covers truth
+        true_B2 = 10 ** TWO_COMPONENT_TRUTH['location'].iloc[1]
+        assert summary.loc[2, 'B_mean_mT_p2_5'] < true_B2
+        assert summary.loc[2, 'B_mean_mT_p97_5'] > true_B2
+        # the broad component carries genuinely larger uncertainty, which the
+        # posterior should report as a wider relative interval
+        width_1 = (summary.loc[1, 'B_mean_mT_p97_5']
+                   - summary.loc[1, 'B_mean_mT_p2_5']) / summary.loc[1, 'B_mean_mT_p50']
+        width_2 = (summary.loc[2, 'B_mean_mT_p97_5']
+                   - summary.loc[2, 'B_mean_mT_p2_5']) / summary.loc[2, 'B_mean_mT_p50']
+        assert width_1 > width_2
+
+    def test_evidence_prefers_two_components(self, bayes_result):
+        x, curve = synthetic_curve(noise=0.005, n=BAYES_N)
+        one_comp = rmag.unmix_coercivity_bayes(x, curve, n_components=1,
+                                               random_seed=6, **FAST_BAYES)
+        assert bayes_result['bayes']['logz'] > one_comp['bayes']['logz'] + 10
+
+    def test_noise_estimate_recovered(self, bayes_result):
+        # data were generated with sigma = 0.005
+        assert bayes_result['bayes']['noise'] == pytest.approx(0.005,
+                                                               rel=0.5)
+
+    def test_result_structure(self, bayes_result):
+        assert bayes_result['method'] == 'bayes'
+        assert bayes_result['success']
+        assert np.isfinite(bayes_result['stats']['logz'])
+        curves = bayes_result['bayes']['curves']
+        assert (curves['total_p97_5'] >= curves['total_p2_5']).all()
+        samples = bayes_result['bayes']['samples']
+        assert samples['proportion'].shape[1] == 2
+
+    def test_registered_in_dispatcher(self):
+        assert 'bayes' in rmag.UNMIXING_METHODS
+
+    def test_dispatch_with_initial_parameters_builds_priors(self):
+        """Passing initial_parameters to the bayes method builds priors
+        centered on them and infers n_components. The high-coercivity
+        component is well constrained and should be recovered; the broad
+        low-coercivity component sits on a trade-off ridge and is only
+        loosely constrained, so we check it stays within its prior window
+        rather than pinning its median."""
+        x, curve = synthetic_curve(noise=0.005, n=BAYES_N)
+        result = rmag.unmix_coercivity(x, curve, method='bayes',
+                                       initial_parameters=TWO_COMPONENT_TRUTH,
+                                       random_seed=2, **FAST_BAYES)
+        assert result['n_components'] == 2
+        params = result['params'].sort_values('location')
+        # well-constrained high-coercivity component recovered
+        assert params['location'].iloc[1] == pytest.approx(
+            TWO_COMPONENT_TRUTH['location'].iloc[1], abs=0.15)
+        # components ordered and proportions valid
+        assert params['location'].iloc[0] < params['location'].iloc[1]
+        assert result['params']['proportion'].sum() == pytest.approx(1.0)
+
+    def test_seed_reproducibility(self):
+        x, curve = synthetic_curve(noise=0.005, n=BAYES_N)
+        a = rmag.unmix_coercivity_bayes(x, curve, n_components=1,
+                                        random_seed=13, **FAST_BAYES)
+        b = rmag.unmix_coercivity_bayes(x, curve, n_components=1,
+                                        random_seed=13, **FAST_BAYES)
+        assert a['bayes']['logz'] == pytest.approx(b['bayes']['logz'])
+
+    def test_custom_priors_respected(self):
+        x, curve = synthetic_curve(noise=0.005, n=BAYES_N)
+        priors = {'location': [(2.2, 2.6), (2.7, 3.0)],
+                  'dp': [(0.3, 0.8), (0.05, 0.3)]}
+        result = rmag.unmix_coercivity_bayes(x, curve, n_components=2,
+                                             priors=priors, random_seed=2,
+                                             **FAST_BAYES)
+        locations = result['bayes']['samples']['location']
+        assert locations[:, 0].min() >= 2.2 and locations[:, 0].max() <= 2.6
+        assert locations[:, 1].min() >= 2.7 and locations[:, 1].max() <= 3.0
+
+
+class TestOrderedUniformTransform:
+    """The order-statistics prior transform used for component locations."""
+
+    def test_output_is_ordered(self):
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            values = rmag._ordered_uniform_transform(rng.uniform(size=4),
+                                                     0.0, 1.0)
+            assert (np.diff(values) >= 0).all()
+            assert values.min() >= 0 and values.max() <= 1
+
+    def test_marginals_match_order_statistics(self):
+        """The transform reproduces uniform order-statistic means
+        E[x_(k)] = k / (K + 1)."""
+        rng = np.random.default_rng(1)
+        draws = np.array([rmag._ordered_uniform_transform(
+            rng.uniform(size=3), 0.0, 1.0) for _ in range(20000)])
+        expected = np.array([1, 2, 3]) / 4.0
+        assert np.allclose(draws.mean(axis=0), expected, atol=0.01)
+
+
+@pytest.fixture(scope='module')
+def boot():
+    """A bootstrapped two-component fit shared by the visualization tests."""
+    x, spectrum = synthetic_spectrum(noise=0.02)
+    fit = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2,
+                                         vary_skew=False)
+    return rmag.unmixing_bootstrap(fit, n_boot=60, random_seed=3)
+
+
+class TestUncertaintyVisualization:
+    """The bootstrap/posterior uncertainty-visualization helpers."""
+
+    def test_samples_accessor_bootstrap(self, boot):
+        samples, source = rmag._unmixing_samples(boot)
+        assert source == 'bootstrap'
+        assert 'B_mean_mT' in samples
+        assert samples['B_mean_mT'].shape[1] == 2
+
+    def test_samples_accessor_raises_without_draws(self):
+        x, spectrum = synthetic_spectrum()
+        fit = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2)
+        with pytest.raises(ValueError):
+            rmag._unmixing_samples(fit)
+
+    def test_posterior_plot(self, boot):
+        fig, axes = rmag.plot_unmixing_posterior(boot, quantity='proportion')
+        assert len(axes) == 2
+        plt.close(fig)
+
+    def test_posterior_plot_bad_quantity(self, boot):
+        with pytest.raises(KeyError):
+            rmag.plot_unmixing_posterior(boot, quantity='not_a_quantity')
+
+    def test_tradeoff_plot(self, boot):
+        fig, ax = rmag.plot_unmixing_tradeoff(boot, x='B_mean_mT',
+                                              y='proportion')
+        # all draws of both components are scattered
+        n_points = sum(len(c.get_offsets()) for c in ax.collections)
+        assert n_points == 2 * boot['bootstrap']['n_success']
+        plt.close(fig)
+
+    def test_tradeoff_single_component(self, boot):
+        fig, ax = rmag.plot_unmixing_tradeoff(boot, component=1)
+        assert len(ax.collections) == 1
+        plt.close(fig)
+
+    def test_ensemble_plot(self, boot):
+        fig, ax = rmag.plot_unmixing_ensemble(boot, space='spectrum',
+                                              n_draws=30, random_seed=1)
+        assert ax.get_title().endswith('bootstrap draws')
+        plt.close(fig)
+
+    def test_ensemble_curve_space(self, boot):
+        fig, ax = rmag.plot_unmixing_ensemble(boot, space='curve',
+                                              n_draws=20, random_seed=1)
+        plt.close(fig)
+
+
+class TestMineralPriors:
+    """The coercivity component prior library and mineral_priors helper."""
+
+    def test_library_entries_are_well_formed(self):
+        for name, entry in rmag.COERCIVITY_COMPONENT_LIBRARY.items():
+            for key in ('B_median_mT', 'dp', 'skew'):
+                low, high = entry[key]
+                assert low < high, f'{name} {key} not ordered'
+            assert 'source' in entry
+
+    def test_builds_priors_sorted_by_coercivity(self):
+        priors = rmag.mineral_priors(['hematite_detrital',
+                                      'magnetite_detrital'])
+        # returned in increasing coercivity order regardless of input order
+        assert priors['components'] == ['magnetite_detrital',
+                                        'hematite_detrital']
+        assert priors['location'][0][1] < priors['location'][1][0]
+
+    def test_location_bounds_match_library(self):
+        priors = rmag.mineral_priors(['magnetite_detrital'])
+        low, high = rmag.COERCIVITY_COMPONENT_LIBRARY[
+            'magnetite_detrital']['B_median_mT']
+        assert priors['location'][0] == pytest.approx(
+            (np.log10(low), np.log10(high)))
+
+    def test_tighten_narrows_ranges(self):
+        wide = rmag.mineral_priors(['hematite'])['dp'][0]
+        narrow = rmag.mineral_priors(['hematite'], tighten=2)['dp'][0]
+        assert (narrow[1] - narrow[0]) == pytest.approx(
+            (wide[1] - wide[0]) / 2)
+        # same center
+        assert (narrow[0] + narrow[1]) == pytest.approx(wide[0] + wide[1])
+
+    def test_field_max_clips_location(self):
+        priors = rmag.mineral_priors(['goethite'], field_max_mT=2000)
+        assert priors['location'][0][1] == pytest.approx(np.log10(2000))
+
+    def test_accepts_single_string(self):
+        priors = rmag.mineral_priors('hematite')
+        assert len(priors['location']) == 1
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(KeyError):
+            rmag.mineral_priors(['unobtainium'])
+
+    def test_tighten_below_one_raises(self):
+        with pytest.raises(ValueError):
+            rmag.mineral_priors(['hematite'], tighten=0.5)
+
+    @needs_dynesty
+    def test_priors_drive_bayes_and_infer_n_components(self):
+        x, curve = synthetic_curve(noise=0.005, n=BAYES_N)
+        # the synthetic components sit near 250 and 750 mT; use library
+        # windows that bracket them, and let n_components come from priors
+        priors = rmag.mineral_priors(['hematite_pigmentary',
+                                      'hematite_detrital'])
+        result = rmag.unmix_coercivity(x, curve, method='bayes',
+                                       priors=priors, random_seed=3,
+                                       **FAST_BAYES)
+        assert result['n_components'] == 2
+        # each component stays within its mineral's coercivity window
+        samples = result['bayes']['samples']['location']
+        for comp, (low, high) in enumerate(priors['location']):
+            assert samples[:, comp].min() >= low - 1e-6
+            assert samples[:, comp].max() <= high + 1e-6
+
+
+class TestParseDescription:
+    """parse_specimen_description edge cases."""
+
+    def test_nan_returns_empty(self):
+        text, data = rmag.parse_specimen_description(np.nan)
+        assert text == '' and data == {}
+
+    def test_plain_text(self):
+        text, data = rmag.parse_specimen_description('powder for Mossbauer')
+        assert text == 'powder for Mossbauer' and data == {}
+
+    def test_legacy_python_dict_repr(self):
+        text, data = rmag.parse_specimen_description(
+            "{'g1_amplitude': 0.5, 'g1_center': 100.0}")
+        assert data == {'g1_amplitude': 0.5, 'g1_center': 100.0}
+
+    def test_json_payload(self):
+        text, data = rmag.parse_specimen_description(
+            'rock chip | {"coercivity_unmixing": {"n_components": 2}}')
+        assert text == 'rock chip'
+        assert data['coercivity_unmixing']['n_components'] == 2

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -548,6 +548,40 @@ class TestBootstrap:
         assert curves['total_p97_5'].shape == (150,)
         assert (curves['total_p97_5'] >= curves['total_p2_5']).all()
 
+    def test_maxunmix_result_bootstraps_in_spectrum_space(self):
+        """Regression: a maxunmix result is spectrum-space, so bootstrapping
+        it must refit with the spectrum model. Dispatching on the method name
+        alone (method == 'spectrum') sent maxunmix results through the
+        cumulative-curve branch, fitting the wrong model to derivative data
+        and recovering nonsense coercivities."""
+        x, curve = synthetic_curve(noise=0.002)
+        result = rmag.unmix_coercivity(x, curve, method='maxunmix',
+                                       n_components=2, vary_skew=False,
+                                       n_boot=20, random_seed=1)
+        boot = rmag.unmixing_bootstrap(result, n_boot=40, random_seed=2)
+        summary = boot['bootstrap']['param_summary']
+        assert boot['bootstrap']['n_success'] > 0
+        # the refit recovers the true coercivities (it fit the spectrum, not
+        # the cumulative curve model applied to spectrum data)
+        for comp in (1, 2):
+            true_B = 10 ** TWO_COMPONENT_TRUTH['location'].iloc[comp - 1]
+            assert (summary.loc[comp, 'B_mean_mT_p2_5']
+                    < true_B < summary.loc[comp, 'B_mean_mT_p97_5'])
+
+    def test_bayes_result_rejected(self):
+        """A Bayesian result already carries posterior uncertainty, so
+        unmixing_bootstrap refuses it with a clear error rather than silently
+        refitting a least-squares model (previously the spectrum-space bayes
+        result took the curve branch and fit the cumulative model to the
+        spectrum)."""
+        x, curve = synthetic_curve(noise=0.01)
+        result = rmag.unmix_coercivity(x, curve, method='bayes',
+                                       space='spectrum', n_components=2,
+                                       vary_skew=False, random_seed=1,
+                                       **FAST_BAYES)
+        with pytest.raises(ValueError, match='posterior uncertainty'):
+            rmag.unmixing_bootstrap(result)
+
 
 # ---------------------------------------------------------------------------
 # MagIC batch processing and specimens export

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -18,6 +18,19 @@ from scipy.integrate import quad
 from pmagpy import rockmag as rmag
 
 
+# dynesty (nested sampling) is an optional dependency; skip the tests that
+# genuinely run a Bayesian fit when it is absent (e.g. on CI). Defined here at
+# module top so every test class below can reference it.
+try:
+    import dynesty  # noqa: F401
+    HAS_DYNESTY = True
+except ImportError:
+    HAS_DYNESTY = False
+
+needs_dynesty = pytest.mark.skipif(not HAS_DYNESTY,
+                                   reason='dynesty not installed')
+
+
 # a two-component reference model resembling red bed hematite spectra:
 # a broad lower-coercivity component and a narrow high-coercivity one
 TWO_COMPONENT_TRUTH = pd.DataFrame({
@@ -623,12 +636,10 @@ class TestBootstrap:
         unmixing_bootstrap refuses it with a clear error rather than silently
         refitting a least-squares model (previously the spectrum-space bayes
         result took the curve branch and fit the cumulative model to the
-        spectrum)."""
-        x, curve = synthetic_curve(noise=0.01)
-        result = rmag.unmix_coercivity(x, curve, method='bayes',
-                                       space='spectrum', n_components=2,
-                                       vary_skew=False, random_seed=1,
-                                       **FAST_BAYES)
+        spectrum). unmixing_bootstrap raises on method == 'bayes' before it
+        touches the result, so a minimal result marker exercises the guard
+        without needing a (dynesty-backed) fit."""
+        result = {'method': 'bayes', 'space': 'spectrum'}
         with pytest.raises(ValueError, match='posterior uncertainty'):
             rmag.unmixing_bootstrap(result)
 
@@ -708,39 +719,43 @@ class TestBatchProcessing:
         assert list(results) == ['synthetic-LP-BCR-BF-1']
         assert components_df['experiment'].nunique() == 1
 
-    def test_smoothing_routes_spectrum_but_not_bayes(self):
-        """Regression: with smoothing on, the finite-difference 'spectrum'
-        method fits the smoothed curve, but the measurement-space Bayesian
-        method must fit the UNSMOOTHED curve. Routing the denoised data to
-        the bayes likelihood (which infers its own noise level) understates
-        the noise and yields overconfident credible intervals."""
-        measurements = make_magic_measurements()
+    def test_smoothing_reaches_spectrum_method(self):
+        """The finite-difference 'spectrum' method fits the (optionally
+        smoothed) curve: the data it fits differs between a smoothed and an
+        unsmoothed run. Uses spline smoothing so it is independent of the
+        optional statsmodels/LOWESS dependency."""
+        measurements = make_magic_measurements(rng=np.random.default_rng(2027))
         experiment = 'synthetic-LP-BCR-BF-1'
-        one = measurements[measurements['experiment'] == experiment].copy()
-        processed, _bcr = rmag.backfield_data_processing(one, smooth_frac=0.2)
-        unsmoothed = processed['magn_mass_shift'].to_numpy()
-        # sanity: smoothing actually changed the curve
-        assert not np.allclose(
-            unsmoothed, processed['smoothed_magn_mass_shift'].to_numpy())
-
-        # smoothing reaches the spectrum method: the data it fits differs
-        # between a smoothed and an unsmoothed run
         _c, spec_smoothed = rmag.unmix_backfield_experiments(
             measurements, method='spectrum', n_components=2, vary_skew=False,
-            smooth_frac=0.2, verbose=False)
+            smooth_frac=0.3, smooth_mode='spline', verbose=False)
         _c0, spec_raw = rmag.unmix_backfield_experiments(
             measurements, method='spectrum', n_components=2, vary_skew=False,
             smooth_frac=0.0, verbose=False)
         assert not np.allclose(np.asarray(spec_smoothed[experiment]['y']),
                                np.asarray(spec_raw[experiment]['y']))
 
-        # measurement-space bayes fits the unsmoothed curve directly, so its
-        # fitted data is unchanged by smooth_frac and equals the raw curve
-        _c2, bayes_smoothed = rmag.unmix_backfield_experiments(
+    @needs_dynesty
+    def test_bayes_ignores_smoothing(self):
+        """Regression: the measurement-space Bayesian method fits the
+        UNSMOOTHED curve even with smoothing on, so its inferred noise model
+        sees the true measurement noise. Feeding it the denoised curve would
+        understate the noise and yield overconfident credible intervals."""
+        measurements = make_magic_measurements(rng=np.random.default_rng(2027))
+        experiment = 'synthetic-LP-BCR-BF-1'
+        one = measurements[measurements['experiment'] == experiment].copy()
+        processed, _bcr = rmag.backfield_data_processing(
+            one, smooth_frac=0.3, smooth_mode='spline')
+        unsmoothed = processed['magn_mass_shift'].to_numpy()
+        # sanity: smoothing actually changed the curve
+        assert not np.allclose(
+            unsmoothed, processed['smoothed_magn_mass_shift'].to_numpy())
+        # the bayes fit's stored data equals the unsmoothed curve
+        _c, results = rmag.unmix_backfield_experiments(
             measurements, method='bayes', n_components=2, vary_skew=False,
-            smooth_frac=0.2, random_seed=3, verbose=False, **FAST_BAYES)
-        assert np.allclose(np.asarray(bayes_smoothed[experiment]['y']),
-                           unsmoothed)
+            smooth_frac=0.3, smooth_mode='spline', random_seed=3,
+            verbose=False, **FAST_BAYES)
+        assert np.allclose(np.asarray(results[experiment]['y']), unsmoothed)
 
 
 class TestAggregateByClass:
@@ -1091,15 +1106,6 @@ class TestMultistart:
 # Bayesian unmixing (requires dynesty)
 # ---------------------------------------------------------------------------
 
-try:
-    import dynesty  # noqa: F401
-    HAS_DYNESTY = True
-except ImportError:
-    HAS_DYNESTY = False
-
-needs_dynesty = pytest.mark.skipif(not HAS_DYNESTY,
-                                   reason='dynesty not installed')
-
 
 @pytest.fixture(scope='module')
 def bayes_result():
@@ -1267,6 +1273,24 @@ def bayes_viz():
                                  random_seed=1, **FAST_BAYES)
 
 
+@pytest.fixture(scope='module')
+def posterior_result():
+    """A synthetic posterior-style result whose draws mix per-component 2-D
+    quantities with the 1-D global 'offset'/'noise' arrays. Built directly
+    (no dynesty-backed fit) so the plot helpers' handling of 1-D quantities
+    can be tested wherever numpy is available, including CI without dynesty."""
+    rng = np.random.default_rng(0)
+    n = 200
+    samples = {
+        'B_mean_mT': 10 ** rng.normal([2.4, 2.8], 0.08, size=(n, 2)),
+        'proportion': (np.tile([0.4, 0.6], (n, 1))
+                       + rng.normal(0.0, 0.03, size=(n, 2))),
+        'offset': rng.normal(0.0, 0.01, size=n),   # 1-D global quantity
+        'noise': np.abs(rng.normal(0.02, 0.004, size=n)),  # 1-D global
+    }
+    return {'bayes': {'samples': samples}}
+
+
 class TestUncertaintyVisualization:
     """The bootstrap/posterior uncertainty-visualization helpers."""
 
@@ -1304,28 +1328,29 @@ class TestUncertaintyVisualization:
         assert len(ax.collections) == 1
         plt.close(fig)
 
-    def test_posterior_plot_global_quantity(self, bayes_viz):
+    def test_posterior_plot_global_quantity(self, posterior_result):
         """Regression: a 1-D global quantity ('noise') renders as a single
         histogram rather than raising IndexError on values.shape[1]."""
-        fig, axes = rmag.plot_unmixing_posterior(bayes_viz, quantity='noise')
+        fig, axes = rmag.plot_unmixing_posterior(posterior_result,
+                                                 quantity='noise')
         assert len(axes) == 1
         assert axes[0].get_ylabel() == 'density'
         plt.close(fig)
 
-    def test_tradeoff_plot_global_vs_component(self, bayes_viz):
+    def test_tradeoff_plot_global_vs_component(self, posterior_result):
         """Regression: a global quantity ('noise') pairs with a per-component
         one, broadcasting across components instead of raising IndexError."""
-        fig, ax = rmag.plot_unmixing_tradeoff(bayes_viz, x='noise',
+        fig, ax = rmag.plot_unmixing_tradeoff(posterior_result, x='noise',
                                               y='B_mean_mT')
         n_points = sum(len(c.get_offsets()) for c in ax.collections)
         n_draws = np.asarray(
-            bayes_viz['bayes']['samples']['noise']).shape[0]
+            posterior_result['bayes']['samples']['noise']).shape[0]
         assert n_points == 2 * n_draws
         plt.close(fig)
 
-    def test_tradeoff_plot_global_vs_global(self, bayes_viz):
+    def test_tradeoff_plot_global_vs_global(self, posterior_result):
         """Two global quantities ('offset' vs 'noise') scatter as one series."""
-        fig, ax = rmag.plot_unmixing_tradeoff(bayes_viz, x='offset',
+        fig, ax = rmag.plot_unmixing_tradeoff(posterior_result, x='offset',
                                               y='noise')
         assert len(ax.collections) == 1
         plt.close(fig)

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -339,6 +339,31 @@ class TestMethodDispatch:
         assert result['bootstrap']['param_noise'] == 0.02
         assert 'param_summary' in result['bootstrap']
 
+    def test_maxunmix_param_noise_kwarg(self):
+        """The restart-perturbation size is controlled by 'param_noise' (the
+        name the docstring advertises), forwarded through **kwargs."""
+        x, curve = synthetic_curve(noise=0.002)
+        result = rmag.unmix_coercivity(x, curve, method='maxunmix',
+                                       n_components=2, vary_skew=False,
+                                       n_boot=30, random_seed=7,
+                                       param_noise=0.05)
+        assert result['bootstrap']['param_noise'] == 0.05
+
+    def test_maxunmix_replicates_respect_kwargs_bounds(self):
+        """Regression: replicate refits must run under the same bounds as the
+        main fit. Previously **kwargs (dp_bounds, skew_bounds) were forwarded
+        only to the main fit, so replicate dispersions escaped the user's
+        dp_bounds (reaching ~0.66 under a (0.20, 0.21) constraint)."""
+        x, curve = synthetic_curve(noise=0.002)
+        result = rmag.unmix_coercivity(x, curve, method='maxunmix',
+                                       n_components=2, vary_skew=False,
+                                       n_boot=30, random_seed=1,
+                                       dp_bounds=(0.2, 0.21))
+        summary = result['bootstrap']['param_summary']
+        # every replicate's dispersion stays inside the tight bounds
+        assert (summary['dp_p2_5'] >= 0.20 - 1e-6).all()
+        assert (summary['dp_p97_5'] <= 0.21 + 1e-6).all()
+
     def test_unknown_method_raises(self):
         x, curve = synthetic_curve()
         with pytest.raises(ValueError, match='unknown unmixing method'):

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -1189,6 +1189,16 @@ def boot():
     return rmag.unmixing_bootstrap(fit, n_boot=60, random_seed=3)
 
 
+@pytest.fixture(scope='module')
+def bayes_viz():
+    """A Bayesian fit whose draws include the 1-D global 'offset' and 'noise'
+    arrays (per-draw scalars, not per-component)."""
+    x, curve = synthetic_curve(noise=0.01, n=BAYES_N)
+    return rmag.unmix_coercivity(x, curve, method='bayes', space='curve',
+                                 n_components=2, vary_skew=False,
+                                 random_seed=1, **FAST_BAYES)
+
+
 class TestUncertaintyVisualization:
     """The bootstrap/posterior uncertainty-visualization helpers."""
 
@@ -1223,6 +1233,32 @@ class TestUncertaintyVisualization:
 
     def test_tradeoff_single_component(self, boot):
         fig, ax = rmag.plot_unmixing_tradeoff(boot, component=1)
+        assert len(ax.collections) == 1
+        plt.close(fig)
+
+    def test_posterior_plot_global_quantity(self, bayes_viz):
+        """Regression: a 1-D global quantity ('noise') renders as a single
+        histogram rather than raising IndexError on values.shape[1]."""
+        fig, axes = rmag.plot_unmixing_posterior(bayes_viz, quantity='noise')
+        assert len(axes) == 1
+        assert axes[0].get_ylabel() == 'density'
+        plt.close(fig)
+
+    def test_tradeoff_plot_global_vs_component(self, bayes_viz):
+        """Regression: a global quantity ('noise') pairs with a per-component
+        one, broadcasting across components instead of raising IndexError."""
+        fig, ax = rmag.plot_unmixing_tradeoff(bayes_viz, x='noise',
+                                              y='B_mean_mT')
+        n_points = sum(len(c.get_offsets()) for c in ax.collections)
+        n_draws = np.asarray(
+            bayes_viz['bayes']['samples']['noise']).shape[0]
+        assert n_points == 2 * n_draws
+        plt.close(fig)
+
+    def test_tradeoff_plot_global_vs_global(self, bayes_viz):
+        """Two global quantities ('offset' vs 'noise') scatter as one series."""
+        fig, ax = rmag.plot_unmixing_tradeoff(bayes_viz, x='offset',
+                                              y='noise')
         assert len(ax.collections) == 1
         plt.close(fig)
 

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -18,8 +18,6 @@ from scipy.integrate import quad
 from pmagpy import rockmag as rmag
 
 
-RNG = np.random.default_rng(2026)
-
 # a two-component reference model resembling red bed hematite spectra:
 # a broad lower-coercivity component and a narrow high-coercivity one
 TWO_COMPONENT_TRUTH = pd.DataFrame({
@@ -556,9 +554,16 @@ class TestBootstrap:
 # ---------------------------------------------------------------------------
 
 def make_magic_measurements(experiment='synthetic-LP-BCR-BF-1',
-                            specimen='spec1', noise=0.002, rng=RNG):
+                            specimen='spec1', noise=0.002, rng=None):
     """Build a minimal MagIC-style measurements table with a backfield
-    experiment generated from the reference two-component model."""
+    experiment generated from the reference two-component model.
+
+    Uses a fresh seeded generator by default so each call is deterministic
+    and independent of test execution order (a shared module-level RNG made
+    the noise depend on how many other tests had drawn from it first).
+    """
+    if rng is None:
+        rng = np.random.default_rng(2026)
     x = np.linspace(0.5, 3.2, 90)
     curve_shifted = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
                                                 curve_type='backfield')
@@ -625,9 +630,7 @@ class TestBatchProcessing:
         method must fit the UNSMOOTHED curve. Routing the denoised data to
         the bayes likelihood (which infers its own noise level) understates
         the noise and yields overconfident credible intervals."""
-        # use an isolated RNG so this test does not advance the module-level
-        # RNG stream that later tests' fixtures draw from
-        measurements = make_magic_measurements(rng=np.random.default_rng(2027))
+        measurements = make_magic_measurements()
         experiment = 'synthetic-LP-BCR-BF-1'
         one = measurements[measurements['experiment'] == experiment].copy()
         processed, _bcr = rmag.backfield_data_processing(one, smooth_frac=0.2)

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -1275,6 +1275,22 @@ class TestMineralPriors:
         # hematite window is (150, 1500) mT; a 1 T max field clips the top
         priors = rmag.mineral_priors(['hematite'], field_max_mT=1000)
         assert priors['mean'][0][1] == pytest.approx(np.log10(1000))
+        # the lower bound is untouched, so the window keeps a real width
+        assert priors['mean'][0][0] < priors['mean'][0][1]
+
+    def test_field_max_below_window_raises(self):
+        """Regression: a component whose whole coercivity window lies above
+        the maximum applied field must raise, not silently collapse to a
+        zero-width window pinned at log10(field_max)."""
+        with pytest.raises(ValueError, match='cannot constrain'):
+            rmag.mineral_priors(['hematite_detrital'], field_max_mT=300)
+
+    def test_field_max_names_the_unconstrainable_component(self):
+        """In a mixed list only the component beyond the field range trips the
+        error, and the message identifies it."""
+        with pytest.raises(ValueError, match='hematite_detrital'):
+            rmag.mineral_priors(['hematite_pigmentary', 'hematite_detrital'],
+                                field_max_mT=300)
 
     def test_accepts_single_string(self):
         priors = rmag.mineral_priors('hematite')

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -478,6 +478,25 @@ class TestSelectNComponents:
         assert 'reduced_chi2' in table.columns
         assert selected >= 1
 
+    def test_chi2_units_match_spectrum_space_fit(self):
+        """Regression: for spectrum-space methods the noise must be estimated
+        in spectrum units so reduced chi-square is O(1). Previously the noise
+        was taken from the measured curve while rss was in dM/dlog10(B) units,
+        inflating reduced chi-square by the finite-difference amplification
+        (~10^2-10^3) so the chi2 branch always ran to max_components."""
+        x, curve = synthetic_curve(noise=0.001)
+        selected, table, _r = rmag.select_n_components(
+            x, curve, method='spectrum', criterion='chi2',
+            reduced_chi2_target=1.0, max_components=4)
+        # at the true 2-component count the model fits to within the (spectrum)
+        # noise: reduced chi-square is order unity, not the ~10^3 unit-mismatch
+        chi2_at_two = table.loc[table['n_components'] == 2,
+                                'reduced_chi2'].iloc[0]
+        assert 0.1 < chi2_at_two < 20.0
+        # one component leaves misfit above the noise, two clears it: the
+        # criterion resolves the true count instead of running to max_components
+        assert selected == 2
+
     def test_unknown_method_raises(self):
         x, curve = synthetic_curve()
         with pytest.raises(ValueError):
@@ -770,6 +789,46 @@ class TestSpecimensExport:
         twice = rmag.unmixing_to_specimens_table(once, components_df,
                                                  mode='rows')
         assert len(once) == len(twice)
+
+    def test_rows_mode_idempotent_with_colon_delimited_experiments(
+            self, batch_output):
+        """Regression: when the specimen's 'experiments' cell lists several
+        experiments (colon-delimited), re-runs must not accumulate duplicate
+        component rows. Previously the new rows inherited the full colon
+        string while cleanup matched the single experiment name, so exact
+        matching failed and rows piled up (2 -> 4 -> 6)."""
+        components_df, specimens = batch_output
+        specimens = specimens.copy()
+        specimens['experiments'] = 'synthetic-LP-BCR-BF-1:synthetic-LP-HYS-1'
+        df = specimens
+        for _ in range(3):
+            df = rmag.unmixing_to_specimens_table(df, components_df,
+                                                  mode='rows')
+        marker = 'coercivity_unmixing_component_row'
+        component_rows = df['description'].astype(str).str.contains(
+            marker, na=False)
+        assert int(component_rows.sum()) == 2
+        # the appended rows carry the single experiment, not the full list
+        assert (df.loc[component_rows, 'experiments']
+                == 'synthetic-LP-BCR-BF-1').all()
+
+    def test_rows_mode_preserves_original_row_with_rem_cmf(self, batch_output):
+        """Regression: cleanup must remove only the component rows this
+        function created, identified by an explicit marker -- never an
+        original specimen row that happens to carry a 'coercivity_unmixing'
+        description payload (from mode='description') together with a
+        populated rem_cmf."""
+        components_df, specimens = batch_output
+        specimens = specimens.copy()
+        specimens['rem_cmf'] = 0.05
+        specimens['description'] = '{"coercivity_unmixing": {"n_components": 2}}'
+        updated = rmag.unmixing_to_specimens_table(specimens, components_df,
+                                                   mode='rows')
+        # the original row survives (2 new component rows + 1 original == 3)
+        assert len(updated) == 3
+        survived = updated['description'] == \
+            '{"coercivity_unmixing": {"n_components": 2}}'
+        assert survived.sum() == 1
 
     def test_description_mode_preserves_text(self, batch_output):
         components_df, specimens = batch_output

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -619,6 +619,42 @@ class TestBatchProcessing:
         assert list(results) == ['synthetic-LP-BCR-BF-1']
         assert components_df['experiment'].nunique() == 1
 
+    def test_smoothing_routes_spectrum_but_not_bayes(self):
+        """Regression: with smoothing on, the finite-difference 'spectrum'
+        method fits the smoothed curve, but the measurement-space Bayesian
+        method must fit the UNSMOOTHED curve. Routing the denoised data to
+        the bayes likelihood (which infers its own noise level) understates
+        the noise and yields overconfident credible intervals."""
+        # use an isolated RNG so this test does not advance the module-level
+        # RNG stream that later tests' fixtures draw from
+        measurements = make_magic_measurements(rng=np.random.default_rng(2027))
+        experiment = 'synthetic-LP-BCR-BF-1'
+        one = measurements[measurements['experiment'] == experiment].copy()
+        processed, _bcr = rmag.backfield_data_processing(one, smooth_frac=0.2)
+        unsmoothed = processed['magn_mass_shift'].to_numpy()
+        # sanity: smoothing actually changed the curve
+        assert not np.allclose(
+            unsmoothed, processed['smoothed_magn_mass_shift'].to_numpy())
+
+        # smoothing reaches the spectrum method: the data it fits differs
+        # between a smoothed and an unsmoothed run
+        _c, spec_smoothed = rmag.unmix_backfield_experiments(
+            measurements, method='spectrum', n_components=2, vary_skew=False,
+            smooth_frac=0.2, verbose=False)
+        _c0, spec_raw = rmag.unmix_backfield_experiments(
+            measurements, method='spectrum', n_components=2, vary_skew=False,
+            smooth_frac=0.0, verbose=False)
+        assert not np.allclose(np.asarray(spec_smoothed[experiment]['y']),
+                               np.asarray(spec_raw[experiment]['y']))
+
+        # measurement-space bayes fits the unsmoothed curve directly, so its
+        # fitted data is unchanged by smooth_frac and equals the raw curve
+        _c2, bayes_smoothed = rmag.unmix_backfield_experiments(
+            measurements, method='bayes', n_components=2, vary_skew=False,
+            smooth_frac=0.2, random_seed=3, verbose=False, **FAST_BAYES)
+        assert np.allclose(np.asarray(bayes_smoothed[experiment]['y']),
+                           unsmoothed)
+
 
 class TestAggregateByClass:
     """aggregate_by_class collapses components into coercivity classes."""

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -1504,3 +1504,121 @@ class TestParseDescription:
             'rock chip | {"coercivity_unmixing": {"n_components": 2}}')
         assert text == 'rock chip'
         assert data['coercivity_unmixing']['n_components'] == 2
+
+
+# ---------------------------------------------------------------------------
+# shared summary helpers, unified defaults, and trial-fit economy
+# ---------------------------------------------------------------------------
+
+
+class TestSharedSummaryHelpers:
+    def test_vectorized_median_matches_scalar(self):
+        for skew in (-4.0, -1.0, 0.0, 0.7, 3.0):
+            stats = rmag.skewnormal_stats(1.7, 0.3, skew)
+            z = rmag._skewnormal_median_z(np.array([skew]))[0]
+            assert 1.7 + 0.3 * z == pytest.approx(stats['median'], abs=1e-6)
+
+    def test_vectorized_mode_matches_scalar(self):
+        for skew in (-4.0, -1.0, 0.0, 0.7, 3.0):
+            stats = rmag.skewnormal_stats(1.7, 0.3, skew)
+            z = rmag._skewnormal_mode_z(np.array([skew]))[0]
+            assert 1.7 + 0.3 * z == pytest.approx(stats['mode'], abs=2e-3)
+
+    @needs_dynesty
+    def test_bootstrap_and_bayes_summaries_share_columns(self, boot,
+                                                         bayes_viz):
+        # the three uncertainty flavors (bootstrap, maxunmix, bayes) now
+        # build their summaries through the same helper, so code written
+        # against one summary works against the others
+        boot_columns = set(boot['bootstrap']['param_summary'].columns)
+        bayes_columns = set(bayes_viz['bayes']['param_summary'].columns)
+        assert boot_columns == bayes_columns
+        assert 'B_median_mT_p2_5' in bayes_columns
+        assert 'B_peak_mT_p97_5' in bayes_columns
+
+    def test_maxunmix_summary_shares_columns_with_bootstrap(self, boot):
+        x, curve = synthetic_curve(noise=0.005)
+        res = rmag.unmix_coercivity(x, curve, method='maxunmix',
+                                    n_components=2, vary_skew=False,
+                                    n_boot=20, random_seed=11)
+        assert (set(res['bootstrap']['param_summary'].columns)
+                == set(boot['bootstrap']['param_summary'].columns))
+
+
+class TestUnifiedDefaults:
+    def test_sibling_method_defaults_agree(self):
+        import inspect
+        assert rmag.DEFAULT_UNMIX_METHOD == 'spectrum'
+        for func in (rmag.unmix_coercivity, rmag.select_n_components,
+                     rmag.unmixing_multistart,
+                     rmag.unmix_backfield_experiments):
+            assert (inspect.signature(func).parameters['method'].default
+                    == rmag.DEFAULT_UNMIX_METHOD), func.__name__
+
+    def test_sibling_vary_skew_defaults_agree(self):
+        import inspect
+        for func in (rmag.unmix_coercivity, rmag.unmix_coercivity_spectrum,
+                     rmag.unmix_backfield_curve, rmag.select_n_components,
+                     rmag.unmixing_multistart,
+                     rmag.unmix_backfield_experiments):
+            assert (inspect.signature(func).parameters['vary_skew'].default
+                    == rmag.DEFAULT_UNMIX_VARY_SKEW), func.__name__
+        # deliberate, documented deviation: nested sampling with free skew
+        # is expensive and better constrained through explicit priors
+        import inspect as _inspect
+        assert (_inspect.signature(rmag.unmix_coercivity_bayes)
+                .parameters['vary_skew'].default is False)
+
+
+class TestMaxunmixTrialEconomy:
+    def test_n_boot_zero_returns_point_fit(self):
+        x, curve = synthetic_curve(noise=0.005)
+        res = rmag.unmix_coercivity(x, curve, method='maxunmix',
+                                    n_components=2, vary_skew=False,
+                                    n_boot=0)
+        assert res['success']
+        assert 'bootstrap' not in res
+
+    def test_multistart_bootstraps_winner_only(self):
+        x, curve = synthetic_curve(noise=0.005)
+        best = rmag.unmixing_multistart(x, curve, method='maxunmix',
+                                        n_components=2, n_starts=4,
+                                        vary_skew=False, random_seed=7,
+                                        n_boot=20)
+        # the returned winner carries the full resampling uncertainty...
+        assert 'bootstrap' in best
+        assert best['bootstrap']['n_boot'] == 20
+        assert 'multistart' in best
+        # ...but the trial representatives skipped it
+        for trial in best['multistart']['results']:
+            assert 'bootstrap' not in trial
+
+    def test_select_n_components_refits_selected_only(self):
+        x, curve = synthetic_curve(noise=0.005)
+        selected, table, results = rmag.select_n_components(
+            x, curve, method='maxunmix', max_components=3, vary_skew=False,
+            n_boot=20, random_seed=13)
+        assert selected == 2
+        assert 'bootstrap' in results[selected]
+        for K, res in results.items():
+            if K != selected:
+                assert 'bootstrap' not in res
+
+
+class TestLegacyMaxUnmixDeprecation:
+    def test_backfield_MaxUnmix_warns(self):
+        x = np.linspace(0.5, 3.0, 60)
+        curve = rmag.coercivity_curve_model(x, TWO_COMPONENT_TRUTH,
+                                            curve_type='backfield')
+        params = pd.DataFrame({'amplitude': [0.5], 'center': [2.7],
+                               'sigma': [0.2], 'gamma': [0.0]})
+        with pytest.warns(FutureWarning, match='backfield_MaxUnmix is '
+                                               'deprecated'):
+            try:
+                rmag.backfield_MaxUnmix(x, curve, n_comps=1,
+                                        parameters=params, n_resample=2,
+                                        random_seed=0)
+            except ImportError:
+                pytest.skip('lmfit not installed')
+            finally:
+                plt.close('all')

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -600,6 +600,139 @@ class TestBatchProcessing:
         assert components_df['experiment'].nunique() == 1
 
 
+class TestAggregateByClass:
+    """aggregate_by_class collapses components into coercivity classes."""
+
+    @staticmethod
+    def _components():
+        # two experiments; expt A has a single magnetite component that the
+        # optimizer split into two, expt B has magnetite + hematite
+        return pd.DataFrame({
+            'experiment': ['A', 'A', 'B', 'B'],
+            'specimen': ['sA', 'sA', 'sB', 'sB'],
+            'B_mean_mT': [40.0, 60.0, 50.0, 600.0],
+            'proportion': [0.5, 0.5, 0.7, 0.3],
+            'contribution': [0.5, 0.5, 0.7, 0.3],
+            'r_squared': [0.999, 0.999, 0.998, 0.998],
+        })
+
+    def test_split_component_is_robust(self):
+        out = rmag.aggregate_by_class(
+            self._components(), boundaries_mT=200.0,
+            class_names=['magnetite', 'hematite'])
+        row_a = out[out['experiment'] == 'A'].iloc[0]
+        # the spurious two-way split of one mineral is summed back to 1.0
+        assert row_a['magnetite_fraction'] == pytest.approx(1.0)
+        assert row_a['hematite_fraction'] == pytest.approx(0.0)
+        row_b = out[out['experiment'] == 'B'].iloc[0]
+        assert row_b['magnetite_fraction'] == pytest.approx(0.7)
+        assert row_b['hematite_fraction'] == pytest.approx(0.3)
+
+    def test_passthrough_columns_carried(self):
+        out = rmag.aggregate_by_class(
+            self._components(), boundaries_mT=200.0,
+            class_names=['magnetite', 'hematite'])
+        assert set(['specimen', 'r_squared']).issubset(out.columns)
+        assert out[out['experiment'] == 'A'].iloc[0]['specimen'] == 'sA'
+
+    def test_curve_factor_halves_remanence(self):
+        out = rmag.aggregate_by_class(
+            self._components(), boundaries_mT=200.0,
+            class_names=['magnetite', 'hematite'], curve_factor=2.0)
+        row_b = out[out['experiment'] == 'B'].iloc[0]
+        # contribution 0.7 divided by the backfield span factor of 2
+        assert row_b['magnetite_remanence'] == pytest.approx(0.35)
+
+    def test_three_classes_from_two_boundaries(self):
+        out = rmag.aggregate_by_class(
+            self._components(), boundaries_mT=[45.0, 200.0],
+            class_names=['soft', 'mid', 'hard'])
+        row_a = out[out['experiment'] == 'A'].iloc[0]
+        # 40 mT -> soft, 60 mT -> mid
+        assert row_a['soft_fraction'] == pytest.approx(0.5)
+        assert row_a['mid_fraction'] == pytest.approx(0.5)
+        assert row_a['hard_fraction'] == pytest.approx(0.0)
+
+    def test_default_class_names(self):
+        out = rmag.aggregate_by_class(self._components(), boundaries_mT=200.0)
+        assert 'class_1_fraction' in out.columns
+        assert 'class_2_fraction' in out.columns
+
+    def test_wrong_class_name_count_raises(self):
+        with pytest.raises(ValueError):
+            rmag.aggregate_by_class(self._components(), boundaries_mT=200.0,
+                                    class_names=['only_one'])
+
+    def test_missing_coercivity_column_raises(self):
+        with pytest.raises(KeyError):
+            rmag.aggregate_by_class(self._components(), boundaries_mT=200.0,
+                                    coercivity_column='nope')
+
+    def test_end_to_end_from_batch(self):
+        measurements = make_magic_measurements()
+        components_df, _results = rmag.unmix_backfield_experiments(
+            measurements, n_components=2, vary_skew=False, verbose=False)
+        out = rmag.aggregate_by_class(
+            components_df, boundaries_mT=500.0,
+            class_names=['low', 'high'])
+        row = out.iloc[0]
+        # the two synthetic components straddle 500 mT (250 and 750)
+        assert row['low_fraction'] == pytest.approx(0.4, abs=0.08)
+        assert row['high_fraction'] == pytest.approx(0.6, abs=0.08)
+        assert (row['low_fraction'] + row['high_fraction']) == pytest.approx(
+            1.0, abs=1e-6)
+
+
+class TestComponentColors:
+    """color_by option of plot_coercivity_unmixing / helper."""
+
+    def test_component_colors_by_order(self):
+        colors = rmag._unmixing_component_colors(
+            [40.0, 600.0], color_by='component',
+            class_boundaries=None, class_colors=None)
+        assert colors == ['C0', 'C1']
+
+    def test_class_colors_group_by_coercivity(self):
+        # two low-coercivity components and one high: the two low ones share
+        # a color, the high one differs
+        colors = rmag._unmixing_component_colors(
+            [40.0, 60.0, 600.0], color_by='class',
+            class_boundaries=200.0, class_colors=None)
+        assert colors[0] == colors[1]
+        assert colors[0] != colors[2]
+
+    def test_class_requires_boundaries(self):
+        with pytest.raises(ValueError):
+            rmag._unmixing_component_colors(
+                [40.0], color_by='class',
+                class_boundaries=None, class_colors=None)
+
+    def test_bad_color_by_raises(self):
+        with pytest.raises(ValueError):
+            rmag._unmixing_component_colors(
+                [40.0], color_by='rainbow',
+                class_boundaries=None, class_colors=None)
+
+    def test_custom_class_colors(self):
+        colors = rmag._unmixing_component_colors(
+            [40.0, 600.0], color_by='class', class_boundaries=200.0,
+            class_colors=['k', 'r'])
+        assert colors == ['k', 'r']
+
+    def test_wrong_class_colors_count_raises(self):
+        with pytest.raises(ValueError):
+            rmag._unmixing_component_colors(
+                [40.0, 600.0], color_by='class', class_boundaries=200.0,
+                class_colors=['k'])
+
+    def test_plot_accepts_color_by_class(self):
+        x, spectrum = synthetic_spectrum()
+        fit = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2)
+        fig, _ax = rmag.plot_coercivity_unmixing(
+            fit, color_by='class', class_boundaries=500.0)
+        plt.close(fig)
+
+
 class TestSpecimensExport:
     """unmixing_to_specimens_table in both recording modes."""
 
@@ -970,6 +1103,41 @@ class TestMineralPriors:
     def test_tighten_below_one_raises(self):
         with pytest.raises(ValueError):
             rmag.mineral_priors(['hematite'], tighten=0.5)
+
+    def test_widen_broadens_ranges(self):
+        wide = rmag.mineral_priors(['hematite'])['dp'][0]
+        wider = rmag.mineral_priors(['hematite'], widen=2)['dp'][0]
+        assert (wider[1] - wider[0]) == pytest.approx(2 * (wide[1] - wide[0]))
+        # same center
+        assert (wider[0] + wider[1]) == pytest.approx(wide[0] + wide[1])
+
+    def test_widen_below_one_raises(self):
+        with pytest.raises(ValueError):
+            rmag.mineral_priors(['hematite'], widen=0.5)
+
+    def test_widen_and_tighten_compose(self):
+        base = rmag.mineral_priors(['hematite'])['dp'][0]
+        both = rmag.mineral_priors(['hematite'], widen=3, tighten=2)['dp'][0]
+        # net width factor is widen / tighten = 1.5
+        assert (both[1] - both[0]) == pytest.approx(1.5 * (base[1] - base[0]))
+
+    def test_override_replaces_window(self):
+        priors = rmag.mineral_priors(
+            ['magnetite_detrital'],
+            overrides={'magnetite_detrital': {'B_median_mT': (20.0, 160.0)}})
+        assert priors['location'][0] == pytest.approx(
+            (np.log10(20.0), np.log10(160.0)))
+        # non-overridden windows still come from the library
+        assert priors['dp'][0] == pytest.approx(
+            rmag.COERCIVITY_COMPONENT_LIBRARY['magnetite_detrital']['dp'])
+
+    def test_override_composes_with_widen(self):
+        priors = rmag.mineral_priors(
+            ['hematite'], widen=2,
+            overrides={'hematite': {'dp': (0.2, 0.4)}})
+        low, high = priors['dp'][0]
+        # override window (0.2, 0.4) widened x2 about center 0.3 -> (0.1, 0.5)
+        assert (low, high) == pytest.approx((0.1, 0.5))
 
     @needs_dynesty
     def test_priors_drive_bayes_and_infer_n_components(self):

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -260,6 +260,31 @@ class TestSpectrumFitting:
                                            np.array([0.1, 0.5, 0.1]),
                                            n_components=2)
 
+    def test_covariance_ok_flag_false_on_normal_fit(self):
+        """A well-behaved fit reports finite standard errors and flags the
+        covariance as non-singular."""
+        x, spectrum = synthetic_spectrum(noise=0.01)
+        result = rmag.unmix_coercivity_spectrum(x, spectrum, n_components=2,
+                                                vary_skew=False)
+        assert result['stats']['covariance_singular'] is False
+        assert np.isfinite(result['params']['se_location']).all()
+
+    def test_singular_covariance_warns_and_flags(self, monkeypatch):
+        """Regression: when the covariance computation fails (singular
+        Jacobian), the fit warns and sets stats['covariance_singular'] so the
+        resulting NaN standard errors are not silently mistaken for those of a
+        degenerate fit."""
+        def raise_linalg(*args, **kwargs):
+            raise np.linalg.LinAlgError('forced singular')
+        monkeypatch.setattr(np.linalg, 'pinv', raise_linalg)
+        x, spectrum = synthetic_spectrum(noise=0.01)
+        with pytest.warns(RuntimeWarning, match='covariance'):
+            result = rmag.unmix_coercivity_spectrum(x, spectrum,
+                                                    n_components=2,
+                                                    vary_skew=False)
+        assert result['stats']['covariance_singular'] is True
+        assert np.isnan(result['params']['se_location']).all()
+
 
 class TestCurveFitting:
     """unmix_backfield_curve parameter recovery."""

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -336,9 +336,10 @@ class TestMethodDispatch:
                                        n_components=2, vary_skew=False,
                                        n_boot=30, random_seed=7)
         assert 'bootstrap' in result
-        assert result['bootstrap']['resample'] == 'cases'
+        assert result['bootstrap']['method'] == 'maxunmix'
         assert result['bootstrap']['proportion'] == 0.95
-        assert result['bootstrap']['noise_level'] == 0.02
+        assert result['bootstrap']['param_noise'] == 0.02
+        assert 'param_summary' in result['bootstrap']
 
     def test_unknown_method_raises(self):
         x, curve = synthetic_curve()
@@ -933,6 +934,31 @@ class TestBayesianUnmixing:
         samples = bayes_result['bayes']['samples']
         assert samples['proportion'].shape[1] == 2
 
+    def test_spectrum_space_recovers_truth(self):
+        """space='spectrum' fits the finite-difference spectrum and should
+        recover the same synthetic components as the curve-space fit, with no
+        offset parameter."""
+        x, curve = synthetic_curve(noise=0.003, n=BAYES_N)
+        result = rmag.unmix_coercivity_bayes(x, curve, n_components=2,
+                                             space='spectrum', random_seed=6,
+                                             **FAST_BAYES)
+        assert result['space'] == 'spectrum'
+        assert result['offset'] == 0.0
+        params = result['params'].sort_values('location')
+        truth = TWO_COMPONENT_TRUTH.sort_values('location')
+        assert params['location'].iloc[1] == pytest.approx(
+            truth['location'].iloc[1], abs=0.15)
+        assert result['params']['proportion'].sum() == pytest.approx(1.0)
+        # the fitted spectrum data are the finite differences (n-1 points)
+        assert len(result['x']) == BAYES_N - 1
+
+    def test_spectrum_space_dispatch(self):
+        x, curve = synthetic_curve(noise=0.003, n=BAYES_N)
+        result = rmag.unmix_coercivity(x, curve, method='bayes',
+                                       n_components=2, space='spectrum',
+                                       random_seed=6, **FAST_BAYES)
+        assert result['space'] == 'spectrum'
+
     def test_registered_in_dispatcher(self):
         assert 'bayes' in rmag.UNMIXING_METHODS
 
@@ -1071,13 +1097,13 @@ class TestMineralPriors:
         # returned in increasing coercivity order regardless of input order
         assert priors['components'] == ['magnetite_detrital',
                                         'hematite_detrital']
-        assert priors['location'][0][1] < priors['location'][1][0]
+        assert priors['mean'][0][1] < priors['mean'][1][0]
 
-    def test_location_bounds_match_library(self):
+    def test_mean_bounds_match_library(self):
         priors = rmag.mineral_priors(['magnetite_detrital'])
         low, high = rmag.COERCIVITY_COMPONENT_LIBRARY[
             'magnetite_detrital']['B_median_mT']
-        assert priors['location'][0] == pytest.approx(
+        assert priors['mean'][0] == pytest.approx(
             (np.log10(low), np.log10(high)))
 
     def test_tighten_narrows_ranges(self):
@@ -1088,17 +1114,39 @@ class TestMineralPriors:
         # same center
         assert (narrow[0] + narrow[1]) == pytest.approx(wide[0] + wide[1])
 
-    def test_field_max_clips_location(self):
-        priors = rmag.mineral_priors(['goethite'], field_max_mT=2000)
-        assert priors['location'][0][1] == pytest.approx(np.log10(2000))
+    def test_field_max_clips_mean(self):
+        # hematite window is (150, 1500) mT; a 1 T max field clips the top
+        priors = rmag.mineral_priors(['hematite'], field_max_mT=1000)
+        assert priors['mean'][0][1] == pytest.approx(np.log10(1000))
 
     def test_accepts_single_string(self):
         priors = rmag.mineral_priors('hematite')
-        assert len(priors['location']) == 1
+        assert len(priors['mean']) == 1
 
     def test_unknown_name_raises(self):
         with pytest.raises(KeyError):
             rmag.mineral_priors(['unobtainium'])
+
+    def test_prior_table(self):
+        table = rmag.coercivity_prior_table(['hematite', 'magnetite'])
+        # sorted by central coercivity (magnetite softer than hematite)
+        assert list(table['component']) == ['magnetite', 'hematite']
+        assert set(['family', 'mean coercivity (mT)', 'skew (alpha)',
+                    'asymmetry']).issubset(table.columns)
+        assert table.loc[0, 'asymmetry'].startswith('left')
+        assert table.loc[1, 'asymmetry'].startswith('right')
+
+    def test_plot_prior_library(self):
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot as plt
+        fig, ax = rmag.plot_coercivity_prior_library()
+        assert len(ax.get_yticklabels()) == len(
+            rmag.COERCIVITY_COMPONENT_LIBRARY)
+        fig2, _ = rmag.plot_coercivity_prior_library(
+            ['magnetite', 'hematite_detrital'])
+        plt.close(fig)
+        plt.close(fig2)
 
     def test_tighten_below_one_raises(self):
         with pytest.raises(ValueError):
@@ -1125,7 +1173,7 @@ class TestMineralPriors:
         priors = rmag.mineral_priors(
             ['magnetite_detrital'],
             overrides={'magnetite_detrital': {'B_median_mT': (20.0, 160.0)}})
-        assert priors['location'][0] == pytest.approx(
+        assert priors['mean'][0] == pytest.approx(
             (np.log10(20.0), np.log10(160.0)))
         # non-overridden windows still come from the library
         assert priors['dp'][0] == pytest.approx(
@@ -1150,11 +1198,12 @@ class TestMineralPriors:
                                        priors=priors, random_seed=3,
                                        **FAST_BAYES)
         assert result['n_components'] == 2
-        # each component stays within its mineral's coercivity window
-        samples = result['bayes']['samples']['location']
-        for comp, (low, high) in enumerate(priors['location']):
-            assert samples[:, comp].min() >= low - 1e-6
-            assert samples[:, comp].max() <= high + 1e-6
+        # each component's MEAN coercivity stays within its mineral window
+        # (the 'mean' window constrains 10**B_mean_mT directly)
+        mean_log = np.log10(result['bayes']['samples']['B_mean_mT'])
+        for comp, (low, high) in enumerate(priors['mean']):
+            assert mean_log[:, comp].min() >= low - 1e-6
+            assert mean_log[:, comp].max() <= high + 1e-6
 
 
 class TestParseDescription:

--- a/pmagpy/test/test_rockmag_unmixing.py
+++ b/pmagpy/test/test_rockmag_unmixing.py
@@ -951,6 +951,49 @@ class TestSpecimensExport:
         assert list(data) == ['coercivity_unmixing']
 
 
+class TestSpecimenStatExport:
+    """add_unmixing_stats_to_specimens_table and add_Bcr_to_specimens_table
+    experiment matching."""
+
+    def test_stats_match_colon_delimited_experiments(self):
+        """A colon-delimited 'experiments' cell (several experiments per row)
+        is matched by the experiment substring, not exact equality."""
+        specs = pd.DataFrame({
+            'specimen': ['S1'],
+            'experiments': ['S1_LP-BCR-BF:S1_LP-HYS'],
+            'description': ['rock chip'],
+        })
+        rmag.add_unmixing_stats_to_specimens_table(
+            specs, 'S1_LP-BCR-BF', {'Bcr': 45.0, 'S_ratio': 0.9},
+            method='MaxUnmix')
+        text, data = rmag.parse_specimen_description(specs.at[0, 'description'])
+        assert text == 'rock chip'
+        assert data['Bcr'] == 45.0
+
+    def test_stats_raise_when_experiment_absent(self):
+        """A non-matching experiment name fails loudly instead of silently
+        recording nothing."""
+        specs = pd.DataFrame({
+            'specimen': ['S1'], 'experiments': ['S1_LP-BCR-BF'],
+            'description': [''],
+        })
+        with pytest.raises(ValueError, match='no specimens row matches'):
+            rmag.add_unmixing_stats_to_specimens_table(
+                specs, 'MISSING', {'Bcr': 1.0}, method='MaxUnmix')
+
+    def test_bcr_matches_colon_delimited_experiments(self):
+        specs = pd.DataFrame({
+            'specimen': ['S1'], 'experiments': ['S1_LP-BCR-BF:S1_LP-HYS']})
+        rmag.add_Bcr_to_specimens_table(specs, 'S1_LP-BCR-BF', 0.045)
+        assert specs.loc[0, 'rem_bcr'] == 0.045
+
+    def test_bcr_raises_when_experiment_absent(self):
+        specs = pd.DataFrame({
+            'specimen': ['S1'], 'experiments': ['S1_LP-BCR-BF']})
+        with pytest.raises(ValueError, match='no specimens row matches'):
+            rmag.add_Bcr_to_specimens_table(specs, 'MISSING', 0.045)
+
+
 # ---------------------------------------------------------------------------
 # multi-start solution mapping
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Coercivity spectrum unmixing and hysteresis processing fixes

This PR contains progress in `pmagpy/rockmag.py` on both coercivity spectrum unmixing and hysteresis loop processing, each with its own test suite. Changes and new features will be documented in rockmagpy notebooks in that separate repository.

## Coercivity spectrum unmixing

A rebuilt coercivity unmixing suite: skew-normal components can be fit either to the coercivity spectrum (MaxUnMix lineage) or directly to the measured backfield/acquisition curve. Includes a method-dispatch entry point (`unmix_coercivity`), bootstrap and Bayesian uncertainty estimation, batch processing of MagIC measurement tables, and export of results to MagIC specimens tables. Tests with known synthetic components are in `pmagpy/test/test_rockmag_unmixing.py`.

## Hysteresis loop processing

The hysteresis processing functions were audited against Jackson & Solheid (2010, doi:10.1029/2009GC002932) — the protocol they implement — and against HystLab (Paterson et al., 2018; MATLAB source consulted directly). 

The changes that were made are associated with:

- **Statistical fixes.** The high-field saturation test mixed sums of squares over different point sets (FNL could go negative; unsaturated loops passed  as saturated, biasing Ms low); `Fnl_lin` now implements eq. 21 of Jackson & Solheid (2010); the loop closure test was inert (classified every loop as closed) and is rebuilt to match HystLab's implementation, including its err(H)-based noise estimate; Q is now computed on the offset-corrected loop (previously a loop offset could depress Q below the Q < 2 gate that decides whether to correct that offset); off-by-one in the prorated drift correction.
- **Q convention retained and documented**: Q = log10(1/sqrt(1−R²)), matching the IRM software and HystLab (the equation as printed in Jackson & Solheid 2010 omits the sqrt; see Paterson et al. 2018, eq. 4).
- **Robust branch splitting** (closes #876): `find_hysteresis_turning_point`(after fixing a latent compressed-index bug) and `collapse_hysteresis_field_plateaus` are now wired into `split_hysteresis_loop`/`grid_hysteresis_loop`, replacing the gradient detection and its half-split fallback. Gridded-loop behavior is unchanged.
- **Stream-agnostic inputs**: new `sanitize_hysteresis_inputs` (lists, numeric strings, NaN dropping with report, non-tesla field warning), and either field sweep order is now handled, so the workflow serves plain field/moment data as well as MagIC tables.
- Docstring updates throughout (including an inverted description of the saturation test result and misdocumented units on `linear_HF_fit`).

Tests: `pmagpy/test/test_rockmag_hysteresis.py` (38 tests on synthetic loops with analytical expectations).