### PR TITLE
Add multi-method Curie temperature estimation to rockmag.py

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -9,6 +9,7 @@ import re
 import sys
 import time
 import urllib
+import warnings
 import zipfile
 import io
 
@@ -8338,6 +8339,22 @@ def curie(path_to_file='.', file_name='', magic=False,
     The estimated curie temperation is the maximum of the 2nd derivative.
     Temperature steps should be in multiples of 1.0 degrees.
 
+    .. deprecated::
+        ``ipmag.curie`` is deprecated and will be removed in a future release.
+        It reports a single Curie temperature from the maximum of the smoothed
+        second derivative. Use the multi-method estimators in ``pmagpy.rockmag``
+        instead, which make method-dependent biases explicit (Fabian et al.,
+        2013, doi:10.1029/2012GC004440):
+
+        - ``rockmag.curie_temperature_estimates()`` applies the selected methods
+          to the heating/cooling branches of a MagIC experiment and returns a
+          tidy comparison table with per-method caveats.
+        - ``rockmag.curie_derivative_estimates()`` is the direct analog of this
+          function, returning both the inflection-point and maximum-curvature
+          estimates (the ``max_curvature`` method reproduces the legacy value
+          here: 552 C vs 549 C on data_files/curie/curie_example.dat with a
+          10-degree window).
+
     Parameters:
         file_name : name of file to be opened
         path_to_file : path to directory that contains file (default is current directory, '.')
@@ -8352,6 +8369,14 @@ def curie(path_to_file='.', file_name='', magic=False,
     Returns:
         A plot is shown and saved if save=True.
     """
+    warnings.warn(
+        "ipmag.curie is deprecated and will be removed in a future release. "
+        "Use pmagpy.rockmag.curie_temperature_estimates (MagIC experiments) or "
+        "pmagpy.rockmag.curie_derivative_estimates (the max_curvature/inflection "
+        "analog of this function) instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     plot = 0
     window_len = window_length
 

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -4461,6 +4461,23 @@ def _inverse_susceptibility(chi):
     return np.divide(1.0, chi, out=np.full_like(chi, np.nan), where=chi > 0)
 
 
+def _repeated_value_fraction(values):
+    """
+    Fraction of points that repeat an identical neighbor.
+
+    Runs of identical values within a fitting window are the signature of a
+    resolution-limited (quantized) susceptibility tail or a flattened/altered
+    magnetization tail; either flattens a fitted slope and biases the
+    extrapolated Curie temperature. Returns a value in [0, 1].
+    """
+    values = np.asarray(values, dtype=float)
+    if values.size < 2:
+        return 0.0
+    repeated = np.concatenate([[False], values[1:] == values[:-1]])
+    repeated[:-1] |= repeated[1:]
+    return float(repeated.mean())
+
+
 def _dedupe_temperatures(T, y):
     """
     Average y-values measured at duplicate temperatures.
@@ -4928,10 +4945,7 @@ def curie_inverse_susceptibility(T, chi, fit_range=None, min_points=5,
     # repeated identical susceptibility values in the window are the
     # signature of a resolution-limited (quantized) tail, which flattens the
     # fitted slope and biases theta low
-    chi_fit = chi[mask]
-    repeated = np.concatenate([[False], chi_fit[1:] == chi_fit[:-1]])
-    repeated[:-1] |= repeated[1:]
-    quantized_fraction = float(repeated.mean())
+    quantized_fraction = _repeated_value_fraction(chi[mask])
     if quantized_fraction > 1.0 / 3.0:
         result["params"]["warning"] = (
             f"{quantized_fraction:.0%} of the fitted points repeat identical "
@@ -4946,6 +4960,174 @@ def curie_inverse_susceptibility(T, chi, fit_range=None, min_points=5,
         "inv_chi_fit": inv_chi,
         "line_T": np.array([theta, T_fit.max()]),
         "line_inv_chi": np.array([0.0, slope * T_fit.max() + intercept]),
+    }
+    return result
+
+
+def curie_ms_squared_extrapolation(T, M, fit_range=None, exponent=2.0,
+                                   min_points=5, min_m=None):
+    """
+    Mean-field (Moskowitz, 1981) extrapolation of Ms**exponent to zero.
+
+    Fits ``M**exponent`` linearly in temperature over ``fit_range`` and returns
+    the x-intercept (where ``M**exponent = 0``) as the Curie temperature. This
+    is the extrapolation method of Moskowitz (1981,
+    doi:10.1016/0012-821X(81)90028-5) for saturation-magnetization (Ms-T)
+    thermomagnetic curves whose signal terminates below Tc — e.g.
+    titanomaghemites that chemically invert on heating before Ms reaches zero,
+    so a direct Ms = 0 crossing is unavailable.
+
+    Near Tc a second-order (mean-field / Landau-Belov) treatment gives
+    Js proportional to (Tc - T)**(1/2), so Js**2 is linear in T and
+    extrapolates to zero at Tc (Moskowitz, 1981, eqs. 4-5). This is the
+    magnetization-space analog of the Curie-Weiss inverse-susceptibility
+    method: there 1/chi rises linearly to a zero at theta; here Ms**2 falls
+    linearly to a zero at Tc, so ``curie_temp = -intercept/slope`` with the
+    slope required to be negative. (Moskowitz normalizes by Js0 = Js(T0); the
+    normalization does not change the x-intercept and is omitted here.)
+
+    The mean-field form is valid for T/Tc > 0.8 (roughly the uppermost ~100 C
+    below Tc), so restrict ``fit_range`` to the steep descent below where the
+    curve flattens out or the sample alters; report the window. Following
+    Moskowitz, ``exponent=2`` (critical exponent beta = 1/2) is the
+    theoretically justified, best-conditioned choice and minimized his fit
+    error (+/-5 C) on standards (Fe3O4 572 C, Ni 360 C, CrO2 133 C). For a
+    mean-field curve exponent=2 is exact; any other exponent introduces
+    curvature into the fitted data and moves the extrapolated Tc off the true
+    value. Moskowitz reported that a smaller exponent shifted Tc lower for his
+    irreversible titanomaghemite samples; on ideal and mean-field curves a
+    smaller exponent instead biases Tc high, so the direction of the bias
+    depends on the true curve shape. For a multiphase sample only the Curie
+    temperature of the highest-Tc phase is recovered.
+
+    Parameters
+    ----------
+    T : array-like
+        Temperatures, ascending (Celsius or Kelvin; Tc is returned in the same
+        unit as the input, since the x-intercept is unit-invariant).
+    M : array-like
+        Saturation-magnetization (Ms) values.
+    fit_range : tuple of (float, float), optional
+        Temperature interval for the linear fit of ``M**exponent``. If None,
+        the upper 40 percent of the temperature span is used — a starting
+        guess only; inspect the fit and set the window explicitly (below the
+        flattening/alteration temperature) for reported values.
+    exponent : float, optional
+        Power to which ``M`` is raised before the linear fit (default 2.0,
+        i.e. beta = 1/2). Any other exponent introduces curvature into the
+        fit and moves Tc off the mean-field value (Moskowitz, 1981).
+    min_points : int, optional
+        Minimum number of usable points in the window (default 5; floored at
+        3, since the covariance fit needs more than two points).
+    min_m : float, optional
+        Exclude points with magnetization below this value from the fit (same
+        units as ``M``). Useful for screening out a flattened, weak, or
+        altered tail.
+
+    Returns
+    -------
+    dict
+        ``curie_temp`` (Tc = -intercept/slope, in the input temperature unit),
+        ``curie_temp_stderr`` (1-sigma from the fit covariance), ``params``
+        with ``slope``, ``intercept``, ``r_squared``, ``n_points``,
+        ``fit_range``, ``exponent``, a ``note`` when the fit is not usable
+        (too few points or a non-negative slope), and a ``warning`` when the
+        fitted points are dominated by repeated (flattened/altered) values,
+        and ``diagnostics`` with ``T``, ``m_pow`` (= ``M**exponent``), the
+        fitted points, and the extrapolated line.
+    """
+    T = np.asarray(T, dtype=float)
+    M = np.asarray(M, dtype=float)
+    # a straight-line covariance fit needs more than two points; below three
+    # np.polyfit(..., cov=True) raises instead of returning gracefully
+    min_points = max(int(min_points), 3)
+
+    if fit_range is None:
+        t_span = T.max() - T.min()
+        fit_range = (T.min() + 0.6 * t_span, T.max())
+
+    mask = (
+        (T >= fit_range[0])
+        & (T <= fit_range[1])
+        & np.isfinite(M)
+        & (M > 0)
+    )
+    if min_m is not None:
+        mask &= M >= min_m
+    result = {
+        "curie_temp": np.nan,
+        "curie_temp_stderr": np.nan,
+        "params": {"fit_range": (float(fit_range[0]), float(fit_range[1])),
+                   "n_points": int(mask.sum()),
+                   "exponent": float(exponent)},
+        "diagnostics": {},
+    }
+    if mask.sum() < min_points:
+        result["params"]["note"] = (
+            f"only {int(mask.sum())} usable points in fit_range; "
+            f"at least {min_points} required"
+        )
+        return result
+
+    T_fit = T[mask]
+    m_pow_fit = M[mask] ** exponent
+
+    (slope, intercept), cov = np.polyfit(T_fit, m_pow_fit, 1, cov=True)
+    if slope >= 0:
+        # Ms**exponent must decrease with T toward the transition; a
+        # non-negative slope means the window is not on the descending limb
+        # below Tc (wrong window, or a flattened/altered tail)
+        result["params"]["note"] = (
+            "non-negative slope in the Ms**exponent fit; the fitting window "
+            "does not sample the descending magnetization below Tc — adjust "
+            "fit_range"
+        )
+        return result
+    tc = -intercept / slope
+
+    # 1-sigma uncertainty on Tc from the fit covariance
+    d_tc_d_slope = intercept / slope**2
+    d_tc_d_intercept = -1.0 / slope
+    var_tc = (
+        d_tc_d_slope**2 * cov[0, 0]
+        + d_tc_d_intercept**2 * cov[1, 1]
+        + 2.0 * d_tc_d_slope * d_tc_d_intercept * cov[0, 1]
+    )
+    tc_stderr = float(np.sqrt(var_tc)) if var_tc >= 0 else np.nan
+
+    predicted = slope * T_fit + intercept
+    ss_res = float(np.sum((m_pow_fit - predicted) ** 2))
+    ss_tot = float(np.sum((m_pow_fit - m_pow_fit.mean()) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else np.nan
+
+    result["curie_temp"] = float(tc)
+    result["curie_temp_stderr"] = tc_stderr
+    result["params"].update({
+        "slope": float(slope),
+        "intercept": float(intercept),
+        "r_squared": float(r_squared),
+    })
+
+    # repeated identical magnetization values in the window signal a flattened
+    # or altered tail, which flattens the fitted slope and biases Tc
+    fraction_repeated = _repeated_value_fraction(M[mask])
+    if fraction_repeated > 1.0 / 3.0:
+        result["params"]["warning"] = (
+            f"{fraction_repeated:.0%} of the fitted points repeat identical "
+            "magnetization values (flattened or altered tail); Tc is likely "
+            "biased — tighten fit_range or set min_m"
+        )
+
+    m_pow_all = np.full_like(M, np.nan)
+    positive = np.isfinite(M) & (M > 0)
+    m_pow_all[positive] = M[positive] ** exponent
+    result["diagnostics"] = {
+        "T": T,
+        "m_pow": m_pow_all,
+        "T_fit": T_fit,
+        "m_pow_fit": m_pow_fit,
+        "line_T": np.array([tc, T_fit.max()]),
+        "line_m_pow": np.array([0.0, slope * T_fit.max() + intercept]),
     }
     return result
 
@@ -5203,6 +5385,11 @@ _CURIE_METHOD_NOTES = {
         "fit of the in-field Landau equation of state (Fabian et al., 2013); "
         "Tc at the inflection point, with formal uncertainty"
     ),
+    "ms_squared_extrapolation": (
+        "Ms^2 extrapolation (Moskowitz, 1981); mean-field extrapolation of "
+        "Ms^2 to zero for M(T) curves that end below Tc, e.g. titanomaghemites "
+        "that invert on heating; recovers only the highest-Tc phase"
+    ),
 }
 
 
@@ -5274,6 +5461,9 @@ def curie_temperature_estimates(
     * ``'landau'`` — in-field Landau equation-of-state fit
       (``curie_landau_fit``); for M(T), supports extrapolation from runs
       that end below Tc.
+    * ``'ms_squared_extrapolation'`` — mean-field extrapolation of Ms^2 to
+      zero (``curie_ms_squared_extrapolation``; Moskowitz, 1981); for M(T)
+      curves that end below Tc. Not selectable for susceptibility data.
 
     Parameters
     ----------
@@ -5348,11 +5538,17 @@ def curie_temperature_estimates(
             methods = ("inflection", "max_curvature", "two_tangent", "landau")
 
     known = {"inflection", "max_curvature", "two_tangent",
-             "inverse_susceptibility", "landau"}
+             "inverse_susceptibility", "landau", "ms_squared_extrapolation"}
     unknown = set(methods) - known
     if unknown:
         raise ValueError(f"unknown method(s): {sorted(unknown)}; "
                          f"choose from {sorted(known)}")
+    if is_susceptibility and "ms_squared_extrapolation" in methods:
+        raise ValueError(
+            "ms_squared_extrapolation is a magnetization (Ms-T) method and "
+            "does not apply to susceptibility data; use data_type="
+            "'magnetization' for Ms(T) experiments"
+        )
     unknown_kwargs = set(method_kwargs) - known - {"derivative"}
     if unknown_kwargs:
         raise ValueError(
@@ -5425,6 +5621,14 @@ def curie_temperature_estimates(
                 landau_kwargs = dict(method_kwargs.get("landau", {}))
                 landau_kwargs.setdefault("temp_unit", temp_unit)
                 r = curie_landau_fit(T, y, **landau_kwargs)
+                curie_temp, stderr, params = (r["curie_temp"],
+                                              r["curie_temp_stderr"],
+                                              r["params"])
+                method_results[(branch, method)] = r
+            elif method == "ms_squared_extrapolation":
+                r = curie_ms_squared_extrapolation(
+                    T, y, **method_kwargs.get("ms_squared_extrapolation", {})
+                )
                 curie_temp, stderr, params = (r["curie_temp"],
                                               r["curie_temp_stderr"],
                                               r["params"])

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -4520,11 +4520,24 @@ def curie_derivative_estimates(T, y, t_range=None):
       implemented in many software packages (including the legacy
       ``ipmag.curie``). On M(T) curves it lies systematically above the
       inflection-point Tc (typically 10-15 degrees C) and shifts with the
-      strength of the applied field (Fabian et al., 2013).
+      strength of the applied field (Fabian et al., 2013). It is searched on
+      the concave shoulder above the steepest descent, consistent with this
+      definition.
 
-    The input arrays are assumed to be smoothed as appropriate (see
-    ``prepare_thermomag_branches``); derivatives amplify noise, so unsmoothed
-    noisy data will produce spurious extrema.
+    Non-finite temperature or magnetization values are dropped before
+    differentiation, and the steepest descent is located over the interior of
+    the branch (the one-sided derivatives at the first and last points are the
+    most noise-prone). Both estimates are anchored to that steepest-descent
+    point, so isolated noise or structure in the flat tails does not capture
+    them.
+
+    The input arrays are nonetheless assumed to be smoothed as appropriate
+    (see ``prepare_thermomag_branches``); derivatives amplify noise, and a
+    noise feature steeper than a gently field-rounded transition can still
+    displace the estimate. For noisy data or multi-phase curves, smooth the
+    branch and use ``t_range`` to isolate the transition of interest, and
+    check the returned estimate against ``first_derivative_min_temp`` and the
+    ``diagnostics`` arrays.
 
     Parameters
     ----------
@@ -4552,6 +4565,9 @@ def curie_derivative_estimates(T, y, t_range=None):
         mask = (T >= t_range[0]) & (T <= t_range[1])
         T = T[mask]
         y = y[mask]
+    finite = np.isfinite(T) & np.isfinite(y)
+    T = T[finite]
+    y = y[finite]
     T, y = _dedupe_temperatures(T, y)
     if T.size < 4:
         nan = np.nan
@@ -4566,7 +4582,11 @@ def curie_derivative_estimates(T, y, t_range=None):
     dy = np.gradient(y, T)
     d2y = np.gradient(dy, T)
 
-    i_steep = int(np.argmin(dy))
+    # locate the steepest descent over the interior only; np.gradient forms
+    # one-sided differences at the array boundaries, which are the most
+    # noise-prone points and can otherwise anchor the estimate to an edge
+    interior = np.arange(1, T.size - 1)
+    i_steep = int(interior[np.argmin(dy[interior])])
     first_derivative_min_temp = T[i_steep]
 
     # restrict the curvature analysis to the transition zone around the
@@ -4581,16 +4601,18 @@ def curie_derivative_estimates(T, y, t_range=None):
     after = np.nonzero(near_zero[i_steep:])[0]
     j_end = int(after[0]) + i_steep if after.size else T.size - 1
 
-    zone = slice(j_start, j_end + 1)
-    d2y_zone = d2y[zone]
-    T_zone = T[zone]
-    max_curvature_temp = T_zone[np.argmax(d2y_zone)]
+    # the maximum-curvature estimate lies on the concave shoulder above the
+    # inflection (Ade-Hall et al., 1965; Fabian et al., 2013), so search the
+    # second derivative from the steepest descent upward; a noise feature on
+    # the low-temperature side of the transition cannot then capture it
+    upper_zone = slice(i_steep, j_end + 1)
+    max_curvature_temp = T[upper_zone][np.argmax(d2y[upper_zone])]
 
-    # zero crossings of the second derivative between its extrema bracket the
-    # inflection point of the descending limb
-    lower, upper = sorted([int(np.argmin(d2y_zone)), int(np.argmax(d2y_zone))])
+    # the inflection is the zero of the second derivative at the steepest
+    # descent; take the zone crossing nearest that point so the estimate stays
+    # anchored to the transition rather than to tail structure
     zero_crossing_temps = _interpolated_zero_crossings(
-        T_zone[lower:upper + 1], d2y_zone[lower:upper + 1]
+        T[j_start:j_end + 1], d2y[j_start:j_end + 1]
     )
     if zero_crossing_temps.size:
         inflection_temp = zero_crossing_temps[

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -4436,8 +4436,10 @@ def plot_X_T(
 # * low-field susceptibility X(T): several mechanisms (para-effect, rotation
 #   against anisotropy, domain-wall motion, superparamagnetism) contribute
 #   near the ordering temperature; the Hopkinson peak marks blocking, not Tc,
-#   and the two-tangent construction is not physically justified (Petrovsky &
-#   Kapicka, 2006, doi:10.1029/2006JB004507). The inverse-susceptibility
+#   and the maximum-curvature and two-tangent constructions lack a rigorous
+#   physical basis (Petrovsky & Kapicka, 2006, doi:10.1029/2006JB004507) --
+#   both are robust, transition-based estimators but lie above the inflection
+#   point. The inverse-susceptibility
 #   (Curie-Weiss) extrapolation yields the paramagnetic Curie temperature
 #   theta, an upper bound on Tc.
 #
@@ -4508,7 +4510,7 @@ def _interpolated_zero_crossings(x, y):
     return np.array(crossings, dtype=float)
 
 
-def curie_derivative_estimates(T, y, t_range=None):
+def curie_derivative_estimates(T, y, t_range=None, smooth_window=0):
     """
     Derivative-based Curie temperature estimates from one thermomagnetic branch.
 
@@ -4537,12 +4539,16 @@ def curie_derivative_estimates(T, y, t_range=None):
     point, so isolated noise or structure in the flat tails does not capture
     them.
 
-    The input arrays are nonetheless assumed to be smoothed as appropriate
-    (see ``prepare_thermomag_branches``); derivatives amplify noise, and a
-    noise feature steeper than a gently field-rounded transition can still
-    displace the estimate. For noisy data or multi-phase curves, smooth the
-    branch and use ``t_range`` to isolate the transition of interest, and
-    check the returned estimate against ``first_derivative_min_temp`` and the
+    Differentiation amplifies noise, so even a smoothed signal can yield a
+    ragged first derivative whose global minimum is a noise spike within a
+    broad, flat-bottomed transition rather than the true steepest descent.
+    Set ``smooth_window`` to smooth the first and second derivatives on the
+    same temperature scale used to smooth the signal (as the legacy
+    ``ipmag.curie`` does), which locates the estimate at the center of the
+    transition instead of an arbitrary spike; ``curie_temperature_estimates``
+    passes its smoothing window through automatically. For multi-phase curves,
+    additionally use ``t_range`` to isolate the transition of interest, and
+    check the estimate against ``first_derivative_min_temp`` and the
     ``diagnostics`` arrays.
 
     Parameters
@@ -4556,6 +4562,12 @@ def curie_derivative_estimates(T, y, t_range=None):
         Restrict the analysis to temperatures within ``(t_min, t_max)``.
         Useful for isolating one Curie transition in a multi-phase curve or
         excluding low-temperature structure (e.g., a Hopkinson peak).
+    smooth_window : float, optional
+        Width, in the temperature units of ``T``, of a moving-average window
+        applied to the first and second derivatives before their extrema are
+        located (default 0, no derivative smoothing). Recommended for noisy
+        data; a good choice is the window used to smooth the signal. The
+        ``diagnostics`` arrays reflect the smoothed derivatives actually used.
 
     Returns
     -------
@@ -4587,7 +4599,16 @@ def curie_derivative_estimates(T, y, t_range=None):
         }
 
     dy = np.gradient(y, T)
+    if smooth_window and smooth_window > 0:
+        # np.gradient's one-sided boundary values are unreliable; replace them
+        # before smoothing so edge padding cannot propagate an outlier into a
+        # spurious plateau that captures the steepest-descent search
+        dy[0], dy[-1] = dy[1], dy[-2]
+        _, dy = smooth_moving_avg(T, dy, smooth_window)
     d2y = np.gradient(dy, T)
+    if smooth_window and smooth_window > 0:
+        d2y[0], d2y[-1] = d2y[1], d2y[-2]
+        _, d2y = smooth_moving_avg(T, d2y, smooth_window)
 
     # locate the steepest descent over the interior only; np.gradient forms
     # one-sided differences at the array boundaries, which are the most
@@ -4651,9 +4672,10 @@ def curie_two_tangent(T, y, lower_range=None, upper_range=None, min_points=3):
     M(T). Even there it coincides with the maximum-curvature estimate and
     therefore lies systematically above the inflection-point Curie temperature
     (Fabian et al., 2013, doi:10.1029/2012GC004440). Applied to low-field
-    susceptibility X(T) it is not physically justified and can considerably
-    overestimate Tc (Petrovsky & Kapicka, 2006, doi:10.1029/2006JB004507); it
-    is provided for such data only to allow comparison with legacy results.
+    susceptibility X(T) it lacks a rigorous physical basis and can overestimate
+    Tc (Petrovsky & Kapicka, 2006, doi:10.1029/2006JB004507); it remains a
+    robust, transition-based estimator useful for mineral identification and
+    for comparison with legacy results.
 
     Parameters
     ----------
@@ -5139,10 +5161,17 @@ def curie_landau_fit(T, M, fit_range=None, temp_unit="C", tc_bounds=None,
 
 
 _CURIE_CHI_METHOD_CAVEATS = {
+    "max_curvature": (
+        "maximum-curvature estimate on susceptibility lacks a rigorous "
+        "physical basis and lies above the inflection-point Tc; it "
+        "coincides with the two-tangent estimate and can overestimate Tc "
+        "(Fabian et al., 2013; Petrovsky & Kapicka, 2006)"
+    ),
     "two_tangent": (
-        "two-tangent intersection on susceptibility is not physically "
-        "justified and can considerably overestimate Tc (Petrovsky & "
-        "Kapicka, 2006)"
+        "two-tangent intersection on susceptibility lacks a rigorous "
+        "physical basis and lies above the inflection-point Tc; it "
+        "coincides with the maximum-curvature estimate and can overestimate "
+        "Tc (Fabian et al., 2013; Petrovsky & Kapicka, 2006)"
     ),
     "landau": (
         "the Landau M(T) model does not describe the mechanisms that "
@@ -5332,6 +5361,7 @@ def curie_temperature_estimates(
         )
 
     derivative_kwargs = {
+        "smooth_window": smooth_window,
         **method_kwargs.get("derivative", {}),
         **method_kwargs.get("inflection", {}),
         **method_kwargs.get("max_curvature", {}),
@@ -5874,14 +5904,17 @@ def add_curie_estimates_to_specimens_table(
     # specimen name recorded in the estimates table; exact/token matching is
     # used rather than substring matching so that an experiment name cannot
     # match a longer sibling name (e.g., '...-MST-1' matching '...-MST-10')
-    experiments_column = specimens_df["experiments"].astype(str)
-    target = experiments_column == experiment_name
+    experiments_column = specimens_df["experiments"]
+    target = (experiments_column == experiment_name).fillna(False).to_numpy(
+        dtype=bool)
     if not target.any():
-        target = experiments_column.apply(
-            lambda cell: experiment_name in cell.split(":")
-        )
+        target = np.array([
+            isinstance(cell, str) and experiment_name in cell.split(":")
+            for cell in experiments_column
+        ])
     if not target.any() and row["specimen"]:
-        target = specimens_df["specimen"] == row["specimen"]
+        target = (specimens_df["specimen"] == row["specimen"]).fillna(
+            False).to_numpy(dtype=bool)
     if not target.any():
         raise ValueError(
             f"experiment '{experiment_name}' (and specimen "

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -4190,6 +4190,12 @@ def plot_X_T(
             window, one of 'flat', 'hanning', 'hamming', 'bartlett', or
             'blackman' (default 'hanning'). Only used when smooth_window > 0.
             See prepare_thermomag_branches for a description of each option.
+
+    Returns:
+        tuple or None: If return_figure is True, a tuple of the figure
+        objects created (Matplotlib Figures when interactive is False, Bokeh
+        figures when interactive is True). Otherwise the figures are displayed
+        and None is returned.
     """
     branches = prepare_thermomag_branches(
         experiment,
@@ -4542,7 +4548,8 @@ def curie_derivative_estimates(T, y, t_range=None):
     Parameters
     ----------
     T : array-like
-        Temperatures, ascending.
+        Temperatures, ascending (Celsius or Kelvin; the returned temperatures
+        are in the same unit as the input).
     y : array-like
         Magnetization or susceptibility values.
     t_range : tuple of (float, float), optional
@@ -4651,7 +4658,8 @@ def curie_two_tangent(T, y, lower_range=None, upper_range=None, min_points=3):
     Parameters
     ----------
     T : array-like
-        Temperatures, ascending.
+        Temperatures, ascending (Celsius or Kelvin; the returned intersection
+        temperature is in the same unit as the input).
     y : array-like
         Magnetization (preferred) or susceptibility values.
     lower_range : tuple of (float, float), optional
@@ -4671,13 +4679,19 @@ def curie_two_tangent(T, y, lower_range=None, upper_range=None, min_points=3):
     dict
         ``curie_temp`` (intersection temperature, NaN if the tangents are
         parallel or a segment has too few points), ``params`` with the two
-        (slope, intercept) pairs, the temperature ranges actually used, and
-        point counts, and ``diagnostics`` with the segment masks for plotting.
+        (slope, intercept) pairs, the temperature ranges actually used, point
+        counts, and ``reliable`` (False when no near-flat baseline was found
+        above the transition and the upper tangent fell back to the uppermost
+        points, i.e. the curve may end below Tc), and ``diagnostics`` with the
+        segment masks for plotting.
     """
-    T, y = _dedupe_temperatures(T, y)
+    T = np.asarray(T, dtype=float)
+    y = np.asarray(y, dtype=float)
+    finite = np.isfinite(T) & np.isfinite(y)
+    T, y = _dedupe_temperatures(T[finite], y[finite])
     result = {
         "curie_temp": np.nan,
-        "params": {},
+        "params": {"reliable": False},
         "diagnostics": {},
     }
     if T.size < 2 * min_points:
@@ -4751,6 +4765,7 @@ def curie_two_tangent(T, y, lower_range=None, upper_range=None, min_points=3):
             "be on the descending limb if the curve ends below the Curie "
             "temperature — verify or set upper_range explicitly"
         )
+    result["params"]["reliable"] = not baseline_fallback
     result["diagnostics"] = {
         "T": T,
         "y": y,
@@ -4792,7 +4807,8 @@ def curie_inverse_susceptibility(T, chi, fit_range=None, min_points=5,
     Parameters
     ----------
     T : array-like
-        Temperatures, ascending.
+        Temperatures, ascending (Celsius or Kelvin; theta is returned in the
+        same unit as the input).
     chi : array-like
         Susceptibility values (holder-corrected).
     fit_range : tuple of (float, float), optional
@@ -4818,6 +4834,9 @@ def curie_inverse_susceptibility(T, chi, fit_range=None, min_points=5,
     """
     T = np.asarray(T, dtype=float)
     chi = np.asarray(chi, dtype=float)
+    # a straight-line covariance fit needs more than two points; below three
+    # np.polyfit(..., cov=True) raises instead of returning gracefully
+    min_points = max(int(min_points), 3)
 
     if fit_range is None:
         t_span = T.max() - T.min()
@@ -5694,6 +5713,20 @@ def interactive_curie_inverse_susceptibility(
         temperature range — a starting position only, meant to be dragged.
     figsize : tuple, optional
         (width, height) in inches; height sets the Bokeh plot height.
+
+    Returns
+    -------
+    None
+        The interactive Bokeh application is displayed as a side effect; no
+        value is returned. For a reproducible, reportable estimate use
+        ``curie_inverse_susceptibility`` with the ``fit_range`` identified
+        here.
+
+    Raises
+    ------
+    ValueError
+        If the requested ``branch`` is not present in the experiment, or if it
+        has fewer than two usable (finite, positive-susceptibility) points.
     """
     _check_bokeh()
 
@@ -5920,7 +5953,14 @@ def smooth_moving_avg(
             Otherwise, only return smoothed x and y. Defaults to False.
 
     Returns:
-        smoothed_x, smoothed_y (, x_var, y_var)
+        tuple: ``(smoothed_x, smoothed_y)`` by default, or
+        ``(smoothed_x, smoothed_y, x_var, y_var)`` when return_variance is
+        True. ``smoothed_x`` and ``smoothed_y`` are the window-averaged arrays
+        (same length as the inputs); ``x_var`` and ``y_var`` are the
+        corresponding per-point weighted variances within each window (in the
+        squared units of x and y), a measure of local spread. When
+        x_window is 0 the inputs are returned unchanged and the variances are
+        zero.
     """
     # convert to numpy arrays
     x = np.asarray(x)

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -3982,12 +3982,20 @@ def split_warm_cool(experiment, temperature_column='meas_temp',
     """
     Split a thermomagnetic curve into heating and cooling portions.
 
-    Points are classified by the sign of the local temperature change: a
-    measurement is assigned to the heating branch when the temperature
-    increased relative to the previous measurement, and to the cooling branch
-    otherwise (the first point is assigned to the heating branch). Rows with
-    non-finite temperature or magnetic values are dropped. Data that only heat
-    (or only cool) return an empty array for the missing branch.
+    The sequence is split at the temperature turning point (the global
+    maximum): measurements up to and including the peak form the heating
+    branch and the descending remainder forms the cooling branch. A run whose
+    temperature never descends after its peak returns an empty cooling branch,
+    and a run that descends from its first measurement returns an empty heating
+    branch. Rows with non-finite temperature or magnetic values are dropped.
+
+    Splitting at the turning point rather than on the sign of each local step
+    keeps repeated furnace-stabilization temperatures (where the step is zero)
+    and noisy readings on the heating ramp within the heating branch. A
+    point-by-point classification instead misroutes those points into a
+    spurious cooling branch, so a heating-only run with duplicated or noisy
+    temperatures would otherwise produce a phantom cooling curve. This assumes
+    a single heat-then-cool trajectory, the standard thermomagnetic protocol.
 
     Parameters
     ----------
@@ -4021,11 +4029,14 @@ def split_warm_cool(experiment, temperature_column='meas_temp',
         empty = np.array([], dtype=float)
         return empty, empty.copy(), empty.copy(), empty.copy()
 
-    steps = np.diff(T) > 0
-    # the first point takes the direction of the first step so that a
-    # cooling-only sequence does not produce a spurious one-point heating branch
-    first = steps[0] if steps.size else True
-    is_heating = np.insert(steps, 0, first)
+    peak_index = int(np.argmax(T))
+    descends_after_peak = bool(np.any(T[peak_index + 1:] < T[peak_index]))
+    if not descends_after_peak:
+        is_heating = np.ones(T.size, dtype=bool)
+    elif peak_index == 0:
+        is_heating = np.zeros(T.size, dtype=bool)
+    else:
+        is_heating = np.arange(T.size) <= peak_index
 
     warm_T = T[is_heating]
     warm_X = X[is_heating]

--- a/pmagpy/rockmag.py
+++ b/pmagpy/rockmag.py
@@ -3977,17 +3977,22 @@ def add_hyst_stats_to_specimens_table(specimens_df, hyst_results, overwrite=True
 # X-T functions
 # ------------------------------------------------------------------------------------------------------------------
 
-def split_warm_cool(experiment,temperature_column='meas_temp',
+def split_warm_cool(experiment, temperature_column='meas_temp',
                     magnetic_column='susc_chi_mass'):
     """
-    Split a thermomagnetic curve into heating and cooling portions. Default
-    columns are 'meas_temp' and 'susc_chi_mass' for susceptibility measurements.
-    Funcation can also be used for other warming then cooling data.
+    Split a thermomagnetic curve into heating and cooling portions.
+
+    Points are classified by the sign of the local temperature change: a
+    measurement is assigned to the heating branch when the temperature
+    increased relative to the previous measurement, and to the cooling branch
+    otherwise (the first point is assigned to the heating branch). Rows with
+    non-finite temperature or magnetic values are dropped. Data that only heat
+    (or only cool) return an empty array for the missing branch.
 
     Parameters
     ----------
     experiment : pandas.DataFrame
-        the experiment data
+        the experiment data (rows in measurement order)
     temperature_column : str, optional
         name of the temperature column (default 'meas_temp')
     magnetic_column : str, optional
@@ -3996,26 +4001,147 @@ def split_warm_cool(experiment,temperature_column='meas_temp',
 
     Returns
     -------
-    warm_T : list[float]
-        temperatures for the heating cycle
-    warm_X : list[float]
+    warm_T : numpy.ndarray
+        temperatures for the heating cycle (measurement order)
+    warm_X : numpy.ndarray
         magnetization/susceptibility for the heating cycle
-    cool_T : list[float]
-        temperatures for the cooling cycle
-    cool_X : list[float]
+    cool_T : numpy.ndarray
+        temperatures for the cooling cycle (measurement order)
+    cool_X : numpy.ndarray
         magnetization/susceptibility for the cooling cycle
     """
-    Tlist = experiment[temperature_column] # temperature list
-    Xlist = experiment[magnetic_column] # Chi list
-    
-    warmorcool = np.array(np.insert((np.diff(Tlist) > 0 )* 1, 0, 1))
-#     print(warmorcool)
-    warm_T = [Tlist[i] for i in range(len(warmorcool)) if warmorcool[i]==1]
-    cool_T = [Tlist[i] for i in range(len(warmorcool)) if warmorcool[i]==0]
-    warm_X = [Xlist[i] for i in range(len(warmorcool)) if warmorcool[i]==1]
-    cool_X = [Xlist[i] for i in range(len(warmorcool)) if warmorcool[i]==0]
+    T = np.asarray(experiment[temperature_column], dtype=float)
+    X = np.asarray(experiment[magnetic_column], dtype=float)
+
+    finite = np.isfinite(T) & np.isfinite(X)
+    T = T[finite]
+    X = X[finite]
+
+    if T.size == 0:
+        empty = np.array([], dtype=float)
+        return empty, empty.copy(), empty.copy(), empty.copy()
+
+    steps = np.diff(T) > 0
+    # the first point takes the direction of the first step so that a
+    # cooling-only sequence does not produce a spurious one-point heating branch
+    first = steps[0] if steps.size else True
+    is_heating = np.insert(steps, 0, first)
+
+    warm_T = T[is_heating]
+    warm_X = X[is_heating]
+    cool_T = T[~is_heating]
+    cool_X = X[~is_heating]
 
     return warm_T, warm_X, cool_T, cool_X
+
+
+def prepare_thermomag_branches(
+    experiment,
+    temperature_column="meas_temp",
+    magnetic_column="susc_chi_mass",
+    temp_unit="C",
+    input_unit="K",
+    smooth_window=0,
+    remove_holder=True,
+    window_type="hanning",
+):
+    """
+    Preprocess a thermomagnetic experiment into clean heating/cooling branches.
+
+    This is the shared preprocessing step for the Curie temperature estimators
+    and thermomagnetic plots. It splits the measurement sequence into heating
+    and cooling branches (``split_warm_cool``), converts temperatures to the
+    requested unit, optionally subtracts the per-branch minimum as an estimate
+    of the sample-holder background, sorts each branch by ascending
+    temperature, and optionally smooths each branch with an x-space moving
+    window (``smooth_moving_avg``).
+
+    Subtracting the per-branch minimum assumes that the magnetic signal decays
+    to the holder background at the highest temperatures (i.e., the experiment
+    passes above the Curie temperature of all ferromagnetic phases). When that
+    assumption does not hold (e.g., a run that ends below the Curie
+    temperature), set ``remove_holder=False``.
+
+    Parameters
+    ----------
+    experiment : pandas.DataFrame
+        MagIC-formatted experiment DataFrame (rows in measurement order).
+    temperature_column : str, optional
+        Name of the temperature column (default 'meas_temp').
+    magnetic_column : str, optional
+        Name of the magnetization/susceptibility column
+        (default 'susc_chi_mass').
+    temp_unit : {'C', 'K'}, optional
+        Unit for the returned temperatures (default 'C').
+    input_unit : {'K', 'C'}, optional
+        Unit of the temperatures in ``experiment`` (default 'K', the MagIC
+        convention for ``meas_temp``).
+    smooth_window : float, optional
+        Width of the smoothing window in units of ``temp_unit``. If 0
+        (default), no smoothing is applied and the smoothed arrays equal the
+        raw arrays.
+    remove_holder : bool, optional
+        Subtract the per-branch minimum value from each branch (default True).
+    window_type : {'flat', 'hanning', 'hamming', 'bartlett', 'blackman'}, optional
+        Weighting function applied within each smoothing window by
+        ``smooth_moving_avg`` (default 'hanning'). Only used when
+        ``smooth_window > 0``. The options are:
+
+        - 'flat': uniform weights, i.e. a simple unweighted running mean.
+        - 'hanning': raised-cosine (Hann) taper; weights fall smoothly to
+          zero at the window edges. A good general-purpose default that
+          suppresses edge/ringing artifacts.
+        - 'hamming': raised-cosine taper similar to 'hanning' but with
+          nonzero end weights, giving slightly less edge attenuation.
+        - 'bartlett': triangular taper; weights decrease linearly from the
+          window center to zero at the edges.
+        - 'blackman': three-term cosine taper that is more strongly peaked
+          than 'hanning'/'hamming', giving the heaviest smoothing (widest
+          effective averaging) of the tapered options.
+
+        All options other than 'flat' are the correspondingly named
+        ``numpy`` window functions.
+
+    Returns
+    -------
+    dict
+        ``{'heating': branch or None, 'cooling': branch or None}`` where each
+        branch is a dict with keys ``'T'`` and ``'y'`` (smoothed arrays,
+        ascending temperature) and ``'raw_T'`` and ``'raw_y'`` (unsmoothed
+        arrays, ascending temperature). A branch with no measurements is
+        ``None``.
+    """
+    warm_T, warm_X, cool_T, cool_X = split_warm_cool(
+        experiment,
+        temperature_column=temperature_column,
+        magnetic_column=magnetic_column,
+    )
+
+    branches = {}
+    for name, T, y in (("heating", warm_T, warm_X), ("cooling", cool_T, cool_X)):
+        if T.size == 0:
+            branches[name] = None
+            continue
+        T = convert_temperature(T, input_unit, temp_unit)
+        if remove_holder:
+            y = y - np.min(y)
+        order = np.argsort(T, kind="stable")
+        T = T[order]
+        y = y[order]
+        # average duplicate temperatures once here so that every estimator
+        # receives strictly increasing temperatures and repeated logged
+        # points (furnace stabilization) do not over-weight the fits
+        analysis_T, analysis_y = _dedupe_temperatures(T, y)
+        sm_T, sm_y = smooth_moving_avg(analysis_T, analysis_y, smooth_window,
+                                       window_type=window_type)
+        branches[name] = {
+            "T": np.asarray(sm_T, dtype=float),
+            "y": np.asarray(sm_y, dtype=float),
+            "raw_T": T,
+            "raw_y": y,
+        }
+
+    return branches
 
 
 def plot_X_T(
@@ -4030,6 +4156,7 @@ def plot_X_T(
     interactive=True,
     return_figure=False,
     figsize=(6, 6),
+    window_type="hanning",
 ):
     """
     Plot the high-temperature susceptibility curve, and optionally its derivative
@@ -4039,7 +4166,8 @@ def plot_X_T(
         experiment (pandas.DataFrame): MagIC-formatted experiment DataFrame.
         temperature_column (str): Name of temperature column.
         magnetic_column (str): Name of susceptibility column.
-        temp_unit (str): "C" for Celsius.
+        temp_unit (str): "C" or "K" for the plotted temperatures (input
+            temperatures are assumed to be in Kelvin, the MagIC convention).
         smooth_window (int): Window for smoothing, if 0, no smoothing is applied.
         remove_holder (bool): Subtract holder signal.
         plot_derivative (bool): Plot derivative.
@@ -4047,24 +4175,31 @@ def plot_X_T(
         interactive (bool): True for Bokeh, False for Matplotlib.
         return_figure (bool): Return figure objects if True.
         figsize (tuple): (width, height) in inches.
+        window_type (str): Weighting function applied within each smoothing
+            window, one of 'flat', 'hanning', 'hamming', 'bartlett', or
+            'blackman' (default 'hanning'). Only used when smooth_window > 0.
+            See prepare_thermomag_branches for a description of each option.
     """
-    warm_T, warm_X, cool_T, cool_X = split_warm_cool(
+    branches = prepare_thermomag_branches(
         experiment,
         temperature_column=temperature_column,
         magnetic_column=magnetic_column,
+        temp_unit=temp_unit,
+        smooth_window=smooth_window,
+        remove_holder=remove_holder,
+        window_type=window_type,
     )
-    if temp_unit == "C":
-        warm_T = [T - 273.15 for T in warm_T]
-        cool_T = [T - 273.15 for T in cool_T]
-    else:
-        raise ValueError('temp_unit must be "C"')
-    if remove_holder:
-        holder_w = min(warm_X)
-        holder_c = min(cool_X)
-        warm_X = [X - holder_w for X in warm_X]
-        cool_X = [X - holder_c for X in cool_X]
-    swT, swX = smooth_moving_avg(warm_T, warm_X, smooth_window)
-    scT, scX = smooth_moving_avg(cool_T, cool_X, smooth_window)
+    empty = np.array([], dtype=float)
+    heating = branches["heating"]
+    cooling = branches["cooling"]
+    warm_T = heating["raw_T"] if heating else empty
+    warm_X = heating["raw_y"] if heating else empty
+    cool_T = cooling["raw_T"] if cooling else empty
+    cool_X = cooling["raw_y"] if cooling else empty
+    swT = heating["T"] if heating else empty
+    swX = heating["y"] if heating else empty
+    scT = cooling["T"] if cooling else empty
+    scX = cooling["y"] if cooling else empty
     title = experiment["specimen"].unique()[0]
     figs = []
 
@@ -4125,22 +4260,28 @@ def plot_X_T(
             )
             p_dx.xaxis.axis_label_text_font_style = "normal"
             p_dx.yaxis.axis_label_text_font_style = "normal"
-            dx_w = np.gradient(swX, swT)
-            dx_c = np.gradient(scX, scT)
+            # average duplicate temperatures before differencing so that
+            # repeated logged temperatures do not produce zero spacing
+            swT_d, swX_d = _dedupe_temperatures(swT, swX)
+            scT_d, scX_d = _dedupe_temperatures(scT, scX)
+            dx_w = np.gradient(swX_d, swT_d) if swT_d.size > 1 else empty
+            dx_c = np.gradient(scX_d, scT_d) if scT_d.size > 1 else empty
+            swT_d = swT_d if swT_d.size > 1 else empty
+            scT_d = scT_d if scT_d.size > 1 else empty
             r_dx_w = p_dx.line(
-                swT, dx_w, legend_label="Heating – dχ/dT",
+                swT_d, dx_w, legend_label="Heating – dχ/dT",
                 line_width=2, color="red"
             )
             r_dx_w_c = p_dx.scatter(
-                swT, dx_w, legend_label="Heating – dχ/dT",
+                swT_d, dx_w, legend_label="Heating – dχ/dT",
                 color="red", alpha=0.5, size=6
             )
             r_dx_c = p_dx.line(
-                scT, dx_c, legend_label="Cooling – dχ/dT",
+                scT_d, dx_c, legend_label="Cooling – dχ/dT",
                 line_width=2, color="blue"
             )
             r_dx_c_c = p_dx.scatter(
-                scT, dx_c, legend_label="Cooling – dχ/dT",
+                scT_d, dx_c, legend_label="Cooling – dχ/dT",
                 color="blue", alpha=0.5, size=6
             )
             p_dx.add_tools(
@@ -4170,14 +4311,8 @@ def plot_X_T(
             )
             p_inv.xaxis.axis_label_text_font_style = "normal"
             p_inv.yaxis.axis_label_text_font_style = "normal"
-            swX_arr = np.array(swX)
-            scX_arr = np.array(scX)
-            inv_w = np.divide(1.0, swX_arr,
-                              out=np.full_like(swX_arr, np.nan),
-                              where=swX_arr != 0.0)
-            inv_c = np.divide(1.0, scX_arr,
-                              out=np.full_like(scX_arr, np.nan),
-                              where=scX_arr != 0.0)
+            inv_w = _inverse_susceptibility(swX)
+            inv_c = _inverse_susceptibility(scX)
             mask_w = np.isfinite(inv_w)
             mask_c = np.isfinite(inv_c)
             r_inv_w = p_inv.line(
@@ -4231,11 +4366,17 @@ def plot_X_T(
         figs.append(fig1)
 
         if plot_derivative:
-            dx_w = np.gradient(swX, swT)
-            dx_c = np.gradient(scX, scT)
+            # average duplicate temperatures before differencing so that
+            # repeated logged temperatures do not produce zero spacing
+            swT_d, swX_d = _dedupe_temperatures(swT, swX)
+            scT_d, scX_d = _dedupe_temperatures(scT, scX)
+            dx_w = np.gradient(swX_d, swT_d) if swT_d.size > 1 else empty
+            dx_c = np.gradient(scX_d, scT_d) if scT_d.size > 1 else empty
+            swT_d = swT_d if swT_d.size > 1 else empty
+            scT_d = scT_d if scT_d.size > 1 else empty
             fig2, ax2 = plt.subplots(**fig_kwargs)
-            ax2.plot(swT, dx_w, label="Heating – dχ/dT", linewidth=2, marker="o")
-            ax2.plot(scT, dx_c, label="Cooling – dχ/dT", linewidth=2, marker="o")
+            ax2.plot(swT_d, dx_w, label="Heating – dχ/dT", linewidth=2, marker="o")
+            ax2.plot(scT_d, dx_c, label="Cooling – dχ/dT", linewidth=2, marker="o")
             ax2.set_title(f"{title} – dχ/dT")
             ax2.set_xlabel(f"Temperature (°{temp_unit})")
             ax2.set_ylabel("dχ/dT")
@@ -4244,18 +4385,8 @@ def plot_X_T(
             figs.append(fig2)
 
         if plot_inverse:
-            swX_arr = np.array(swX)
-            scX_arr = np.array(scX)
-            inv_w = np.divide(
-                1.0, swX_arr,
-                out=np.full_like(swX_arr, np.nan),
-                where=swX_arr != 0.0,
-            )
-            inv_c = np.divide(
-                1.0, scX_arr,
-                out=np.full_like(scX_arr, np.nan),
-                where=scX_arr != 0.0,
-            )
+            inv_w = _inverse_susceptibility(swX)
+            inv_c = _inverse_susceptibility(scX)
             mask_w = np.isfinite(inv_w)
             mask_c = np.isfinite(inv_c)
             fig3, ax3 = plt.subplots(**fig_kwargs)
@@ -4268,180 +4399,1463 @@ def plot_X_T(
             ax3.legend(loc="upper left")
             figs.append(fig3)
 
-        for fig in figs:
-            plt.show(fig)
+        plt.show()
 
     if return_figure:
         return tuple(figs)
     return None
 
-def estimate_curie_temperature(
+# Curie temperature estimation
+# ------------------------------------------------------------------------------------------------------------------
+# The estimators below implement the methods reviewed by Fabian et al. (2013,
+# doi:10.1029/2012GC004440). Method applicability depends on the type of
+# thermomagnetic data:
+#
+# * in-field magnetization M(T): the Curie temperature corresponds to the
+#   inflection point of M(T) (minimum of dM/dT); the classical
+#   maximum-curvature (second-derivative maximum) and two-tangent estimates
+#   coincide with each other and lie systematically above the inflection-point
+#   Tc (typically by 10-15 degrees C, increasing with applied field).
+# * low-field susceptibility X(T): several mechanisms (para-effect, rotation
+#   against anisotropy, domain-wall motion, superparamagnetism) contribute
+#   near the ordering temperature; the Hopkinson peak marks blocking, not Tc,
+#   and the two-tangent construction is not physically justified (Petrovsky &
+#   Kapicka, 2006, doi:10.1029/2006JB004507). The inverse-susceptibility
+#   (Curie-Weiss) extrapolation yields the paramagnetic Curie temperature
+#   theta, an upper bound on Tc.
+#
+# Systematic inter-method offsets of several to tens of degrees are expected
+# and documented on synthetic titanomagnetites by Lattard et al. (2006,
+# doi:10.1029/2006JB004591); comparing estimates from multiple methods is
+# therefore diagnostic rather than redundant.
+
+
+def _inverse_susceptibility(chi):
+    """
+    Compute 1/chi with non-positive values masked to NaN.
+
+    Non-positive susceptibilities (possible after holder over-correction)
+    have no meaningful inverse for Curie-Weiss purposes; masking them here
+    keeps the displayed and fitted inverse-susceptibility curves consistent.
+    """
+    chi = np.asarray(chi, dtype=float)
+    return np.divide(1.0, chi, out=np.full_like(chi, np.nan), where=chi > 0)
+
+
+def _dedupe_temperatures(T, y):
+    """
+    Average y-values measured at duplicate temperatures.
+
+    Finite-difference derivatives require strictly increasing abscissae;
+    thermomagnetic instruments commonly log repeated temperatures while the
+    furnace stabilizes. Returns (unique ascending T, mean y per T).
+    """
+    T = np.asarray(T, dtype=float)
+    y = np.asarray(y, dtype=float)
+    unique_T, inverse = np.unique(T, return_inverse=True)
+    if unique_T.size == T.size:
+        order = np.argsort(T, kind="stable")
+        return T[order], y[order]
+    sums = np.bincount(inverse, weights=y)
+    counts = np.bincount(inverse)
+    return unique_T, sums / counts
+
+
+def _interpolated_zero_crossings(x, y):
+    """
+    Find zero crossings of y(x) by linear interpolation.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Monotonically ordered abscissa values.
+    y : numpy.ndarray
+        Ordinate values.
+
+    Returns
+    -------
+    numpy.ndarray
+        Interpolated x-positions where y changes sign (empty if none).
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    crossings = []
+    for i in range(y.size - 1):
+        y0, y1 = y[i], y[i + 1]
+        if not (np.isfinite(y0) and np.isfinite(y1)):
+            continue
+        if y0 == 0.0:
+            crossings.append(x[i])
+        elif y0 * y1 < 0.0:
+            crossings.append(x[i] - y0 * (x[i + 1] - x[i]) / (y1 - y0))
+    return np.array(crossings, dtype=float)
+
+
+def curie_derivative_estimates(T, y, t_range=None):
+    """
+    Derivative-based Curie temperature estimates from one thermomagnetic branch.
+
+    Two estimates are returned:
+
+    * ``inflection_temp`` — the inflection point of the curve, located as the
+      zero crossing of the second derivative between its extrema (refined by
+      linear interpolation), with the minimum of the first derivative as
+      fallback. For in-field magnetization curves M(T), Landau theory places
+      the Curie temperature at this inflection point, independent of the
+      applied field (Fabian et al., 2013, doi:10.1029/2012GC004440).
+    * ``max_curvature_temp`` — the maximum of the second derivative
+      ("maximum curvature" of the concave part of the heating curve). This is
+      the classical practical definition of Ade-Hall et al. (1965) that is
+      implemented in many software packages (including the legacy
+      ``ipmag.curie``). On M(T) curves it lies systematically above the
+      inflection-point Tc (typically 10-15 degrees C) and shifts with the
+      strength of the applied field (Fabian et al., 2013).
+
+    The input arrays are assumed to be smoothed as appropriate (see
+    ``prepare_thermomag_branches``); derivatives amplify noise, so unsmoothed
+    noisy data will produce spurious extrema.
+
+    Parameters
+    ----------
+    T : array-like
+        Temperatures, ascending.
+    y : array-like
+        Magnetization or susceptibility values.
+    t_range : tuple of (float, float), optional
+        Restrict the analysis to temperatures within ``(t_min, t_max)``.
+        Useful for isolating one Curie transition in a multi-phase curve or
+        excluding low-temperature structure (e.g., a Hopkinson peak).
+
+    Returns
+    -------
+    dict
+        ``inflection_temp``, ``max_curvature_temp``,
+        ``first_derivative_min_temp`` (the discrete minimum of dy/dT),
+        ``zero_crossing_temps`` (all interpolated zero crossings of the second
+        derivative between its extrema), and ``diagnostics`` with the arrays
+        ``T``, ``dy_dT``, and ``d2y_dT2``.
+    """
+    T = np.asarray(T, dtype=float)
+    y = np.asarray(y, dtype=float)
+    if t_range is not None:
+        mask = (T >= t_range[0]) & (T <= t_range[1])
+        T = T[mask]
+        y = y[mask]
+    T, y = _dedupe_temperatures(T, y)
+    if T.size < 4:
+        nan = np.nan
+        return {
+            "inflection_temp": nan,
+            "max_curvature_temp": nan,
+            "first_derivative_min_temp": nan,
+            "zero_crossing_temps": np.array([]),
+            "diagnostics": {"T": T, "dy_dT": np.array([]), "d2y_dT2": np.array([])},
+        }
+
+    dy = np.gradient(y, T)
+    d2y = np.gradient(dy, T)
+
+    i_steep = int(np.argmin(dy))
+    first_derivative_min_temp = T[i_steep]
+
+    # restrict the curvature analysis to the transition zone around the
+    # steepest descent: from where the descent last began (slope within 5
+    # percent of zero relative to the steepest slope) to where the curve first
+    # returns to baseline above it; outside this zone, noise in the flat
+    # segments dominates the second derivative of real data
+    slope_floor = 0.05 * np.abs(dy[i_steep])
+    near_zero = np.abs(dy) <= slope_floor
+    before = np.nonzero(near_zero[:i_steep])[0]
+    j_start = int(before[-1]) if before.size else 0
+    after = np.nonzero(near_zero[i_steep:])[0]
+    j_end = int(after[0]) + i_steep if after.size else T.size - 1
+
+    zone = slice(j_start, j_end + 1)
+    d2y_zone = d2y[zone]
+    T_zone = T[zone]
+    max_curvature_temp = T_zone[np.argmax(d2y_zone)]
+
+    # zero crossings of the second derivative between its extrema bracket the
+    # inflection point of the descending limb
+    lower, upper = sorted([int(np.argmin(d2y_zone)), int(np.argmax(d2y_zone))])
+    zero_crossing_temps = _interpolated_zero_crossings(
+        T_zone[lower:upper + 1], d2y_zone[lower:upper + 1]
+    )
+    if zero_crossing_temps.size:
+        inflection_temp = zero_crossing_temps[
+            np.argmin(np.abs(zero_crossing_temps - first_derivative_min_temp))
+        ]
+    else:
+        inflection_temp = first_derivative_min_temp
+
+    return {
+        "inflection_temp": float(inflection_temp),
+        "max_curvature_temp": float(max_curvature_temp),
+        "first_derivative_min_temp": float(first_derivative_min_temp),
+        "zero_crossing_temps": zero_crossing_temps,
+        "diagnostics": {"T": T, "dy_dT": dy, "d2y_dT2": d2y},
+    }
+
+
+def curie_two_tangent(T, y, lower_range=None, upper_range=None, min_points=3):
+    """
+    Two-tangent (intersecting tangents) Curie temperature estimate.
+
+    Straight lines are fit to a segment of the steeply descending limb below
+    the Curie temperature and to the near-flat baseline above it; the
+    temperature of their intersection is returned. The construction follows
+    Gromme et al. (1969, doi:10.1029/JB074i022p05277), who applied it to
+    strong-field J-T curves.
+
+    Applicability and bias: the method is intended for magnetization curves
+    M(T). Even there it coincides with the maximum-curvature estimate and
+    therefore lies systematically above the inflection-point Curie temperature
+    (Fabian et al., 2013, doi:10.1029/2012GC004440). Applied to low-field
+    susceptibility X(T) it is not physically justified and can considerably
+    overestimate Tc (Petrovsky & Kapicka, 2006, doi:10.1029/2006JB004507); it
+    is provided for such data only to allow comparison with legacy results.
+
+    Parameters
+    ----------
+    T : array-like
+        Temperatures, ascending.
+    y : array-like
+        Magnetization (preferred) or susceptibility values.
+    lower_range : tuple of (float, float), optional
+        Temperature interval for the descending-limb tangent. If None, the
+        contiguous region around the steepest descent where the slope is at
+        least half the steepest slope is used.
+    upper_range : tuple of (float, float), optional
+        Temperature interval for the baseline tangent. If None, points above
+        the steepest descent where the slope has decayed to within 5 percent
+        of the steepest slope are used (falling back to the uppermost decile
+        of points).
+    min_points : int, optional
+        Minimum number of points required in each tangent segment (default 3).
+
+    Returns
+    -------
+    dict
+        ``curie_temp`` (intersection temperature, NaN if the tangents are
+        parallel or a segment has too few points), ``params`` with the two
+        (slope, intercept) pairs, the temperature ranges actually used, and
+        point counts, and ``diagnostics`` with the segment masks for plotting.
+    """
+    T, y = _dedupe_temperatures(T, y)
+    result = {
+        "curie_temp": np.nan,
+        "params": {},
+        "diagnostics": {},
+    }
+    if T.size < 2 * min_points:
+        result["params"]["note"] = "insufficient points for two-tangent fit"
+        return result
+
+    dy = np.gradient(y, T)
+    i_steep = int(np.argmin(dy))
+    steepest = dy[i_steep]
+
+    if lower_range is None:
+        # contiguous run around the steepest descent where the slope is at
+        # least half the steepest slope
+        steep_enough = dy <= 0.5 * steepest
+        i0 = i_steep
+        while i0 > 0 and steep_enough[i0 - 1]:
+            i0 -= 1
+        i1 = i_steep
+        while i1 < T.size - 1 and steep_enough[i1 + 1]:
+            i1 += 1
+        lower_mask = np.zeros(T.size, dtype=bool)
+        lower_mask[i0:i1 + 1] = True
+        lower_range = (float(T[i0]), float(T[i1]))
+    else:
+        lower_mask = (T >= lower_range[0]) & (T <= lower_range[1])
+
+    baseline_fallback = False
+    if upper_range is None:
+        baseline = (np.arange(T.size) > i_steep) & (np.abs(dy) <= 0.05 * np.abs(steepest))
+        if baseline.sum() < min_points:
+            # no near-flat baseline exists above the steepest descent: the
+            # curve may not reach above the Curie temperature, so the
+            # uppermost points used here can still be on the descending limb
+            baseline_fallback = True
+            n_tail = max(min_points, T.size // 10)
+            baseline = np.zeros(T.size, dtype=bool)
+            baseline[-n_tail:] = True
+        upper_mask = baseline
+        upper_range = (float(T[upper_mask].min()), float(T[upper_mask].max()))
+    else:
+        upper_mask = (T >= upper_range[0]) & (T <= upper_range[1])
+
+    if lower_mask.sum() < min_points or upper_mask.sum() < min_points:
+        result["params"]["note"] = "insufficient points in a tangent segment"
+        return result
+
+    lower_slope, lower_intercept = np.polyfit(T[lower_mask], y[lower_mask], 1)
+    upper_slope, upper_intercept = np.polyfit(T[upper_mask], y[upper_mask], 1)
+
+    if np.isclose(lower_slope, upper_slope):
+        result["params"]["note"] = "tangents are parallel"
+        return result
+
+    curie_temp = (upper_intercept - lower_intercept) / (lower_slope - upper_slope)
+
+    result["curie_temp"] = float(curie_temp)
+    result["params"] = {
+        "lower_slope": float(lower_slope),
+        "lower_intercept": float(lower_intercept),
+        "upper_slope": float(upper_slope),
+        "upper_intercept": float(upper_intercept),
+        "lower_range": lower_range,
+        "upper_range": upper_range,
+        "n_lower": int(lower_mask.sum()),
+        "n_upper": int(upper_mask.sum()),
+    }
+    if baseline_fallback:
+        result["params"]["note"] = (
+            "no near-flat baseline found above the steepest descent; the "
+            "upper tangent was fit to the uppermost points, which may still "
+            "be on the descending limb if the curve ends below the Curie "
+            "temperature — verify or set upper_range explicitly"
+        )
+    result["diagnostics"] = {
+        "T": T,
+        "y": y,
+        "lower_mask": lower_mask,
+        "upper_mask": upper_mask,
+    }
+    return result
+
+
+def curie_inverse_susceptibility(T, chi, fit_range=None, min_points=5,
+                                 min_chi=None):
+    """
+    Curie-Weiss (inverse susceptibility) estimate of the ordering temperature.
+
+    Above the Curie temperature the susceptibility of the paramagnetic phase
+    follows the Curie-Weiss law chi = C / (T - theta), so 1/chi is linear in T
+    and extrapolates to zero at the paramagnetic Curie temperature theta. A
+    straight line is fit to 1/chi within ``fit_range`` and
+    ``curie_temp = -intercept/slope`` is returned.
+
+    This is the recommended quantitative approach for low-field
+    susceptibility X(T) curves (Petrovsky & Kapicka, 2006,
+    doi:10.1029/2006JB004507). Two caveats apply: (1) theta is an upper bound
+    on the Curie temperature (theta >= Tc, with the difference depending on
+    the strength of magnetic interactions); (2) the estimate is sensitive to
+    the choice of fitting window — the fit must be restricted to temperatures
+    where the signal is fully paramagnetic, above the steep decrease, and
+    where the (holder-corrected) susceptibility is still resolved above the
+    instrument's measurement resolution. Well above the transition the
+    paramagnetic signal commonly becomes so weak that successive readings
+    repeat identical values and 1/chi shows flat plateaus; including
+    such quantized points flattens the fitted slope and biases theta low —
+    a theta below an independently estimated Tc (e.g., the inflection point)
+    is a red flag for this. The function detects repeated quantized values in
+    the fitting window and attaches a warning; use ``min_chi`` or tighten
+    ``fit_range`` to exclude resolution-limited points. Report the fitting
+    window with the estimate.
+
+    Parameters
+    ----------
+    T : array-like
+        Temperatures, ascending.
+    chi : array-like
+        Susceptibility values (holder-corrected).
+    fit_range : tuple of (float, float), optional
+        Temperature interval for the linear fit of 1/chi. If None, the upper
+        20 percent of the temperature span is used — a starting guess only;
+        inspect the fit and set the window explicitly for reported values.
+    min_points : int, optional
+        Minimum number of usable points in the window (default 5).
+    min_chi : float, optional
+        Exclude points with susceptibility below this value from the fit
+        (same units as ``chi``). Useful for screening out
+        resolution-limited values in the high-temperature tail.
+
+    Returns
+    -------
+    dict
+        ``curie_temp`` (theta), ``curie_temp_stderr`` (1-sigma from the fit
+        covariance), ``params`` with slope, intercept, ``r_squared``,
+        ``curie_constant`` (1/slope), ``n_points``, ``fit_range``, and a
+        ``warning`` when the fitted points are dominated by repeated
+        (quantized) susceptibility values, and ``diagnostics`` with the
+        1/chi arrays and fitted line.
+    """
+    T = np.asarray(T, dtype=float)
+    chi = np.asarray(chi, dtype=float)
+
+    if fit_range is None:
+        t_span = T.max() - T.min()
+        fit_range = (T.min() + 0.8 * t_span, T.max())
+
+    mask = (
+        (T >= fit_range[0])
+        & (T <= fit_range[1])
+        & np.isfinite(chi)
+        & (chi > 0)
+    )
+    if min_chi is not None:
+        mask &= chi >= min_chi
+    result = {
+        "curie_temp": np.nan,
+        "curie_temp_stderr": np.nan,
+        "params": {"fit_range": (float(fit_range[0]), float(fit_range[1])),
+                   "n_points": int(mask.sum())},
+        "diagnostics": {},
+    }
+    if mask.sum() < min_points:
+        result["params"]["note"] = (
+            f"only {int(mask.sum())} usable points in fit_range; "
+            f"at least {min_points} required"
+        )
+        return result
+
+    T_fit = T[mask]
+    inv_chi = 1.0 / chi[mask]
+
+    (slope, intercept), cov = np.polyfit(T_fit, inv_chi, 1, cov=True)
+    if slope <= 0:
+        # 1/chi must increase with T above the transition; a non-positive
+        # slope means the window is not sampling a paramagnetic Curie-Weiss
+        # tail (wrong window, over-subtracted holder, or altered signal)
+        result["params"]["note"] = (
+            "non-positive slope in the 1/chi fit; the fitting window does "
+            "not sample a paramagnetic Curie-Weiss tail — adjust fit_range"
+        )
+        return result
+    theta = -intercept / slope
+
+    # 1-sigma uncertainty on theta from the fit covariance
+    d_theta_d_slope = intercept / slope**2
+    d_theta_d_intercept = -1.0 / slope
+    var_theta = (
+        d_theta_d_slope**2 * cov[0, 0]
+        + d_theta_d_intercept**2 * cov[1, 1]
+        + 2.0 * d_theta_d_slope * d_theta_d_intercept * cov[0, 1]
+    )
+    theta_stderr = float(np.sqrt(var_theta)) if var_theta >= 0 else np.nan
+
+    predicted = slope * T_fit + intercept
+    ss_res = float(np.sum((inv_chi - predicted) ** 2))
+    ss_tot = float(np.sum((inv_chi - inv_chi.mean()) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else np.nan
+
+    result["curie_temp"] = float(theta)
+    result["curie_temp_stderr"] = theta_stderr
+    result["params"].update({
+        "slope": float(slope),
+        "intercept": float(intercept),
+        "r_squared": float(r_squared),
+        "curie_constant": float(1.0 / slope),
+    })
+
+    # repeated identical susceptibility values in the window are the
+    # signature of a resolution-limited (quantized) tail, which flattens the
+    # fitted slope and biases theta low
+    chi_fit = chi[mask]
+    repeated = np.concatenate([[False], chi_fit[1:] == chi_fit[:-1]])
+    repeated[:-1] |= repeated[1:]
+    quantized_fraction = float(repeated.mean())
+    if quantized_fraction > 1.0 / 3.0:
+        result["params"]["warning"] = (
+            f"{quantized_fraction:.0%} of the fitted points repeat identical "
+            "susceptibility values (weak, resolution-limited signal); theta "
+            "is likely biased low — tighten fit_range or set min_chi"
+        )
+
+    result["diagnostics"] = {
+        "T": T,
+        "inv_chi": _inverse_susceptibility(chi),
+        "T_fit": T_fit,
+        "inv_chi_fit": inv_chi,
+        "line_T": np.array([theta, T_fit.max()]),
+        "line_inv_chi": np.array([0.0, slope * T_fit.max() + intercept]),
+    }
+    return result
+
+
+def landau_magnetization(tau, h):
+    """
+    Reduced magnetization from the Landau equation of state with field term.
+
+    Solves ``m**3 + tau*m = h`` for the physical (largest real) root, where
+    ``tau = (T - Tc)/Tc`` is the reduced temperature and ``h`` is the reduced
+    field (Fabian et al., 2013, doi:10.1029/2012GC004440, eqs. 3-5). For
+    ``h = 0`` this reduces to ``m = sqrt(-tau)`` below the Curie temperature
+    and ``m = 0`` above it; for ``h > 0`` the transition is rounded and a
+    field-induced tail persists above Tc.
+
+    Parameters
+    ----------
+    tau : array-like
+        Reduced temperatures (T - Tc)/Tc; requires absolute temperatures
+        (Kelvin) in the ratio.
+    h : float
+        Reduced field, >= 0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Reduced magnetization m at each tau.
+    """
+    tau = np.atleast_1d(np.asarray(tau, dtype=float))
+    p = tau
+    q = -float(h)
+
+    m = np.empty_like(p)
+    disc = q**2 / 4.0 + p**3 / 27.0
+
+    # one real root (Cardano); q <= 0 so -q/2 >= 0 and this root is >= 0
+    single = disc >= 0
+    if np.any(single):
+        sq = np.sqrt(disc[single])
+        m[single] = np.cbrt(-q / 2.0 + sq) + np.cbrt(-q / 2.0 - sq)
+
+    # three real roots (trigonometric form); the k=0 root is the largest
+    triple = ~single
+    if np.any(triple):
+        pt = p[triple]
+        arg = (3.0 * q) / (2.0 * pt) * np.sqrt(-3.0 / pt)
+        arg = np.clip(arg, -1.0, 1.0)
+        m[triple] = 2.0 * np.sqrt(-pt / 3.0) * np.cos(np.arccos(arg) / 3.0)
+
+    return m
+
+
+def curie_landau_fit(T, M, fit_range=None, temp_unit="C", tc_bounds=None,
+                     n_grid=40):
+    """
+    Fit the in-field Landau equation of state to a magnetization curve M(T).
+
+    The model is ``M(T) = M0 * m(tau; h)`` where m is the physical root of the
+    Landau equation of state ``m**3 + tau*m = h`` with ``tau = (T - Tc)/Tc``
+    in absolute temperature (Fabian et al., 2013, doi:10.1029/2012GC004440,
+    eqs. 3-5). The reduced field h rounds the transition and produces the
+    field-induced tail above Tc, so the fit uses the full curve without an
+    ad-hoc baseline. In the ``h = 0`` limit the model is
+    ``M = M0*sqrt(1 - T/Tc)`` below Tc — the mean-field form underlying the
+    extrapolation method of Moskowitz (1981,
+    doi:10.1016/0012-821X(81)90028-5).
+
+    The fit provides the physically grounded Curie temperature (at the
+    inflection point of the in-field curve), with a formal 1-sigma
+    uncertainty. When ``fit_range`` excludes the transition (all data below
+    Tc), the fit operates in Moskowitz-style extrapolation mode: this is the
+    only option for runs that end below Tc, but the reliability of the
+    extrapolated Tc decays rapidly with the distance between the highest
+    measured temperature and Tc, and the formal uncertainty then
+    underestimates the true (model-dependence dominated) uncertainty.
+
+    Caveats: the model describes a single ferromagnetic phase near its
+    transition; admixed paramagnetic signal, multiple phases, or alteration
+    during heating violate it — restrict ``fit_range`` to isolate one
+    transition. Applied to low-field susceptibility the model does not
+    describe the dominant susceptibility mechanisms (see Fabian et al., 2013)
+    and results should be treated as qualitative.
+
+    Parameters
+    ----------
+    T : array-like
+        Temperatures, ascending, in ``temp_unit``.
+    M : array-like
+        Magnetization values.
+    fit_range : tuple of (float, float), optional
+        Temperature interval (in ``temp_unit``) used in the fit. Default uses
+        all points.
+    temp_unit : {'C', 'K'}, optional
+        Unit of the input temperatures (default 'C'). The reduced temperature
+        is always formed in Kelvin internally; results are returned in
+        ``temp_unit``.
+    tc_bounds : tuple of (float, float), optional
+        Bounds for Tc in Kelvin (default: (min(T)+1 K, 2000 K)). Tighten for
+        extrapolation fits when independent constraints exist.
+    n_grid : int, optional
+        Number of Tc values in the coarse initialization grid (default 40).
+
+    Returns
+    -------
+    dict
+        ``curie_temp`` and ``curie_temp_stderr`` in ``temp_unit``, ``params``
+        with ``M0``, ``h``, ``rss``, ``n_points``, ``fit_range``,
+        ``tc_bounds``, and ``extrapolation`` (True when the highest fitted
+        temperature is below the fitted Tc), and ``diagnostics`` with the
+        fitted data and a dense model curve for plotting.
+    """
+    T = np.asarray(T, dtype=float)
+    M = np.asarray(M, dtype=float)
+
+    finite = np.isfinite(T) & np.isfinite(M)
+    T = T[finite]
+    M = M[finite]
+
+    T_K = convert_temperature(T, temp_unit, "K")
+    if fit_range is not None:
+        fit_mask = (T >= fit_range[0]) & (T <= fit_range[1])
+    else:
+        fit_mask = np.ones(T.size, dtype=bool)
+        fit_range = (float(T.min()), float(T.max())) if T.size else (np.nan, np.nan)
+
+    T_fit = T_K[fit_mask]
+    M_fit = M[fit_mask]
+
+    result = {
+        "curie_temp": np.nan,
+        "curie_temp_stderr": np.nan,
+        "params": {"fit_range": (float(fit_range[0]), float(fit_range[1])),
+                   "n_points": int(T_fit.size)},
+        "diagnostics": {},
+    }
+    if T_fit.size < 5:
+        result["params"]["note"] = "insufficient points for Landau fit"
+        return result
+
+    if tc_bounds is None:
+        tc_bounds = (float(T_fit.min()) + 1.0, 2000.0)
+
+    m_scale = float(np.max(np.abs(M_fit)))
+    if m_scale == 0:
+        result["params"]["note"] = "magnetization is identically zero"
+        return result
+    M_norm = M_fit / m_scale
+
+    h_init = 1e-3
+
+    def coarse_rss(tc):
+        m = landau_magnetization((T_fit - tc) / tc, h_init)
+        denom = float(np.sum(m**2))
+        if denom == 0:
+            return np.inf, 0.0
+        m0 = float(np.sum(m * M_norm)) / denom
+        return float(np.sum((M_norm - m0 * m) ** 2)), m0
+
+    tc_grid = np.linspace(tc_bounds[0], tc_bounds[1], n_grid)
+    grid_results = [coarse_rss(tc) for tc in tc_grid]
+    best_i = int(np.argmin([r[0] for r in grid_results]))
+    tc0 = float(tc_grid[best_i])
+    m00 = max(grid_results[best_i][1], 1e-6)
+
+    def residuals(params):
+        m0, tc, h = params
+        m = landau_magnetization((T_fit - tc) / tc, h)
+        return m0 * m - M_norm
+
+    fit = least_squares(
+        residuals,
+        x0=[m00, tc0, h_init],
+        bounds=([0.0, tc_bounds[0], 0.0], [np.inf, tc_bounds[1], 10.0]),
+    )
+
+    m0, tc_K, h = fit.x
+    n, n_params = T_fit.size, 3
+    rss = 2.0 * fit.cost  # least_squares cost is 0.5 * sum(residuals**2)
+
+    tc_stderr_K = np.nan
+    if n > n_params:
+        try:
+            cov = np.linalg.pinv(fit.jac.T @ fit.jac) * rss / (n - n_params)
+            tc_stderr_K = float(np.sqrt(cov[1, 1]))
+        except np.linalg.LinAlgError:
+            pass
+
+    curie_temp = float(convert_temperature(np.array([tc_K]), "K", temp_unit)[0])
+
+    # dense model curve across the data range, extended past Tc for
+    # extrapolation fits
+    T_dense_K = np.linspace(T_K.min(), max(T_K.max(), tc_K * 1.05), 500)
+    M_dense = m0 * m_scale * landau_magnetization((T_dense_K - tc_K) / tc_K, h)
+
+    result["curie_temp"] = curie_temp
+    result["curie_temp_stderr"] = tc_stderr_K  # kelvin- and celsius-degree intervals are equal
+    result["params"].update({
+        "M0": float(m0 * m_scale),
+        "h": float(h),
+        "rss": float(rss * m_scale**2),
+        "tc_bounds": (float(tc_bounds[0]), float(tc_bounds[1])),
+        "extrapolation": bool(T_fit.max() < tc_K),
+    })
+    result["diagnostics"] = {
+        "T": T,
+        "M": M,
+        "T_fit": convert_temperature(T_fit, "K", temp_unit),
+        "M_fit": M_fit,
+        "model_T": convert_temperature(T_dense_K, "K", temp_unit),
+        "model_M": M_dense,
+    }
+    return result
+
+
+_CURIE_CHI_METHOD_CAVEATS = {
+    "two_tangent": (
+        "two-tangent intersection on susceptibility is not physically "
+        "justified and can considerably overestimate Tc (Petrovsky & "
+        "Kapicka, 2006)"
+    ),
+    "landau": (
+        "the Landau M(T) model does not describe the mechanisms that "
+        "dominate low-field susceptibility near Tc (Fabian et al., 2013); "
+        "treat as qualitative"
+    ),
+}
+
+_CURIE_METHOD_NOTES = {
+    "inflection": (
+        "inflection point (minimum of dy/dT); for in-field M(T) this is the "
+        "Curie temperature (Fabian et al., 2013)"
+    ),
+    "max_curvature": (
+        "maximum of d2y/dT2 (Ade-Hall et al., 1965; legacy ipmag.curie); "
+        "lies systematically above the inflection-point Tc on M(T) curves "
+        "(Fabian et al., 2013)"
+    ),
+    "two_tangent": (
+        "intersecting tangents (Gromme et al., 1969); coincides with the "
+        "max-curvature estimate and overestimates Tc on M(T) (Fabian et "
+        "al., 2013)"
+    ),
+    "inverse_susceptibility": (
+        "Curie-Weiss extrapolation of 1/chi; yields the paramagnetic Curie "
+        "temperature theta >= Tc (Petrovsky & Kapicka, 2006)"
+    ),
+    "landau": (
+        "fit of the in-field Landau equation of state (Fabian et al., 2013); "
+        "Tc at the inflection point, with formal uncertainty"
+    ),
+}
+
+
+def _resolve_thermomag_data_type(data_type, magnetic_column):
+    """
+    Resolve whether a magnetic column holds susceptibility or magnetization.
+
+    Parameters
+    ----------
+    data_type : {'susceptibility', 'magnetization', None}
+        Explicit data type; when None it is inferred from whether
+        ``magnetic_column`` contains 'susc' or 'chi'.
+    magnetic_column : str
+        Name of the magnetic data column.
+
+    Returns
+    -------
+    str
+        'susceptibility' or 'magnetization'.
+    """
+    if data_type is None:
+        column = magnetic_column.lower()
+        return ("susceptibility" if ("susc" in column or "chi" in column)
+                else "magnetization")
+    if data_type not in ("susceptibility", "magnetization"):
+        raise ValueError(
+            f"data_type must be 'susceptibility', 'magnetization', or None "
+            f"(got '{data_type}')"
+        )
+    return data_type
+
+
+def curie_temperature_estimates(
+    experiment,
+    methods=None,
+    temperature_column="meas_temp",
+    magnetic_column="susc_chi_mass",
+    temp_unit="C",
+    input_unit="K",
+    smooth_window=0,
+    remove_holder=True,
+    branches=("heating", "cooling"),
+    method_kwargs=None,
+    print_estimates=False,
+    data_type=None,
+    branch_data=None,
+    return_method_results=False,
+):
+    """
+    Estimate the Curie temperature of a thermomagnetic experiment with
+    multiple methods and return a tidy comparison table.
+
+    The experiment is preprocessed with ``prepare_thermomag_branches`` and
+    each requested method is applied to each requested branch. Systematic
+    differences between the estimates are expected and diagnostic: see the
+    module notes above and Lattard et al. (2006, doi:10.1029/2006JB004591)
+    for the magnitude of inter-method offsets on synthetic titanomagnetites.
+
+    Methods
+    -------
+    * ``'inflection'`` — inflection point (``curie_derivative_estimates``);
+      the recommended estimator for in-field M(T).
+    * ``'max_curvature'`` — second-derivative maximum
+      (``curie_derivative_estimates``); classical, biased high on M(T).
+    * ``'two_tangent'`` — intersecting tangents (``curie_two_tangent``);
+      for M(T), discouraged on susceptibility.
+    * ``'inverse_susceptibility'`` — Curie-Weiss extrapolation
+      (``curie_inverse_susceptibility``); for susceptibility, heating branch.
+    * ``'landau'`` — in-field Landau equation-of-state fit
+      (``curie_landau_fit``); for M(T), supports extrapolation from runs
+      that end below Tc.
+
+    Parameters
+    ----------
+    experiment : pandas.DataFrame
+        MagIC-formatted experiment DataFrame.
+    methods : sequence of str, optional
+        Methods to apply. Default depends on the data type (see
+        ``data_type``): susceptibility data use
+        ``('inflection', 'max_curvature', 'inverse_susceptibility')``;
+        magnetization data use
+        ``('inflection', 'max_curvature', 'two_tangent', 'landau')``.
+    temperature_column : str, optional
+        Name of the temperature column (default 'meas_temp').
+    magnetic_column : str, optional
+        Name of the magnetization/susceptibility column
+        (default 'susc_chi_mass').
+    temp_unit : {'C', 'K'}, optional
+        Unit for reported temperatures (default 'C').
+    input_unit : {'K', 'C'}, optional
+        Unit of the temperatures in ``experiment`` (default 'K', the MagIC
+        convention).
+    smooth_window : float, optional
+        Smoothing window width in ``temp_unit`` (default 0, no smoothing).
+        Derivative-based methods generally require smoothing of noisy data;
+        see ``optimize_moving_average_window``.
+    remove_holder : bool, optional
+        Subtract the per-branch minimum (default True). Disable for runs that
+        end below the Curie temperature.
+    branches : sequence of str, optional
+        Branches to analyze, from ('heating', 'cooling').
+    method_kwargs : dict, optional
+        Per-method keyword arguments, e.g.
+        ``{'inverse_susceptibility': {'fit_range': (620, 700)},
+        'landau': {'fit_range': (300, 650)}}``. The keys ``'inflection'``
+        and ``'max_curvature'`` (or the shared key ``'derivative'``) forward
+        options such as ``t_range`` to ``curie_derivative_estimates``.
+        Unknown keys raise a ValueError rather than being silently ignored.
+    print_estimates : bool, optional
+        Print a one-line summary per estimate (default False).
+    data_type : {'susceptibility', 'magnetization', None}, optional
+        Explicit data type, controlling the default method set and the
+        caveat notes. When None (default), inferred from whether
+        ``magnetic_column`` contains 'susc' or 'chi'.
+    branch_data : dict, optional
+        Precomputed output of ``prepare_thermomag_branches`` (with matching
+        preprocessing arguments). When provided, preprocessing is skipped —
+        used by ``plot_curie_estimates`` to avoid recomputation.
+    return_method_results : bool, optional
+        If True, also return a dict keyed by ``(branch, method)`` holding
+        each estimator's full result (including ``diagnostics``), for
+        plotting or further analysis (default False).
+
+    Returns
+    -------
+    pandas.DataFrame or (pandas.DataFrame, dict)
+        One row per (branch, method) with columns ``specimen``,
+        ``experiment``, ``branch``, ``method``, ``curie_temp``,
+        ``curie_temp_stderr``, ``temp_unit``, ``params`` (dict of
+        method-specific parameters), and ``notes``. With
+        ``return_method_results=True``, additionally the per-(branch,
+        method) result dicts.
+    """
+    if method_kwargs is None:
+        method_kwargs = {}
+
+    data_type = _resolve_thermomag_data_type(data_type, magnetic_column)
+    is_susceptibility = data_type == "susceptibility"
+    if methods is None:
+        if is_susceptibility:
+            methods = ("inflection", "max_curvature", "inverse_susceptibility")
+        else:
+            methods = ("inflection", "max_curvature", "two_tangent", "landau")
+
+    known = {"inflection", "max_curvature", "two_tangent",
+             "inverse_susceptibility", "landau"}
+    unknown = set(methods) - known
+    if unknown:
+        raise ValueError(f"unknown method(s): {sorted(unknown)}; "
+                         f"choose from {sorted(known)}")
+    unknown_kwargs = set(method_kwargs) - known - {"derivative"}
+    if unknown_kwargs:
+        raise ValueError(
+            f"unknown method_kwargs key(s): {sorted(unknown_kwargs)}; "
+            f"choose from {sorted(known | {'derivative'})}"
+        )
+
+    derivative_kwargs = {
+        **method_kwargs.get("derivative", {}),
+        **method_kwargs.get("inflection", {}),
+        **method_kwargs.get("max_curvature", {}),
+    }
+
+    if branch_data is None:
+        branch_data = prepare_thermomag_branches(
+            experiment,
+            temperature_column=temperature_column,
+            magnetic_column=magnetic_column,
+            temp_unit=temp_unit,
+            input_unit=input_unit,
+            smooth_window=smooth_window,
+            remove_holder=remove_holder,
+        )
+
+    specimen = (experiment["specimen"].unique()[0]
+                if "specimen" in experiment else "")
+    experiment_name = (experiment["experiment"].unique()[0]
+                       if "experiment" in experiment else "")
+
+    rows = []
+    method_results = {}
+    for branch in branches:
+        data = branch_data.get(branch)
+        if data is None:
+            continue
+        T, y = data["T"], data["y"]
+
+        derivative_result = None
+        if "inflection" in methods or "max_curvature" in methods:
+            derivative_result = curie_derivative_estimates(
+                T, y, **derivative_kwargs
+            )
+
+        for method in methods:
+            curie_temp = np.nan
+            stderr = np.nan
+            params = {}
+            if method == "inflection":
+                curie_temp = derivative_result["inflection_temp"]
+                params = {"first_derivative_min_temp":
+                          derivative_result["first_derivative_min_temp"]}
+                method_results[(branch, method)] = derivative_result
+            elif method == "max_curvature":
+                curie_temp = derivative_result["max_curvature_temp"]
+                method_results[(branch, method)] = derivative_result
+            elif method == "two_tangent":
+                r = curie_two_tangent(T, y, **method_kwargs.get("two_tangent", {}))
+                curie_temp, params = r["curie_temp"], r["params"]
+                method_results[(branch, method)] = r
+            elif method == "inverse_susceptibility":
+                r = curie_inverse_susceptibility(
+                    T, y, **method_kwargs.get("inverse_susceptibility", {})
+                )
+                curie_temp, stderr, params = (r["curie_temp"],
+                                              r["curie_temp_stderr"],
+                                              r["params"])
+                method_results[(branch, method)] = r
+            elif method == "landau":
+                landau_kwargs = dict(method_kwargs.get("landau", {}))
+                landau_kwargs.setdefault("temp_unit", temp_unit)
+                r = curie_landau_fit(T, y, **landau_kwargs)
+                curie_temp, stderr, params = (r["curie_temp"],
+                                              r["curie_temp_stderr"],
+                                              r["params"])
+                method_results[(branch, method)] = r
+
+            notes = _CURIE_METHOD_NOTES[method]
+            if is_susceptibility and method in _CURIE_CHI_METHOD_CAVEATS:
+                notes = _CURIE_CHI_METHOD_CAVEATS[method]
+
+            rows.append({
+                "specimen": specimen,
+                "experiment": experiment_name,
+                "branch": branch,
+                "method": method,
+                "curie_temp": curie_temp,
+                "curie_temp_stderr": stderr,
+                "temp_unit": temp_unit,
+                "params": params,
+                "notes": notes,
+            })
+            if print_estimates and np.isfinite(curie_temp):
+                stderr_text = (f" ± {stderr:.1f}" if np.isfinite(stderr) else "")
+                print(f"{branch:<8} {method:<24} "
+                      f"Tc = {curie_temp:.1f}{stderr_text} °{temp_unit}")
+
+    estimates = pd.DataFrame(rows, columns=[
+        "specimen", "experiment", "branch", "method", "curie_temp",
+        "curie_temp_stderr", "temp_unit", "params", "notes",
+    ])
+    if return_method_results:
+        return estimates, method_results
+    return estimates
+
+
+# Okabe & Ito (2008) colorblind-safe colors used to distinguish Curie
+# temperature estimation methods in plots
+_CURIE_METHOD_COLORS = {
+    "inflection": "#0072B2",             # blue
+    "max_curvature": "#E69F00",          # orange
+    "two_tangent": "#009E73",            # green
+    "inverse_susceptibility": "#D55E00", # vermillion
+    "landau": "#CC79A7",                 # purple
+}
+
+
+def plot_curie_estimates(
+    experiment,
+    methods=None,
+    temperature_column="meas_temp",
+    magnetic_column="susc_chi_mass",
+    temp_unit="C",
+    input_unit="K",
+    smooth_window=0,
+    remove_holder=True,
+    branches=("heating", "cooling"),
+    method_kwargs=None,
+    figsize=(10, 10),
+    return_figure=False,
+    save_path=None,
+    data_type=None,
+):
+    """
+    Plot a thermomagnetic curve with Curie temperature estimates from
+    multiple methods overlain.
+
+    Produces a static matplotlib figure with up to three stacked panels:
+    (a) the (holder-corrected) curve per branch with a vertical line at each
+    method's estimate, the two-tangent construction, and the Landau model
+    curve where those methods are requested; (b) the first and second
+    derivatives with the inflection point and curvature maximum marked; and
+    (c) 1/chi with the Curie-Weiss fit when ``'inverse_susceptibility'`` is
+    requested. Method colors follow the colorblind-safe palette of Okabe &
+    Ito (2008); heating estimates are drawn with solid lines and cooling
+    estimates with dashed lines.
+
+    Parameters mirror ``curie_temperature_estimates``; see that function for
+    the estimation details and method caveats.
+
+    Parameters
+    ----------
+    experiment : pandas.DataFrame
+        MagIC-formatted experiment DataFrame.
+    methods : sequence of str, optional
+        Methods to display (default as in ``curie_temperature_estimates``).
+    temperature_column, magnetic_column, temp_unit, input_unit,
+    smooth_window, remove_holder, branches, method_kwargs, data_type :
+        As in ``curie_temperature_estimates``.
+    figsize : tuple, optional
+        Figure size in inches (default (10, 10)).
+    return_figure : bool, optional
+        If True, return ``(fig, axes)`` (default False).
+    save_path : str, optional
+        If given, save the figure to this path.
+
+    Returns
+    -------
+    (matplotlib.figure.Figure, numpy.ndarray of Axes) or None
+    """
+    if method_kwargs is None:
+        method_kwargs = {}
+
+    data_type = _resolve_thermomag_data_type(data_type, magnetic_column)
+    is_susceptibility = data_type == "susceptibility"
+    if methods is None:
+        if is_susceptibility:
+            methods = ("inflection", "max_curvature", "inverse_susceptibility")
+        else:
+            methods = ("inflection", "max_curvature", "two_tangent", "landau")
+
+    branch_data = prepare_thermomag_branches(
+        experiment,
+        temperature_column=temperature_column,
+        magnetic_column=magnetic_column,
+        temp_unit=temp_unit,
+        input_unit=input_unit,
+        smooth_window=smooth_window,
+        remove_holder=remove_holder,
+    )
+    # single computation: the estimators run once here and both the tidy
+    # table and the plotted constructions come from the same results
+    estimates, method_results = curie_temperature_estimates(
+        experiment,
+        methods=methods,
+        temperature_column=temperature_column,
+        magnetic_column=magnetic_column,
+        temp_unit=temp_unit,
+        input_unit=input_unit,
+        smooth_window=smooth_window,
+        remove_holder=remove_holder,
+        branches=branches,
+        method_kwargs=method_kwargs,
+        data_type=data_type,
+        branch_data=branch_data,
+        return_method_results=True,
+    )
+
+    want_derivative_panel = ("inflection" in methods
+                             or "max_curvature" in methods)
+    want_inverse_panel = "inverse_susceptibility" in methods
+    n_panels = 1 + int(want_derivative_panel) + int(want_inverse_panel)
+
+    fig, axes = plt.subplots(n_panels, 1, figsize=figsize, sharex=True)
+    axes = np.atleast_1d(axes)
+    ax_main = axes[0]
+    ax_deriv = axes[1] if want_derivative_panel else None
+    ax_inv = axes[-1] if want_inverse_panel else None
+
+    branch_styles = {
+        "heating": {"data_color": "#bbbbbb", "line_color": "#333333",
+                    "linestyle": "-", "label": "heating"},
+        "cooling": {"data_color": "#dddddd", "line_color": "#888888",
+                    "linestyle": "--", "label": "cooling"},
+    }
+    y_label = ("χ (m³ kg⁻¹)" if is_susceptibility else "M (Am² kg⁻¹)")
+
+    for branch in branches:
+        data = branch_data.get(branch)
+        if data is None:
+            continue
+        style = branch_styles[branch]
+        T, y = data["T"], data["y"]
+
+        ax_main.scatter(data["raw_T"], data["raw_y"], s=8,
+                        color=style["data_color"], zorder=1)
+        ax_main.plot(T, y, color=style["line_color"],
+                     linestyle=style["linestyle"], linewidth=1.5,
+                     label=style["label"], zorder=2)
+
+        # per-method annotations
+        branch_estimates = estimates[estimates["branch"] == branch]
+        for _, row in branch_estimates.iterrows():
+            if not np.isfinite(row["curie_temp"]):
+                continue
+            ax_main.axvline(
+                row["curie_temp"],
+                color=_CURIE_METHOD_COLORS[row["method"]],
+                linestyle=style["linestyle"], linewidth=1.2, alpha=0.9,
+                label=f"{row['method']} ({branch}): "
+                      f"{row['curie_temp']:.0f} °{temp_unit}",
+                zorder=3,
+            )
+
+        two_tangent_result = method_results.get((branch, "two_tangent"))
+        if two_tangent_result is not None and np.isfinite(
+                two_tangent_result["curie_temp"]):
+            p = two_tangent_result["params"]
+            curie_temp = two_tangent_result["curie_temp"]
+            T_lower = np.array([p["lower_range"][0], curie_temp])
+            T_upper = np.array([curie_temp, T.max()])
+            ax_main.plot(
+                T_lower, p["lower_slope"] * T_lower + p["lower_intercept"],
+                color=_CURIE_METHOD_COLORS["two_tangent"],
+                linestyle=":", linewidth=1.2, zorder=3,
+            )
+            ax_main.plot(
+                T_upper, p["upper_slope"] * T_upper + p["upper_intercept"],
+                color=_CURIE_METHOD_COLORS["two_tangent"],
+                linestyle=":", linewidth=1.2, zorder=3,
+            )
+
+        landau_result = method_results.get((branch, "landau"))
+        if landau_result is not None and np.isfinite(
+                landau_result["curie_temp"]):
+            d = landau_result["diagnostics"]
+            ax_main.plot(
+                d["model_T"], d["model_M"],
+                color=_CURIE_METHOD_COLORS["landau"],
+                linestyle="-", linewidth=1.2, alpha=0.9, zorder=3,
+            )
+
+        derivative_result = (method_results.get((branch, "inflection"))
+                             or method_results.get((branch, "max_curvature")))
+        if ax_deriv is not None and derivative_result is not None:
+            r = derivative_result
+            d = r["diagnostics"]
+            if d["dy_dT"].size:
+                ax_deriv.plot(d["T"], d["dy_dT"],
+                              color=style["line_color"],
+                              linestyle=style["linestyle"], linewidth=1.2,
+                              label=f"dy/dT ({branch})")
+                if "inflection" in methods and np.isfinite(r["inflection_temp"]):
+                    ax_deriv.axvline(r["inflection_temp"],
+                                     color=_CURIE_METHOD_COLORS["inflection"],
+                                     linestyle=style["linestyle"],
+                                     linewidth=1.0, alpha=0.9)
+                if ("max_curvature" in methods
+                        and np.isfinite(r["max_curvature_temp"])):
+                    ax_deriv.axvline(r["max_curvature_temp"],
+                                     color=_CURIE_METHOD_COLORS["max_curvature"],
+                                     linestyle=style["linestyle"],
+                                     linewidth=1.0, alpha=0.9)
+
+        inverse_result = method_results.get((branch, "inverse_susceptibility"))
+        if ax_inv is not None and branch == "heating" and inverse_result is not None:
+            r = inverse_result
+            d = r["diagnostics"]
+            if d:
+                ax_inv.plot(d["T"], d["inv_chi"], color=style["line_color"],
+                            linestyle="none", marker="o", markersize=3,
+                            label="1/χ (heating)")
+                if np.isfinite(r["curie_temp"]):
+                    ax_inv.plot(
+                        d["line_T"], d["line_inv_chi"],
+                        color=_CURIE_METHOD_COLORS["inverse_susceptibility"],
+                        linewidth=1.2,
+                        label=f"Curie-Weiss fit: θ = "
+                              f"{r['curie_temp']:.0f} °{temp_unit}",
+                    )
+                    ax_inv.axvline(
+                        r["curie_temp"],
+                        color=_CURIE_METHOD_COLORS["inverse_susceptibility"],
+                        linestyle="-", linewidth=1.0, alpha=0.9,
+                    )
+                ax_inv.set_ylabel("1/χ")
+                ax_inv.legend(fontsize=8, loc="upper left")
+
+    title = (experiment["specimen"].unique()[0]
+             if "specimen" in experiment else "")
+    ax_main.set_title(title)
+    ax_main.set_ylabel(y_label)
+    ax_main.legend(fontsize=8, loc="upper right")
+    if ax_deriv is not None:
+        ax_deriv.set_ylabel("dy/dT")
+        ax_deriv.legend(fontsize=8, loc="lower left")
+    axes[-1].set_xlabel(f"Temperature (°{temp_unit})")
+    for ax in axes:
+        ax.grid(True, alpha=0.4)
+
+    fig.tight_layout()
+    if save_path is not None:
+        fig.savefig(save_path, dpi=300, bbox_inches="tight")
+    if return_figure:
+        return fig, axes
+    plt.show()
+    return None
+
+
+def interactive_curie_inverse_susceptibility(
     experiment,
     temperature_column="meas_temp",
     magnetic_column="susc_chi_mass",
     temp_unit="C",
+    input_unit="K",
     smooth_window=0,
     remove_holder=True,
+    branch="heating",
+    initial_fit_range=None,
     figsize=(6, 6),
-    inverse_method=False,
-    print_estimates=True
 ):
     """
-    Estimate the Curie temperature from high temperature susceptibility curves in multiple ways. Automatically calculates first derivative minimum, second derivative maximum, and
-    second derivative zero-crossing. Also has option to estimate Curie temperature from inverse susceptibility (E. Petrovsky and A. Kapicka, 2006). Uses Bokeh for the interactive plot.
+    Interactive (Bokeh) Curie-Weiss fit to inverse susceptibility.
 
-    Parameters:
-        experiment (pandas.DataFrame): MagIC-formatted experiment DataFrame.
-        temperature_column (str): Name of temperature column.
-        magnetic_column (str): Name of susceptibility column.
-        temp_unit (str): "C" for Celsius.
-        smooth_window (int): Window for smoothing, if 0, no smoothing is applied.
-        remove_holder (bool): Subtracts holder signal to better isolate specimen signal.
-        figsize (tuple): (width, height) in inches.
-        inverse_method (bool): Use inverse susceptibility method.
-        print_estimates (bool): Print estimated Curie temperatures.
-    
-    Returns
-    -------
+    Displays 1/chi versus temperature with a two-point fit line whose
+    endpoints can be dragged (Bokeh ``PointDrawTool``); the extrapolated
+    temperature where 1/chi reaches zero — the paramagnetic Curie temperature
+    theta (Petrovsky & Kapicka, 2006, doi:10.1029/2006JB004507) — updates
+    live below the plot.
 
-    temp_of_first_derivative_min_heating : float
-        temperature of first derivative minimum for heating cycle
-    temp_of_first_derivative_min_cooling : float
-        temperature of first derivative minimum for cooling cycle
-    temp_of_second_derivative_max_heating : float
-        temperature of second derivative maximum for heating cycle
-    temp_of_second_derivative_max_cooling : float
-        temperature of second derivative maximum for cooling cycle
-    heating_zero : list of float or None
-        temperatures of second derivative zero-crossings for heating cycle, or None if none found
-    cooling_zero : list of float or None
-        temperatures of second derivative zero-crossings for cooling cycle, or None if none found
+    This tool is for exploration: it helps identify the temperature interval
+    over which 1/chi is linear (fully paramagnetic). For reported values, use
+    ``curie_inverse_susceptibility`` with the ``fit_range`` identified here,
+    so that the fit is reproducible.
+
+    Parameters
+    ----------
+    experiment : pandas.DataFrame
+        MagIC-formatted experiment DataFrame.
+    temperature_column, magnetic_column, temp_unit, input_unit,
+    smooth_window, remove_holder :
+        As in ``curie_temperature_estimates``.
+    branch : {'heating', 'cooling'}, optional
+        Branch to display (default 'heating').
+    initial_fit_range : tuple of (float, float), optional
+        Initial temperatures (in ``temp_unit``) for the two fit-line
+        endpoints. Defaults to 70 percent and 100 percent of the branch's
+        temperature range — a starting position only, meant to be dragged.
+    figsize : tuple, optional
+        (width, height) in inches; height sets the Bokeh plot height.
     """
+    _check_bokeh()
 
-    warm_T, warm_X, cool_T, cool_X = split_warm_cool(
+    branch_data = prepare_thermomag_branches(
         experiment,
         temperature_column=temperature_column,
-        magnetic_column=magnetic_column
+        magnetic_column=magnetic_column,
+        temp_unit=temp_unit,
+        input_unit=input_unit,
+        smooth_window=smooth_window,
+        remove_holder=remove_holder,
     )
+    data = branch_data.get(branch)
+    if data is None:
+        raise ValueError(f"no {branch} data in this experiment")
 
-    if temp_unit == "C":
-        warm_T = [T - 273.15 for T in warm_T]
-        cool_T = [T - 273.15 for T in cool_T]
+    T_all, chi = data["T"], data["y"]
+    inv_chi = _inverse_susceptibility(chi)
+    mask = np.isfinite(inv_chi)
+    T = T_all[mask]
+    inv_chi = inv_chi[mask]
+    if T.size < 2:
+        raise ValueError("not enough usable points for the 1/chi plot")
+
+    if initial_fit_range is None:
+        i0 = int(T.size * 0.7)
+        i1 = T.size - 1
     else:
-        raise ValueError('temp_unit must be "C"')
+        i0 = int(np.argmin(np.abs(T - initial_fit_range[0])))
+        i1 = int(np.argmin(np.abs(T - initial_fit_range[1])))
+    if i0 == i1:
+        i0 = max(i1 - 1, 0)
 
-    if remove_holder:
-        holder_w = min(warm_X)
-        holder_c = min(cool_X)
-        warm_X = [X - holder_w for X in warm_X]
-        cool_X = [X - holder_c for X in cool_X]
-
-    swT, swX = smooth_moving_avg(warm_T, warm_X, smooth_window)
-    scT, scX = smooth_moving_avg(cool_T, cool_X, smooth_window)
-
-    dx_w = np.gradient(swX, swT)
-    dx_c = np.gradient(scX, scT)
-
-    temp_of_first_derivative_min_heating = swT[np.argmin(dx_w)]
-    temp_of_first_derivative_min_cooling = scT[np.argmin(dx_c)]
-
-    dx_2_w = np.gradient(dx_w, swT)
-    dx_2_c = np.gradient(dx_c, scT)
-
-    temp_of_second_derivative_max_heating = swT[np.argmax(dx_2_w)]
-    temp_of_second_derivative_max_cooling = scT[np.argmax(dx_2_c)]
-
-    # Physically consistent zero-crossing logic for heating
-    min_idx_w = np.argmin(dx_2_w)
-    max_idx_w = np.argmax(dx_2_w)
-    lower_w, upper_w = sorted([min_idx_w, max_idx_w])
-    dx2_slice_w = dx_2_w[lower_w:upper_w]
-    temp_slice_w = swT[lower_w:upper_w]
-    crossings_w = np.where(np.diff(np.sign(dx2_slice_w)))[0]
-    temp_of_zero_crossing_heating = [temp_slice_w[i] for i in crossings_w]
-
-    # Physically consistent zero-crossing logic for cooling
-    min_idx_c = np.argmin(dx_2_c)
-    max_idx_c = np.argmax(dx_2_c)
-    lower_c, upper_c = sorted([min_idx_c, max_idx_c])
-    dx2_slice_c = dx_2_c[lower_c:upper_c]
-    temp_slice_c = scT[lower_c:upper_c]
-    crossings_c = np.where(np.diff(np.sign(dx2_slice_c)))[0]
-    temp_of_zero_crossing_cooling = [temp_slice_c[i] for i in crossings_c]
-
-    if inverse_method:
-        _check_bokeh()
-        bokeh_height = int(figsize[1] * 96)
-        title = experiment["specimen"].unique()[0]
-        swX_arr = np.array(swX)
-        inv_w = np.divide(1.0, swX_arr, out=np.full_like(swX_arr, np.nan), where=swX_arr != 0.0)
-        mask_w = np.isfinite(inv_w)
-        T = np.array(swT)[mask_w]
-        inv_chi = inv_w[mask_w]
-
-        # Creates initial fit endpoints (choose two points in the linear region)
-        # 0.7 is Magic Number which places initial fit near expected linear region
-        fit_x = [T[int(len(T)*0.7)], T[-1]]
-        fit_y = [inv_chi[int(len(inv_chi)*0.7)], inv_chi[-1]]
-        fit_source = ColumnDataSource(data=dict(x=fit_x, y=fit_y))
-        # scatter and line for data
-        data_source = ColumnDataSource(data=dict(x=T, y=inv_chi))
-        p_inv = figure(title=f"{title} – 1/χ",
-                       height=bokeh_height,
-                       x_axis_label=f"Temperature (°{temp_unit})",
-                       y_axis_label="1/χ",
-                       tools="pan,wheel_zoom,box_zoom,reset,save",
-                      )
-        p_inv.scatter('x', 'y', source=data_source, size=8, color="red", legend_label="Heating – 1/χ")
-        renderer = p_inv.scatter('x', 'y', source=fit_source, size=12, color="blue", legend_label="Fit Endpoints")
-        p_inv.line('x', 'y', source=fit_source, line_width=2, color="blue", legend_label="Fit Line")
-        # PointDrawTool for dragging endpoints
-        draw_tool = PointDrawTool(renderers=[renderer], add=False)
-        p_inv.add_tools(draw_tool)
-        p_inv.toolbar.active_tap = draw_tool
-        p_inv.legend.location = "top_left"   
-        # Div to display Curie temperature
-        curie_estimate = Div(text="Curie temperature: --", styles={'font-size': '16px', 'color': 'darkred'})  
-        # JS callback to update fit line and Curie temperature estimate
-        callback = CustomJS(args=dict(source=fit_source, div=curie_estimate), code="""
-            var x = source.data.x;
-            var y = source.data.y;
-            if (x.length == 2) {
-                var slope = (y[1] - y[0]) / (x[1] - x[0]);
-                var intercept = y[0] - slope * x[0];
-                // Estimate Curie temperature: x where y=0
-                var Tc = -intercept / slope;
-                div.text = "Curie temperature estimate: " + Tc.toFixed(2) + " °C";
-            }
-        """)
-        fit_source.js_on_change('data', callback)       
-        show(column(p_inv, curie_estimate))
-
-    if print_estimates:
-        print(f'First derivative minimum is at T={int(temp_of_first_derivative_min_heating)} for heating')
-        print(f'First derivative minimum is at T={int(temp_of_first_derivative_min_cooling)} for cooling')
-        print(f'Second derivative maximum is at T={int(temp_of_second_derivative_max_heating)} for heating')
-        print(f'Second derivative maximum is at T={int(temp_of_second_derivative_max_cooling)} for cooling')
-        if temp_of_zero_crossing_heating:  
-            print(f'The second derivative of the heating curve crosses zero at T = {int(temp_of_zero_crossing_heating[0])}')  
-        else:  
-            print('No zero crossing found for the second derivative of the heating curve.')  
-        if temp_of_zero_crossing_cooling:  
-            print(f'The second derivative of the cooling curve crosses zero at T = {int(temp_of_zero_crossing_cooling[0])}')  
-        else:
-            print('No zero crossing found for the second derivative of the cooling curve.')
-
-    heating_zero = temp_of_zero_crossing_heating[0] if temp_of_zero_crossing_heating else None
-    cooling_zero = temp_of_zero_crossing_cooling[0] if temp_of_zero_crossing_cooling else None
-
-    return (
-        temp_of_first_derivative_min_heating,
-        temp_of_first_derivative_min_cooling,
-        temp_of_second_derivative_max_heating,
-        temp_of_second_derivative_max_cooling,
-        heating_zero,
-        cooling_zero
+    fit_source = ColumnDataSource(
+        data=dict(x=[T[i0], T[i1]], y=[inv_chi[i0], inv_chi[i1]])
     )
+    data_source = ColumnDataSource(data=dict(x=T, y=inv_chi))
+
+    title = (experiment["specimen"].unique()[0]
+             if "specimen" in experiment else "")
+    bokeh_height = int(figsize[1] * 96)
+    p_inv = figure(
+        title=f"{title} – 1/χ ({branch})",
+        height=bokeh_height,
+        x_axis_label=f"Temperature (°{temp_unit})",
+        y_axis_label="1/χ",
+        tools="pan,wheel_zoom,box_zoom,reset,save",
+    )
+    p_inv.scatter("x", "y", source=data_source, size=8, color="red",
+                  legend_label=f"{branch} – 1/χ")
+    renderer = p_inv.scatter("x", "y", source=fit_source, size=12,
+                             color="blue", legend_label="Fit endpoints")
+    p_inv.line("x", "y", source=fit_source, line_width=2, color="blue",
+               legend_label="Fit line")
+    draw_tool = PointDrawTool(renderers=[renderer], add=False)
+    p_inv.add_tools(draw_tool)
+    p_inv.toolbar.active_tap = draw_tool
+    p_inv.legend.location = "top_left"
+
+    curie_estimate = Div(
+        text="Curie temperature: --",
+        styles={"font-size": "16px", "color": "darkred"},
+    )
+    callback = CustomJS(args=dict(source=fit_source, div=curie_estimate,
+                                  unit=temp_unit), code="""
+        var x = source.data.x;
+        var y = source.data.y;
+        if (x.length == 2) {
+            var slope = (y[1] - y[0]) / (x[1] - x[0]);
+            var intercept = y[0] - slope * x[0];
+            var Tc = -intercept / slope;
+            div.text = "Curie temperature estimate: " + Tc.toFixed(2) +
+                       " °" + unit;
+        }
+    """)
+    fit_source.js_on_change("data", callback)
+    show(column(p_inv, curie_estimate))
+
+
+def add_curie_estimates_to_specimens_table(
+    specimens_df,
+    experiment_name,
+    estimates,
+    method="inflection",
+    branch="heating",
+    critical_temp_type="Curie",
+):
+    """
+    Write a Curie temperature estimate to a MagIC specimens table.
+
+    Sets ``critical_temp`` (in Kelvin, per the MagIC data model) and
+    ``critical_temp_type`` (controlled vocabulary; 'Curie' by default) for
+    the rows whose ``experiments`` column matches ``experiment_name``, and
+    records the estimation method, branch, and uncertainty in the
+    ``description`` column so the processing choice is archived with the
+    result. Updates ``specimens_df`` in place.
+
+    Parameters
+    ----------
+    specimens_df : pandas.DataFrame
+        MagIC specimens table (with an 'experiments' column).
+    experiment_name : str
+        Experiment the estimate belongs to.
+    estimates : pandas.DataFrame
+        Tidy table from ``curie_temperature_estimates``.
+    method : str, optional
+        Which method's estimate to write (default 'inflection').
+    branch : str, optional
+        Which branch's estimate to write (default 'heating').
+    critical_temp_type : str, optional
+        MagIC controlled-vocabulary temperature type (default 'Curie').
+    """
+    import ast
+
+    selection = estimates[(estimates["method"] == method)
+                          & (estimates["branch"] == branch)]
+    if selection.empty:
+        raise ValueError(
+            f"no estimate with method='{method}' and branch='{branch}' "
+            f"in the estimates table"
+        )
+    row = selection.iloc[0]
+    if not np.isfinite(row["curie_temp"]):
+        raise ValueError(
+            f"the {method}/{branch} estimate is NaN; nothing to write"
+        )
+
+    curie_temp_K = float(
+        convert_temperature(np.array([row["curie_temp"]]),
+                            row["temp_unit"], "K")[0]
+    )
+
+    if "critical_temp" not in specimens_df.columns:
+        specimens_df["critical_temp"] = np.nan
+    for column_name in ("critical_temp_type", "description"):
+        if column_name not in specimens_df.columns:
+            specimens_df[column_name] = pd.Series(
+                [None] * len(specimens_df), dtype=object
+            )
+        elif specimens_df[column_name].dtype != object:
+            specimens_df[column_name] = specimens_df[column_name].astype(object)
+
+    # match on the experiments column (which may hold colon-delimited lists
+    # of experiment names in real contributions), falling back to the
+    # specimen name recorded in the estimates table; exact/token matching is
+    # used rather than substring matching so that an experiment name cannot
+    # match a longer sibling name (e.g., '...-MST-1' matching '...-MST-10')
+    experiments_column = specimens_df["experiments"].astype(str)
+    target = experiments_column == experiment_name
+    if not target.any():
+        target = experiments_column.apply(
+            lambda cell: experiment_name in cell.split(":")
+        )
+    if not target.any() and row["specimen"]:
+        target = specimens_df["specimen"] == row["specimen"]
+    if not target.any():
+        raise ValueError(
+            f"experiment '{experiment_name}' (and specimen "
+            f"'{row['specimen']}') not found in the specimens table"
+        )
+    specimens_df.loc[target, "critical_temp"] = curie_temp_K
+    specimens_df.loc[target, "critical_temp_type"] = critical_temp_type
+
+    curie_description = {
+        "curie_method": method,
+        "curie_branch": branch,
+        "curie_temp_K": round(curie_temp_K, 2),
+    }
+    if np.isfinite(row["curie_temp_stderr"]):
+        curie_description["curie_temp_stderr"] = round(
+            float(row["curie_temp_stderr"]), 2
+        )
+
+    # merge with any existing description without destroying it: a dict
+    # literal is updated in place, while free text is preserved and the
+    # Curie results appended after it
+    existing = specimens_df.loc[target, "description"].iloc[0]
+    prefix = ""
+    description_dict = {}
+    if isinstance(existing, str) and existing.strip():
+        try:
+            parsed = ast.literal_eval(existing)
+            if isinstance(parsed, dict):
+                description_dict = parsed
+            else:
+                prefix = existing.strip()
+        except (ValueError, SyntaxError):
+            prefix = existing.strip()
+    description_dict.update(curie_description)
+    new_description = str(description_dict)
+    if prefix:
+        new_description = f"{prefix}; {new_description}"
+    specimens_df.loc[target, "description"] = new_description
+    return
+
 
 def smooth_moving_avg(
     x,
@@ -4518,6 +5932,11 @@ def smooth_moving_avg(
             else:
                 w = getattr(np, window_type)(m)
             wsum = w.sum()
+            if wsum <= 0:
+                # window functions like hanning are identically zero for
+                # m <= 2; fall back to a flat window
+                w = np.ones(m)
+                wsum = float(m)
             mean_x = (w * xx).sum() / wsum
             mean_y = (w * yy).sum() / wsum
             if return_variance:
@@ -4566,7 +5985,7 @@ def X_T_running_average(temp_list, chi_list, temp_window):
     chi_vars : List[float]
         The variance of susceptibility values in each window.
     """
-    if not temp_list or not chi_list or temp_window <= 0:
+    if len(temp_list) == 0 or len(chi_list) == 0 or temp_window <= 0:
         return temp_list, chi_list, [], []
     
     avg_temps = []
@@ -5197,14 +6616,14 @@ def plot_backfield_unmixing_result(experiment, result, sigma=2, figsize=(8,6), n
                     [max(best_fit_interp[j]-dely_interp[j],0) for j in range(len(best_fit_interp))],
                     best_fit_interp+dely_interp,
                     color="#8A8A8A", 
-                    label=f'total {sigma}-$\sigma$ band', alpha=0.5)
+                    label=f'total {sigma}-$\\sigma$ band', alpha=0.5)
     if len(result.components) > 1:
         for i in range(len(result.components)):
             this_comp_interp = result.eval_components(x=x_interp)[f'g{i+1}_'] * np.max(raw_derivatives_y)
             this_dely = result.dely_comps[f'g{i+1}_'] * np.max(raw_derivatives_y)
             # impose bounds on the dely to be smaller than the best fit for the component
             this_dely = [min(this_dely[j], this_comp_interp[j]) for j in range(len(this_dely))]
-            ax.plot(x_interp, this_comp_interp, c=f'C{i}', label=f'component #{i+1}, {sigma}-$\sigma$ band')
+            ax.plot(x_interp, this_comp_interp, c=f'C{i}', label=f'component #{i+1}, {sigma}-$\\sigma$ band')
             lower_bound = [max(this_comp_interp[j]-this_dely[j],0) for j in range(len(this_comp_interp))]
             upper_bound = this_comp_interp+this_dely
             ax.fill_between(x_interp,

--- a/pmagpy/test/test_rockmag_curie.py
+++ b/pmagpy/test/test_rockmag_curie.py
@@ -228,6 +228,31 @@ class TestCurieDerivativeEstimates:
                                                  t_range=(400, 700))
         assert result["inflection_temp"] == pytest.approx(580.0, abs=5.0)
 
+    def test_tail_noise_does_not_capture_estimate(self, landau_heating_C):
+        # noise confined to the flat tails must not drag the derivative
+        # estimates off the field-rounded transition; both estimates are
+        # anchored to the steepest descent, which the tails do not move
+        T, M = landau_heating_C
+        rng = np.random.RandomState(1)
+        noise = np.zeros_like(M)
+        # the transition sits at 580 C; keep the noise in the flat tails and
+        # below the transition slope so the steepest descent still finds the
+        # transition (the estimates must follow it, not the tail structure)
+        tail = (T < 430) | (T > 660)
+        noise[tail] = rng.normal(0.0, 0.002, int(tail.sum()))
+        result = rmag.curie_derivative_estimates(T, M + noise)
+        assert result["inflection_temp"] == pytest.approx(580.0, abs=3.0)
+        assert result["max_curvature_temp"] > result["inflection_temp"]
+        assert result["max_curvature_temp"] - 580.0 < 25.0
+
+    def test_non_finite_values_dropped(self, landau_heating_C):
+        # a single NaN must not become the steepest-descent point
+        T, M = landau_heating_C
+        M_nan = M.copy()
+        M_nan[5] = np.nan
+        result = rmag.curie_derivative_estimates(T, M_nan)
+        assert result["inflection_temp"] == pytest.approx(580.0, abs=2.0)
+
 
 class TestCurieTwoTangent:
     def test_recovers_transition_on_landau_curve(self, landau_heating_C):

--- a/pmagpy/test/test_rockmag_curie.py
+++ b/pmagpy/test/test_rockmag_curie.py
@@ -124,6 +124,33 @@ class TestSplitWarmCool:
         assert warm_T.size == 2
         assert np.all(np.isfinite(warm_X))
 
+    def test_duplicate_heating_temperatures_no_phantom_cooling(self):
+        # repeated furnace-stabilization temperatures on a heating-only run
+        # must stay on the heating branch, not seed a spurious cooling branch
+        T = np.repeat(np.arange(300.0, 901.0, 50.0), 2)
+        df = pd.DataFrame({
+            "meas_temp": T,
+            "magn_mass": np.linspace(1.0, 0.1, T.size),
+        })
+        warm_T, _, cool_T, _ = rmag.split_warm_cool(
+            df, magnetic_column="magn_mass"
+        )
+        assert cool_T.size == 0
+        assert warm_T.size == T.size
+
+    def test_noisy_heating_temperatures_no_phantom_cooling(self):
+        # temperature read-noise larger than the step must not scatter heating
+        # points into the cooling branch
+        rng = np.random.RandomState(0)
+        base = np.arange(300.0, 900.0, 3.0)
+        T = base + rng.normal(0.0, 3.0, base.size)
+        df = pd.DataFrame({
+            "meas_temp": T,
+            "magn_mass": np.linspace(1.0, 0.1, T.size),
+        })
+        _, _, cool_T, _ = rmag.split_warm_cool(df, magnetic_column="magn_mass")
+        assert cool_T.size == 0
+
 
 class TestPrepareThermomagBranches:
     def test_branches_ascending_and_holder_removed(self, heat_cool_experiment):
@@ -142,6 +169,15 @@ class TestPrepareThermomagBranches:
         branches = rmag.prepare_thermomag_branches(df)
         assert branches["cooling"] is None
         assert branches["heating"]["T"].size == 50
+
+    def test_duplicate_heating_temperatures_returns_none_cooling(self):
+        # furnace-stabilization duplicates on a heating-only run must not
+        # produce a phantom cooling branch downstream of split_warm_cool
+        T = np.repeat(np.arange(300.0, 901.0, 50.0), 2)
+        df = pd.DataFrame({"meas_temp": T, "susc_chi_mass": np.exp(-T / 300)})
+        branches = rmag.prepare_thermomag_branches(df)
+        assert branches["cooling"] is None
+        assert branches["heating"] is not None
 
     def test_temperature_units(self, heat_cool_experiment):
         branches_C = rmag.prepare_thermomag_branches(

--- a/pmagpy/test/test_rockmag_curie.py
+++ b/pmagpy/test/test_rockmag_curie.py
@@ -484,6 +484,91 @@ class TestCurieLandauFit:
         assert reported == pytest.approx(np.std(recovered), rel=0.4)
 
 
+class TestCurieMsSquaredExtrapolation:
+    def test_exact_recovery_of_tc(self):
+        # Js proportional to (Tc - T)^(1/2), so Js**2 is exactly linear in T
+        # and extrapolates to Js**2 = 0 at Tc (Moskowitz, 1981, eqs. 4-5)
+        Tc = 580.0
+        T = np.linspace(480.0, 575.0, 40)
+        M = np.sqrt(Tc - T)
+        r = rmag.curie_ms_squared_extrapolation(T, M, fit_range=(480, 575))
+        assert r["curie_temp"] == pytest.approx(580.0, abs=0.5)
+        assert r["params"]["r_squared"] == pytest.approx(1.0, abs=1e-8)
+        assert r["params"]["slope"] < 0
+        assert r["params"]["exponent"] == 2.0
+        assert np.isfinite(r["curie_temp_stderr"])
+
+    def test_exponent_two_is_exact_others_biased(self):
+        # exponent 2 (beta = 1/2) is exact for a mean-field curve; a different
+        # exponent introduces curvature that moves the extrapolation off Tc
+        Tc = 580.0
+        T = np.linspace(480.0, 575.0, 40)
+        M = np.sqrt(Tc - T)
+        two = rmag.curie_ms_squared_extrapolation(
+            T, M, fit_range=(480, 575), exponent=2.0)
+        other = rmag.curie_ms_squared_extrapolation(
+            T, M, fit_range=(480, 575), exponent=1.5)
+        assert two["curie_temp"] == pytest.approx(580.0, abs=0.5)
+        assert (abs(other["curie_temp"] - 580.0)
+                > abs(two["curie_temp"] - 580.0) + 5.0)
+        assert other["params"]["exponent"] == 1.5
+
+    def test_stderr_matches_monte_carlo(self):
+        # 1-sigma on Tc from the fit covariance must match the spread under
+        # noise (same delta-method/covariance propagation as Curie-Weiss)
+        Tc = 580.0
+        T = np.linspace(480.0, 575.0, 40)
+        M0 = np.sqrt(Tc - T)
+        sigma = 0.02
+        rng = np.random.default_rng(7)
+        reported = rmag.curie_ms_squared_extrapolation(
+            T, np.clip(M0 + rng.normal(0, sigma, T.size), 1e-6, None),
+            fit_range=(480, 575))["curie_temp_stderr"]
+        recovered = [
+            rmag.curie_ms_squared_extrapolation(
+                T, np.clip(M0 + rng.normal(0, sigma, T.size), 1e-6, None),
+                fit_range=(480, 575))["curie_temp"]
+            for _ in range(1000)
+        ]
+        assert reported == pytest.approx(np.std(recovered), rel=0.5)
+
+    def test_positive_slope_rejected_with_note(self):
+        # increasing magnetization -> Ms**2 increases -> non-negative slope
+        T = np.linspace(300.0, 400.0, 30)
+        M = np.sqrt(T - 250.0)
+        r = rmag.curie_ms_squared_extrapolation(T, M, fit_range=(300, 400))
+        assert np.isnan(r["curie_temp"])
+        assert "note" in r["params"]
+
+    def test_insufficient_points_noted(self):
+        T = np.linspace(560.0, 575.0, 3)
+        M = np.sqrt(580.0 - T)
+        r = rmag.curie_ms_squared_extrapolation(
+            T, M, fit_range=(560, 575), min_points=5)
+        assert np.isnan(r["curie_temp"])
+        assert "note" in r["params"]
+
+    def test_flattened_tail_warns(self):
+        # a coarsely quantized (flattened/altered) window repeats values and
+        # must warn, as in the inverse-susceptibility case
+        Tc = 580.0
+        T = np.linspace(480.0, 575.0, 40)
+        M = np.round(np.sqrt(Tc - T) / 0.6) * 0.6
+        r = rmag.curie_ms_squared_extrapolation(T, M, fit_range=(480, 575))
+        assert "warning" in r["params"]
+
+    def test_temperature_unit_invariance(self):
+        # Tc is returned in the input unit (the x-intercept is unit-invariant)
+        Tc = 580.0
+        T = np.linspace(480.0, 575.0, 40)
+        M = np.sqrt(Tc - T)
+        in_C = rmag.curie_ms_squared_extrapolation(T, M, fit_range=(480, 575))
+        in_K = rmag.curie_ms_squared_extrapolation(
+            T + 273.15, M, fit_range=(480 + 273.15, 575 + 273.15))
+        assert in_C["curie_temp"] == pytest.approx(580.0, abs=0.5)
+        assert in_K["curie_temp"] == pytest.approx(580.0 + 273.15, abs=0.5)
+
+
 class TestCurieTemperatureEstimates:
     def test_tidy_table_shape_and_defaults_magnetization(
             self, heat_cool_experiment):
@@ -603,6 +688,32 @@ class TestCurieTemperatureEstimates:
         infl = float(est[est["branch"] == "heating"].iloc[0]["curie_temp"])
         assert infl == pytest.approx(500.0, abs=4.0)
 
+    def test_ms_squared_extrapolation_selectable_for_magnetization(self):
+        Tc = 580.0
+        T_C = np.linspace(460.0, 575.0, 60)
+        df = pd.DataFrame({
+            "meas_temp": T_C + 273.15,
+            "magn_mass": np.sqrt(Tc - T_C),
+            "specimen": "syn", "experiment": "SYN-LP-MST-1",
+        })
+        est = rmag.curie_temperature_estimates(
+            df, magnetic_column="magn_mass", remove_holder=False,
+            methods=("ms_squared_extrapolation",),
+            method_kwargs={"ms_squared_extrapolation": {"fit_range": (480, 575)}})
+        row = est[est["branch"] == "heating"].iloc[0]
+        assert row["curie_temp"] == pytest.approx(580.0, abs=1.0)
+        assert "Moskowitz" in row["notes"]
+
+    def test_ms_squared_rejected_for_susceptibility(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        df = pd.DataFrame({
+            "meas_temp": T + 273.15, "susc_chi_mass": chi,
+            "specimen": "chi", "experiment": "SYN-LP-X-T-1",
+        })
+        with pytest.raises(ValueError, match="magnetization"):
+            rmag.curie_temperature_estimates(
+                df, methods=("ms_squared_extrapolation",))
+
     def test_heating_only_yields_heating_rows(self):
         T = np.linspace(323.15, 973.15, 200)
         df = pd.DataFrame({
@@ -698,6 +809,31 @@ class TestAddCurieEstimatesToSpecimensTable:
             rmag.add_curie_estimates_to_specimens_table(
                 specimens, "SYN-LP-MST-1", estimates
             )
+
+    def test_writes_ms_squared_extrapolation_estimate(self):
+        Tc = 580.0
+        T_C = np.linspace(460.0, 575.0, 60)
+        df = pd.DataFrame({
+            "meas_temp": T_C + 273.15,
+            "magn_mass": np.sqrt(Tc - T_C),
+            "specimen": "syn", "experiment": "SYN-LP-MST-1",
+        })
+        estimates = rmag.curie_temperature_estimates(
+            df, magnetic_column="magn_mass", remove_holder=False,
+            methods=("ms_squared_extrapolation",),
+            method_kwargs={"ms_squared_extrapolation": {"fit_range": (480, 575)}})
+        specimens = pd.DataFrame({
+            "specimen": ["syn"],
+            "experiments": ["SYN-LP-MST-1"],
+            "description": [np.nan],
+        })
+        rmag.add_curie_estimates_to_specimens_table(
+            specimens, "SYN-LP-MST-1", estimates,
+            method="ms_squared_extrapolation", branch="heating")
+        row = specimens.iloc[0]
+        assert row["critical_temp"] == pytest.approx(580.0 + 273.15, abs=1.0)
+        assert row["critical_temp_type"] == "Curie"
+        assert "ms_squared_extrapolation" in row["description"]
 
     def test_nan_experiments_rows_are_skipped(self, heat_cool_experiment):
         """Real specimens tables include rows with no experiments recorded

--- a/pmagpy/test/test_rockmag_curie.py
+++ b/pmagpy/test/test_rockmag_curie.py
@@ -1,0 +1,684 @@
+"""
+Tests for the Curie temperature estimation functions in pmagpy.rockmag.
+
+Synthetic curves with known analytical answers are used throughout:
+
+* in-field Landau curves M(T) = M0 * m(tau; h), with m the physical root of
+  the Landau equation of state m**3 + tau*m = h (Fabian et al., 2013,
+  doi:10.1029/2012GC004440), for which the Curie temperature Tc is known
+  exactly and the documented biases of the classical estimators (maximum
+  curvature and two-tangent above the inflection-point Tc) must be recovered;
+* susceptibility curves with an exact Curie-Weiss tail chi = C/(T - theta)
+  above the transition, for which the inverse-susceptibility method must
+  recover theta;
+* a real measured curve (data_files/curie/curie_example.dat) for which the
+  maximum-curvature estimate is checked against the legacy ipmag.curie
+  result (552 C with a 10-degree smoothing window).
+"""
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pmagpy.rockmag as rmag
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data_files")
+
+TC_K = 853.15  # 580 C
+M0 = 1.0
+H_REDUCED = 5e-4
+THETA_C = 590.0  # paramagnetic Curie temperature for the chi fixture
+CURIE_CONSTANT = 2e-6
+
+
+def landau_curve_K(T_K, tc_K=TC_K, m0=M0, h=H_REDUCED):
+    """In-field Landau magnetization curve at absolute temperatures T_K."""
+    return m0 * rmag.landau_magnetization((T_K - tc_K) / tc_K, h)
+
+
+@pytest.fixture
+def landau_heating_C():
+    """Dense in-field Landau curve through Tc, temperatures in Celsius."""
+    T_K = np.linspace(323.15, 973.15, 400)
+    return T_K - 273.15, landau_curve_K(T_K)
+
+
+@pytest.fixture
+def curie_weiss_chi():
+    """chi(T) with an exact Curie-Weiss tail above the transition."""
+    T = np.linspace(300.0, 700.0, 400)
+    chi = np.where(
+        T > THETA_C + 2.0,
+        CURIE_CONSTANT / (T - THETA_C),
+        1e-4 * (1.0 - 0.5 * (T / THETA_C)),
+    )
+    return T, chi
+
+
+@pytest.fixture
+def heat_cool_experiment():
+    """MagIC-shaped experiment with heating and cooling branches and a
+    constant holder offset."""
+    T_heat = np.linspace(323.15, 973.15, 300)
+    T_cool = T_heat[::-1]
+    holder = 0.05
+    return pd.DataFrame({
+        "meas_temp": np.concatenate([T_heat, T_cool]),
+        "magn_mass": np.concatenate([
+            landau_curve_K(T_heat) + holder,
+            0.9 * landau_curve_K(T_cool) + holder,
+        ]),
+        "specimen": "synthetic-01",
+        "experiment": "SYN-LP-MST-1",
+    })
+
+
+class TestLandauMagnetization:
+    def test_zero_field_square_root_form(self):
+        tau = np.array([-0.75, -0.5, -0.25, -0.04])
+        m = rmag.landau_magnetization(tau, 0.0)
+        assert np.allclose(m, np.sqrt(-tau), atol=1e-12)
+
+    def test_zero_field_vanishes_above_tc(self):
+        m = rmag.landau_magnetization(np.array([0.01, 0.2, 1.0]), 0.0)
+        assert np.allclose(m, 0.0, atol=1e-12)
+
+    def test_field_rounds_transition(self):
+        tau = np.linspace(-0.5, 0.5, 101)
+        m = rmag.landau_magnetization(tau, 1e-3)
+        # monotonically decreasing, positive tail above Tc
+        assert np.all(np.diff(m) < 0)
+        assert m[-1] > 0
+        # satisfies the equation of state
+        assert np.allclose(m**3 + tau * m, 1e-3, atol=1e-10)
+
+
+class TestSplitWarmCool:
+    def test_heating_then_cooling(self, heat_cool_experiment):
+        warm_T, warm_X, cool_T, cool_X = rmag.split_warm_cool(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        assert warm_T.size == 300
+        assert cool_T.size == 300
+        assert warm_T[0] < warm_T[-1]
+        assert cool_T[0] > cool_T[-1]
+
+    def test_cooling_only_has_empty_heating_branch(self):
+        T = np.linspace(300, 20, 57)
+        df = pd.DataFrame({"meas_temp": T, "magn_mass": np.linspace(38, 42, 57)})
+        warm_T, _, cool_T, _ = rmag.split_warm_cool(
+            df, magnetic_column="magn_mass"
+        )
+        assert warm_T.size == 0
+        assert cool_T.size == 57
+
+    def test_non_finite_rows_dropped(self):
+        df = pd.DataFrame({
+            "meas_temp": [280.0, 290.0, np.nan, 310.0],
+            "magn_mass": [1.0, np.nan, 3.0, 4.0],
+        })
+        warm_T, warm_X, _, _ = rmag.split_warm_cool(
+            df, magnetic_column="magn_mass"
+        )
+        assert warm_T.size == 2
+        assert np.all(np.isfinite(warm_X))
+
+
+class TestPrepareThermomagBranches:
+    def test_branches_ascending_and_holder_removed(self, heat_cool_experiment):
+        branches = rmag.prepare_thermomag_branches(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        for branch in ("heating", "cooling"):
+            T = branches[branch]["T"]
+            assert np.all(np.diff(T) >= 0)
+            # holder offset (0.05) removed: branch minimum is zero
+            assert branches[branch]["y"].min() == pytest.approx(0.0, abs=1e-12)
+
+    def test_heating_only_returns_none_cooling(self):
+        T = np.linspace(300, 900, 50)
+        df = pd.DataFrame({"meas_temp": T, "susc_chi_mass": np.exp(-T / 300)})
+        branches = rmag.prepare_thermomag_branches(df)
+        assert branches["cooling"] is None
+        assert branches["heating"]["T"].size == 50
+
+    def test_temperature_units(self, heat_cool_experiment):
+        branches_C = rmag.prepare_thermomag_branches(
+            heat_cool_experiment, magnetic_column="magn_mass", temp_unit="C"
+        )
+        branches_K = rmag.prepare_thermomag_branches(
+            heat_cool_experiment, magnetic_column="magn_mass", temp_unit="K"
+        )
+        assert branches_K["heating"]["T"][0] - branches_C["heating"]["T"][0] == (
+            pytest.approx(273.15)
+        )
+
+
+class TestCurieDerivativeEstimates:
+    def test_inflection_at_tc_on_landau_curve(self, landau_heating_C):
+        T, M = landau_heating_C
+        result = rmag.curie_derivative_estimates(T, M)
+        assert result["inflection_temp"] == pytest.approx(580.0, abs=2.0)
+
+    def test_max_curvature_above_inflection(self, landau_heating_C):
+        T, M = landau_heating_C
+        result = rmag.curie_derivative_estimates(T, M)
+        # documented bias: the maximum-curvature estimate lies above the
+        # inflection-point Tc on in-field M(T) (Fabian et al., 2013)
+        assert result["max_curvature_temp"] > result["inflection_temp"]
+        assert result["max_curvature_temp"] - 580.0 < 25.0
+
+    def test_duplicate_temperatures_handled(self, landau_heating_C):
+        T, M = landau_heating_C
+        T_dup = np.repeat(T, 2)
+        M_dup = np.repeat(M, 2)
+        result = rmag.curie_derivative_estimates(T_dup, M_dup)
+        assert np.isfinite(result["inflection_temp"])
+        assert result["inflection_temp"] == pytest.approx(580.0, abs=2.0)
+
+    def test_too_few_points_returns_nan(self):
+        result = rmag.curie_derivative_estimates([1.0, 2.0], [1.0, 0.5])
+        assert np.isnan(result["inflection_temp"])
+        assert np.isnan(result["max_curvature_temp"])
+
+    def test_t_range_restricts_search(self, landau_heating_C):
+        T, M = landau_heating_C
+        # a second, low-temperature feature that would otherwise dominate
+        M_two_phase = M + 0.5 * rmag.landau_magnetization(
+            (T + 273.15 - 473.15) / 473.15, H_REDUCED
+        )
+        result = rmag.curie_derivative_estimates(T, M_two_phase,
+                                                 t_range=(400, 700))
+        assert result["inflection_temp"] == pytest.approx(580.0, abs=5.0)
+
+
+class TestCurieTwoTangent:
+    def test_recovers_transition_on_landau_curve(self, landau_heating_C):
+        T, M = landau_heating_C
+        result = rmag.curie_two_tangent(T, M)
+        assert np.isfinite(result["curie_temp"])
+        # documented bias: at or above the true Tc
+        assert result["curie_temp"] >= 580.0 - 1.0
+        assert result["curie_temp"] - 580.0 < 30.0
+
+    def test_bias_ordering(self, landau_heating_C):
+        # two_tangent >= max_curvature-region estimates >= inflection ~ Tc
+        T, M = landau_heating_C
+        derivative = rmag.curie_derivative_estimates(T, M)
+        two_tangent = rmag.curie_two_tangent(T, M)
+        assert (two_tangent["curie_temp"]
+                >= derivative["inflection_temp"] - 1.0)
+
+    def test_explicit_ranges(self, landau_heating_C):
+        T, M = landau_heating_C
+        result = rmag.curie_two_tangent(T, M, lower_range=(540, 575),
+                                        upper_range=(620, 700))
+        assert np.isfinite(result["curie_temp"])
+        assert result["params"]["lower_range"] == (540, 575)
+
+    def test_insufficient_points(self):
+        result = rmag.curie_two_tangent([1, 2, 3], [3, 2, 1])
+        assert np.isnan(result["curie_temp"])
+        assert "note" in result["params"]
+
+
+class TestCurieInverseSusceptibility:
+    def test_exact_recovery_of_theta(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        result = rmag.curie_inverse_susceptibility(T, chi,
+                                                   fit_range=(620, 700))
+        assert result["curie_temp"] == pytest.approx(THETA_C, abs=0.5)
+        assert result["params"]["r_squared"] == pytest.approx(1.0, abs=1e-6)
+        assert result["params"]["curie_constant"] == pytest.approx(
+            CURIE_CONSTANT, rel=1e-3
+        )
+
+    def test_window_below_transition_degrades_fit(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        clean = rmag.curie_inverse_susceptibility(T, chi,
+                                                  fit_range=(620, 700))
+        contaminated = rmag.curie_inverse_susceptibility(
+            T, chi, fit_range=(400, 700)
+        )
+        assert (contaminated["params"]["r_squared"]
+                < clean["params"]["r_squared"])
+
+    def test_default_window_is_top_quintile(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        result = rmag.curie_inverse_susceptibility(T, chi)
+        lo, hi = result["params"]["fit_range"]
+        assert lo == pytest.approx(T.min() + 0.8 * (T.max() - T.min()))
+        assert hi == pytest.approx(T.max())
+
+    def test_insufficient_points_noted(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        result = rmag.curie_inverse_susceptibility(T, chi,
+                                                   fit_range=(699, 700))
+        assert np.isnan(result["curie_temp"])
+        assert "note" in result["params"]
+
+    def test_quantized_tail_warns_and_min_chi_recovers(self):
+        """A resolution-limited tail (susceptibility pinned at integer counts
+        of the meter) flattens the fit and biases theta low; the function
+        must warn, and excluding sub-resolution points with min_chi must
+        recover theta."""
+        step = 5e-9  # one instrument count
+        T = np.linspace(600, 700, 60)
+        chi_true = CURIE_CONSTANT / (T - THETA_C)
+        chi_quantized = np.round(chi_true / step) * step  # pinned counts tail
+        contaminated = rmag.curie_inverse_susceptibility(
+            T, chi_quantized, fit_range=(600, 700))
+        assert "warning" in contaminated["params"]
+        assert contaminated["curie_temp"] < THETA_C  # biased low
+        screened = rmag.curie_inverse_susceptibility(
+            T, chi_quantized, fit_range=(600, 700), min_chi=10 * step)
+        assert "warning" not in screened["params"]
+        assert screened["curie_temp"] == pytest.approx(THETA_C, abs=2.0)
+        assert screened["params"]["n_points"] < contaminated["params"]["n_points"]
+
+    def test_clean_data_has_no_warning(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        result = rmag.curie_inverse_susceptibility(T, chi,
+                                                   fit_range=(620, 700))
+        assert "warning" not in result["params"]
+
+
+class TestCurieLandauFit:
+    def test_exact_recovery_noiseless(self, landau_heating_C):
+        T, M = landau_heating_C
+        result = rmag.curie_landau_fit(T, M, temp_unit="C")
+        assert result["curie_temp"] == pytest.approx(580.0, abs=1.0)
+        assert result["params"]["M0"] == pytest.approx(M0, rel=0.05)
+        assert result["params"]["h"] == pytest.approx(H_REDUCED, rel=0.05)
+        assert not result["params"]["extrapolation"]
+
+    def test_recovery_with_noise(self, landau_heating_C):
+        T, M = landau_heating_C
+        rng = np.random.default_rng(42)
+        M_noisy = M + rng.normal(0, 0.005, M.size)
+        result = rmag.curie_landau_fit(T, M_noisy, temp_unit="C")
+        assert result["curie_temp"] == pytest.approx(580.0, abs=5.0)
+        assert np.isfinite(result["curie_temp_stderr"])
+        assert result["curie_temp_stderr"] > 0
+
+    def test_kelvin_input(self, landau_heating_C):
+        T_C, M = landau_heating_C
+        result = rmag.curie_landau_fit(T_C + 273.15, M, temp_unit="K")
+        assert result["curie_temp"] == pytest.approx(TC_K, abs=1.0)
+
+    def test_extrapolation_mode_flags_and_inflates_uncertainty(self):
+        # truncate far below Tc: with measurement noise the extrapolated Tc
+        # is weakly constrained and the formal uncertainty must reflect that
+        rng = np.random.default_rng(7)
+        T_through = np.linspace(20, 520, 100)
+        M_through = (landau_curve_K(T_through, tc_K=480.0, h=1e-3)
+                     + rng.normal(0, 0.002, T_through.size))
+        T_trunc = np.linspace(20, 300, 57)
+        M_trunc = (landau_curve_K(T_trunc, tc_K=480.0, h=1e-3)
+                   + rng.normal(0, 0.002, T_trunc.size))
+        through = rmag.curie_landau_fit(T_through, M_through, temp_unit="K")
+        truncated = rmag.curie_landau_fit(T_trunc, M_trunc, temp_unit="K")
+        assert truncated["params"]["extrapolation"]
+        assert not through["params"]["extrapolation"]
+        assert (truncated["curie_temp_stderr"]
+                > 10 * through["curie_temp_stderr"])
+
+    def test_fit_range_restricts_points(self, landau_heating_C):
+        T, M = landau_heating_C
+        result = rmag.curie_landau_fit(T, M, fit_range=(200, 700),
+                                       temp_unit="C")
+        assert result["params"]["n_points"] < T.size
+        assert result["curie_temp"] == pytest.approx(580.0, abs=2.0)
+
+    def test_insufficient_points_noted(self):
+        result = rmag.curie_landau_fit([100, 200, 300], [1.0, 0.9, 0.8],
+                                       temp_unit="K")
+        assert np.isnan(result["curie_temp"])
+        assert "note" in result["params"]
+
+
+class TestCurieTemperatureEstimates:
+    def test_tidy_table_shape_and_defaults_magnetization(
+            self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        assert list(estimates.columns) == [
+            "specimen", "experiment", "branch", "method", "curie_temp",
+            "curie_temp_stderr", "temp_unit", "params", "notes",
+        ]
+        # magnetization defaults: 4 methods x 2 branches
+        assert len(estimates) == 8
+        assert set(estimates["method"]) == {
+            "inflection", "max_curvature", "two_tangent", "landau",
+        }
+
+    def test_susceptibility_defaults(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        df = pd.DataFrame({
+            "meas_temp": T + 273.15,
+            "susc_chi_mass": chi,
+            "specimen": "chi-syn",
+            "experiment": "SYN-LP-X-T-1",
+        })
+        estimates = rmag.curie_temperature_estimates(df, remove_holder=False)
+        assert set(estimates["method"]) == {
+            "inflection", "max_curvature", "inverse_susceptibility",
+        }
+
+    def test_bias_ordering_documented(self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        heating = estimates[estimates["branch"] == "heating"].set_index("method")
+        tc = heating["curie_temp"]
+        assert tc["inflection"] <= tc["max_curvature"] + 1.0
+        assert tc["inflection"] <= tc["two_tangent"] + 1.0
+        assert tc["landau"] == pytest.approx(580.0, abs=2.0)
+
+    def test_method_kwargs_forwarding(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        df = pd.DataFrame({
+            "meas_temp": T + 273.15,
+            "susc_chi_mass": chi,
+            "specimen": "chi-syn",
+            "experiment": "SYN-LP-X-T-1",
+        })
+        estimates = rmag.curie_temperature_estimates(
+            df,
+            methods=("inverse_susceptibility",),
+            remove_holder=False,
+            method_kwargs={"inverse_susceptibility":
+                           {"fit_range": (620, 700)}},
+        )
+        row = estimates.iloc[0]
+        assert row["params"]["fit_range"] == (620.0, 700.0)
+        assert row["curie_temp"] == pytest.approx(THETA_C, abs=0.5)
+
+    def test_chi_caveat_notes(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        df = pd.DataFrame({
+            "meas_temp": T + 273.15,
+            "susc_chi_mass": chi,
+            "specimen": "chi-syn",
+            "experiment": "SYN-LP-X-T-1",
+        })
+        estimates = rmag.curie_temperature_estimates(
+            df, methods=("two_tangent",), remove_holder=False
+        )
+        assert "not physically justified" in estimates.iloc[0]["notes"]
+
+    def test_unknown_method_raises(self, heat_cool_experiment):
+        with pytest.raises(ValueError, match="unknown method"):
+            rmag.curie_temperature_estimates(
+                heat_cool_experiment, methods=("kink_point",),
+                magnetic_column="magn_mass",
+            )
+
+    def test_heating_only_yields_heating_rows(self):
+        T = np.linspace(323.15, 973.15, 200)
+        df = pd.DataFrame({
+            "meas_temp": T,
+            "magn_mass": landau_curve_K(T),
+            "specimen": "syn", "experiment": "SYN-1",
+        })
+        estimates = rmag.curie_temperature_estimates(
+            df, magnetic_column="magn_mass"
+        )
+        assert set(estimates["branch"]) == {"heating"}
+
+
+class TestRealDataRegression:
+    def test_max_curvature_matches_legacy_ipmag_curie(self):
+        """The legacy ipmag.curie estimate on curie_example.dat (552 C with a
+        10-degree Bartlett window) is a maximum-curvature estimate; the
+        rockmag implementation must agree within a few degrees despite the
+        different smoothing kernel."""
+        path = os.path.join(DATA_DIR, "curie", "curie_example.dat")
+        if not os.path.exists(path):
+            pytest.skip("curie_example.dat not available")
+        T, M = np.loadtxt(path, unpack=True)
+        sT, sM = rmag.smooth_moving_avg(T, M, 10)
+        result = rmag.curie_derivative_estimates(sT, sM)
+        assert result["max_curvature_temp"] == pytest.approx(552.0, abs=5.0)
+
+
+class TestAddCurieEstimatesToSpecimensTable:
+    def test_writes_kelvin_and_vocab(self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["synthetic-01"],
+            "experiments": ["SYN-LP-MST-1"],
+            "description": [np.nan],
+        })
+        rmag.add_curie_estimates_to_specimens_table(
+            specimens, "SYN-LP-MST-1", estimates, method="landau"
+        )
+        row = specimens.iloc[0]
+        expected_K = (
+            estimates.set_index(["method", "branch"])
+            .loc[("landau", "heating"), "curie_temp"] + 273.15
+        )
+        assert row["critical_temp"] == pytest.approx(expected_K, abs=0.01)
+        assert row["critical_temp_type"] == "Curie"
+        assert "curie_method" in row["description"]
+
+    def test_missing_method_raises(self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["synthetic-01"],
+            "experiments": ["SYN-LP-MST-1"],
+            "description": [np.nan],
+        })
+        with pytest.raises(ValueError, match="no estimate"):
+            rmag.add_curie_estimates_to_specimens_table(
+                specimens, "SYN-LP-MST-1", estimates,
+                method="inverse_susceptibility",
+            )
+
+    def test_specimen_fallback_when_experiment_names_differ(
+            self, heat_cool_experiment):
+        """Real contributions may abbreviate experiment names in the
+        specimens table; the helper falls back to matching the specimen."""
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["synthetic-01"],
+            "experiments": ["SYN-1"],  # abbreviated, no exact/substring match
+            "description": [np.nan],
+        })
+        rmag.add_curie_estimates_to_specimens_table(
+            specimens, "SYN-LP-MST-1", estimates
+        )
+        assert specimens.iloc[0]["critical_temp_type"] == "Curie"
+
+    def test_missing_experiment_raises(self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["other"],
+            "experiments": ["OTHER-EXP"],
+            "description": [np.nan],
+        })
+        with pytest.raises(ValueError, match="not found"):
+            rmag.add_curie_estimates_to_specimens_table(
+                specimens, "SYN-LP-MST-1", estimates
+            )
+
+
+class TestPlotCurieEstimates:
+    def test_returns_figure_and_axes(self, heat_cool_experiment):
+        fig, axes = rmag.plot_curie_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass",
+            return_figure=True,
+        )
+        assert len(axes) == 2  # main + derivative panel
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+    def test_inverse_panel_for_susceptibility(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        df = pd.DataFrame({
+            "meas_temp": T + 273.15,
+            "susc_chi_mass": chi,
+            "specimen": "chi-syn",
+            "experiment": "SYN-LP-X-T-1",
+        })
+        fig, axes = rmag.plot_curie_estimates(
+            df, remove_holder=False, return_figure=True,
+            method_kwargs={"inverse_susceptibility":
+                           {"fit_range": (620, 700)}},
+        )
+        assert len(axes) == 3  # main + derivative + 1/chi panels
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+
+class TestReviewFixes:
+    """Regression tests for issues found in pre-commit review."""
+
+    def test_description_free_text_preserved(self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["synthetic-01"],
+            "experiments": ["SYN-LP-MST-1"],
+            "description": ["chip from the north margin; oxidized rind"],
+        })
+        rmag.add_curie_estimates_to_specimens_table(
+            specimens, "SYN-LP-MST-1", estimates
+        )
+        description = specimens.iloc[0]["description"]
+        assert "chip from the north margin" in description
+        assert "curie_method" in description
+
+    def test_experiment_matching_no_substring_overmatch(
+            self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["other-spec", "other-spec-2"],
+            "experiments": ["SYN-LP-MST-10", "SYN-LP-MST-11"],
+            "description": [np.nan, np.nan],
+        })
+        # 'SYN-LP-MST-1' is a substring of both rows but must match neither
+        with pytest.raises(ValueError, match="not found"):
+            rmag.add_curie_estimates_to_specimens_table(
+                specimens, "SYN-LP-MST-1", estimates
+            )
+
+    def test_experiment_matching_colon_delimited_token(
+            self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["other-spec", "synthetic-01"],
+            "experiments": ["SYN-LP-MST-10", "SYN-HYS-1:SYN-LP-MST-1"],
+            "description": [np.nan, np.nan],
+        })
+        rmag.add_curie_estimates_to_specimens_table(
+            specimens, "SYN-LP-MST-1", estimates
+        )
+        assert specimens.iloc[1]["critical_temp_type"] == "Curie"
+        assert pd.isna(specimens.iloc[0]["critical_temp"])
+
+    def test_negative_slope_rejected_with_note(self):
+        T = np.linspace(600, 700, 50)
+        chi = 1.0 / np.linspace(2e5, 1e5, 50)  # 1/chi DECREASES with T
+        result = rmag.curie_inverse_susceptibility(T, chi,
+                                                   fit_range=(600, 700))
+        assert np.isnan(result["curie_temp"])
+        assert "non-positive slope" in result["params"]["note"]
+
+    def test_unknown_method_kwargs_key_raises(self, heat_cool_experiment):
+        with pytest.raises(ValueError, match="unknown method_kwargs"):
+            rmag.curie_temperature_estimates(
+                heat_cool_experiment, magnetic_column="magn_mass",
+                method_kwargs={"inverse_suceptibility": {}},  # typo
+            )
+
+    def test_per_method_derivative_kwargs_forwarded(self):
+        # a second low-temperature transition that t_range must exclude
+        T_K = np.linspace(323.15, 973.15, 400)
+        M = (landau_curve_K(T_K)
+             + 0.5 * rmag.landau_magnetization((T_K - 473.15) / 473.15,
+                                               H_REDUCED))
+        df = pd.DataFrame({
+            "meas_temp": T_K, "magn_mass": M,
+            "specimen": "two-phase", "experiment": "SYN-2PH-1",
+        })
+        estimates = rmag.curie_temperature_estimates(
+            df, magnetic_column="magn_mass", methods=("inflection",),
+            remove_holder=False,
+            method_kwargs={"inflection": {"t_range": (400, 700)}},
+        )
+        assert estimates.iloc[0]["curie_temp"] == pytest.approx(580.0, abs=5.0)
+
+    def test_data_type_inference_accepts_chi_columns(self, curie_weiss_chi):
+        T, chi = curie_weiss_chi
+        df = pd.DataFrame({
+            "meas_temp": T + 273.15,
+            "chi_corrected": chi,  # susceptibility column without 'susc'
+            "specimen": "chi-syn", "experiment": "SYN-LP-X-T-1",
+        })
+        estimates = rmag.curie_temperature_estimates(
+            df, magnetic_column="chi_corrected", remove_holder=False
+        )
+        assert "inverse_susceptibility" in set(estimates["method"])
+
+    def test_data_type_override_and_validation(self, heat_cool_experiment):
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass",
+            data_type="susceptibility",
+        )
+        assert "inverse_susceptibility" in set(estimates["method"])
+        with pytest.raises(ValueError, match="data_type"):
+            rmag.curie_temperature_estimates(
+                heat_cool_experiment, magnetic_column="magn_mass",
+                data_type="susceptometry",
+            )
+
+    def test_return_method_results_carries_diagnostics(
+            self, heat_cool_experiment):
+        estimates, method_results = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass",
+            return_method_results=True,
+        )
+        landau_result = method_results[("heating", "landau")]
+        assert "model_T" in landau_result["diagnostics"]
+        assert len(method_results) >= len(estimates)
+
+    def test_prepare_dedupes_duplicate_temperatures(self):
+        T_K = np.repeat(np.linspace(323.15, 973.15, 200), 2)
+        M = np.repeat(landau_curve_K(np.linspace(323.15, 973.15, 200)), 2)
+        df = pd.DataFrame({"meas_temp": T_K, "magn_mass": M})
+        branches = rmag.prepare_thermomag_branches(
+            df, magnetic_column="magn_mass"
+        )
+        T = branches["heating"]["T"]
+        assert np.all(np.diff(T) > 0)  # strictly increasing after dedupe
+
+    def test_two_tangent_truncated_curve_flagged(self):
+        # run ends well below Tc: still steeply descending at max T
+        T_K = np.linspace(323.15, 723.15, 200)
+        M = landau_curve_K(T_K)  # Tc = 853.15 K, curve truncated at 723 K
+        result = rmag.curie_two_tangent(T_K, M)
+        assert "note" in result["params"]
+        assert "descending limb" in result["params"]["note"]
+
+    def test_inverse_susceptibility_helper_masks_nonpositive(self):
+        chi = np.array([2.0, 0.0, -1.0, 4.0])
+        inv = rmag._inverse_susceptibility(chi)
+        assert inv[0] == pytest.approx(0.5)
+        assert np.isnan(inv[1]) and np.isnan(inv[2])
+        assert inv[3] == pytest.approx(0.25)

--- a/pmagpy/test/test_rockmag_curie.py
+++ b/pmagpy/test/test_rockmag_curie.py
@@ -283,6 +283,19 @@ class TestCurieTwoTangent:
         assert np.isnan(result["curie_temp"])
         assert "note" in result["params"]
 
+    def test_reliable_flag_true_on_full_curve(self, landau_heating_C):
+        # a curve that reaches a flat baseline above Tc is a reliable fit
+        T, M = landau_heating_C
+        result = rmag.curie_two_tangent(T, M)
+        assert result["params"]["reliable"] is True
+
+    def test_non_finite_values_dropped(self, landau_heating_C):
+        T, M = landau_heating_C
+        M_nan = M.copy()
+        M_nan[7] = np.nan
+        result = rmag.curie_two_tangent(T, M_nan)
+        assert np.isfinite(result["curie_temp"])
+
 
 class TestCurieInverseSusceptibility:
     def test_exact_recovery_of_theta(self, curie_weiss_chi):
@@ -344,6 +357,42 @@ class TestCurieInverseSusceptibility:
                                                    fit_range=(620, 700))
         assert "warning" not in result["params"]
 
+    def test_stderr_matches_monte_carlo(self):
+        # the reported 1-sigma on theta must match the actual spread of theta
+        # under noise, which requires the slope-intercept covariance term in
+        # the delta-method propagation; omitting it inflates the value ~12x
+        # because slope and intercept are almost perfectly anti-correlated
+        theta, C = 590.0, 2e-6
+        T = np.linspace(620, 700, 40)
+        inv_true = (T - theta) / C
+        sigma = 0.01 * inv_true.max()  # homoscedastic noise in 1/chi
+        rng = np.random.default_rng(12345)
+        chi0 = 1.0 / (inv_true + rng.normal(0, sigma, T.size))
+        reported = rmag.curie_inverse_susceptibility(
+            T, chi0, fit_range=(620, 700))["curie_temp_stderr"]
+        recovered = [
+            rmag.curie_inverse_susceptibility(
+                T, 1.0 / (inv_true + rng.normal(0, sigma, T.size)),
+                fit_range=(620, 700))["curie_temp"]
+            for _ in range(1500)
+        ]
+        assert reported == pytest.approx(np.std(recovered), rel=0.5)
+        # guard the covariance cross-term explicitly: without it the reported
+        # value would be several times the true spread
+        (slope, intercept), cov = np.polyfit(T, 1.0 / chi0, 1, cov=True)
+        naive = np.sqrt((intercept / slope**2)**2 * cov[0, 0]
+                        + (1.0 / slope)**2 * cov[1, 1])
+        assert reported < 0.5 * naive
+
+    def test_min_points_below_three_is_graceful(self, curie_weiss_chi):
+        # a covariance line fit needs more than two points; the function must
+        # return a note rather than let np.polyfit(cov=True) raise
+        T, chi = curie_weiss_chi
+        result = rmag.curie_inverse_susceptibility(
+            T, chi, fit_range=(699, 700), min_points=2)
+        assert np.isnan(result["curie_temp"])
+        assert "note" in result["params"]
+
 
 class TestCurieLandauFit:
     def test_exact_recovery_noiseless(self, landau_heating_C):
@@ -398,6 +447,25 @@ class TestCurieLandauFit:
         assert np.isnan(result["curie_temp"])
         assert "note" in result["params"]
 
+    def test_stderr_matches_monte_carlo(self):
+        # the reported 1-sigma on Tc must match the spread of Tc under noise
+        # for a curve measured through the transition
+        tc_K = 853.15
+        T_K = np.linspace(600, 1000, 80)
+        M0 = landau_curve_K(T_K, tc_K=tc_K, h=1e-3)
+        sigma = 0.004
+        rng = np.random.default_rng(2024)
+        reported = rmag.curie_landau_fit(
+            T_K, M0 + rng.normal(0, sigma, T_K.size), temp_unit="K"
+        )["curie_temp_stderr"]
+        recovered = [
+            rmag.curie_landau_fit(
+                T_K, M0 + rng.normal(0, sigma, T_K.size), temp_unit="K"
+            )["curie_temp"]
+            for _ in range(200)
+        ]
+        assert reported == pytest.approx(np.std(recovered), rel=0.4)
+
 
 class TestCurieTemperatureEstimates:
     def test_tidy_table_shape_and_defaults_magnetization(
@@ -437,6 +505,30 @@ class TestCurieTemperatureEstimates:
         assert tc["inflection"] <= tc["max_curvature"] + 1.0
         assert tc["inflection"] <= tc["two_tangent"] + 1.0
         assert tc["landau"] == pytest.approx(580.0, abs=2.0)
+
+    def test_bias_ordering_strict_separation(self, heat_cool_experiment):
+        # the estimators must be genuinely separated, not collapsed onto one
+        # another: two_tangent > max_curvature > inflection (Fabian et al.,
+        # 2013). A slack `<= x + 1` check would pass a degenerate estimator.
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        heating = estimates[estimates["branch"] == "heating"].set_index("method")
+        tc = heating["curie_temp"]
+        assert tc["max_curvature"] > tc["inflection"] + 3.0
+        assert tc["two_tangent"] > tc["max_curvature"] + 3.0
+
+    def test_cooling_branch_recovers_tc(self, heat_cool_experiment):
+        # the cooling branch (scaled Landau curve, same Tc) must yield a
+        # correct Curie temperature, not merely a well-shaped table row
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        cooling = estimates[estimates["branch"] == "cooling"].set_index("method")
+        assert cooling.loc["inflection", "curie_temp"] == pytest.approx(
+            580.0, abs=3.0)
+        assert cooling.loc["landau", "curie_temp"] == pytest.approx(
+            580.0, abs=2.0)
 
     def test_method_kwargs_forwarding(self, curie_weiss_chi):
         T, chi = curie_weiss_chi
@@ -736,6 +828,7 @@ class TestReviewFixes:
         result = rmag.curie_two_tangent(T_K, M)
         assert "note" in result["params"]
         assert "descending limb" in result["params"]["note"]
+        assert result["params"]["reliable"] is False
 
     def test_inverse_susceptibility_helper_masks_nonpositive(self):
         chi = np.array([2.0, 0.0, -1.0, 4.0])
@@ -743,3 +836,27 @@ class TestReviewFixes:
         assert inv[0] == pytest.approx(0.5)
         assert np.isnan(inv[1]) and np.isnan(inv[2])
         assert inv[3] == pytest.approx(0.25)
+
+
+class TestThermomagPlots:
+    def test_plot_x_t_matplotlib_returns_figures(self, heat_cool_experiment):
+        import matplotlib.pyplot as plt
+        figs = rmag.plot_X_T(
+            heat_cool_experiment, magnetic_column="magn_mass",
+            interactive=False, return_figure=True,
+            plot_derivative=True, plot_inverse=True,
+        )
+        assert isinstance(figs, tuple) and len(figs) >= 1
+        assert all(isinstance(f, plt.Figure) for f in figs)
+        plt.close("all")
+
+    def test_interactive_inverse_susceptibility_missing_branch_raises(self):
+        pytest.importorskip("bokeh")
+        T = np.linspace(323.15, 973.15, 100)  # heating-only run
+        df = pd.DataFrame({
+            "meas_temp": T,
+            "susc_chi_mass": np.exp(-T / 300),
+            "specimen": "syn",
+        })
+        with pytest.raises(ValueError):
+            rmag.interactive_curie_inverse_susceptibility(df, branch="cooling")

--- a/pmagpy/test/test_rockmag_curie.py
+++ b/pmagpy/test/test_rockmag_curie.py
@@ -253,6 +253,23 @@ class TestCurieDerivativeEstimates:
         result = rmag.curie_derivative_estimates(T, M_nan)
         assert result["inflection_temp"] == pytest.approx(580.0, abs=2.0)
 
+    def test_smooth_window_stabilizes_noisy_derivative(self):
+        # differentiation amplifies noise: the raw first derivative of a noisy
+        # curve has a ragged minimum, so argmin can latch onto a spike offset
+        # from the true inflection. smooth_window smooths the derivative and
+        # recovers the transition center, without distorting a clean curve.
+        T = np.linspace(300.0, 700.0, 400)
+        M = (1.0 - np.tanh((T - 500.0) / 18.0)) / 2.0  # inflection at 500
+        clean = rmag.curie_derivative_estimates(T, M, smooth_window=20)
+        assert clean["inflection_temp"] == pytest.approx(500.0, abs=1.0)
+        rng = np.random.default_rng(0)
+        y = M + rng.normal(0.0, 0.013, T.size)
+        raw = rmag.curie_derivative_estimates(T, y)["inflection_temp"]
+        smoothed = rmag.curie_derivative_estimates(
+            T, y, smooth_window=20)["inflection_temp"]
+        assert abs(raw - 500.0) > 10.0  # noise displaces the raw estimate
+        assert smoothed == pytest.approx(500.0, abs=3.0)
+
 
 class TestCurieTwoTangent:
     def test_recovers_transition_on_landau_curve(self, landau_heating_C):
@@ -560,7 +577,7 @@ class TestCurieTemperatureEstimates:
         estimates = rmag.curie_temperature_estimates(
             df, methods=("two_tangent",), remove_holder=False
         )
-        assert "not physically justified" in estimates.iloc[0]["notes"]
+        assert "lacks a rigorous physical basis" in estimates.iloc[0]["notes"]
 
     def test_unknown_method_raises(self, heat_cool_experiment):
         with pytest.raises(ValueError, match="unknown method"):
@@ -568,6 +585,23 @@ class TestCurieTemperatureEstimates:
                 heat_cool_experiment, methods=("kink_point",),
                 magnetic_column="magn_mass",
             )
+
+    def test_smooth_window_forwarded_to_derivative(self):
+        # the wrapper must pass its smoothing window through to the derivative
+        # estimator so the recommended path is robust to derivative noise
+        T_K = np.linspace(300.0, 700.0, 400) + 273.15
+        M = (1.0 - np.tanh((T_K - (500.0 + 273.15)) / 18.0)) / 2.0
+        rng = np.random.default_rng(0)
+        df = pd.DataFrame({
+            "meas_temp": T_K,
+            "magn_mass": M + rng.normal(0.0, 0.013, T_K.size),
+            "specimen": "syn", "experiment": "SYN-1",
+        })
+        est = rmag.curie_temperature_estimates(
+            df, magnetic_column="magn_mass", smooth_window=20,
+            methods=("inflection",))
+        infl = float(est[est["branch"] == "heating"].iloc[0]["curie_temp"])
+        assert infl == pytest.approx(500.0, abs=4.0)
 
     def test_heating_only_yields_heating_rows(self):
         T = np.linspace(323.15, 973.15, 200)
@@ -664,6 +698,26 @@ class TestAddCurieEstimatesToSpecimensTable:
             rmag.add_curie_estimates_to_specimens_table(
                 specimens, "SYN-LP-MST-1", estimates
             )
+
+    def test_nan_experiments_rows_are_skipped(self, heat_cool_experiment):
+        """Real specimens tables include rows with no experiments recorded
+        (NaN in a string-dtype column); the colon-token match must skip them
+        rather than raise when it splits the cell."""
+        estimates = rmag.curie_temperature_estimates(
+            heat_cool_experiment, magnetic_column="magn_mass"
+        )
+        specimens = pd.DataFrame({
+            "specimen": ["synthetic-01", "blank-holder"],
+            "experiments": pd.array(
+                ["OTHER-EXP:SYN-LP-MST-1", pd.NA], dtype="string"),
+            "description": [np.nan, np.nan],
+        })
+        rmag.add_curie_estimates_to_specimens_table(
+            specimens, "SYN-LP-MST-1", estimates, method="landau"
+        )
+        # matched the colon-delimited token on row 0; NaN row 1 left untouched
+        assert specimens.loc[0, "critical_temp_type"] == "Curie"
+        assert pd.isna(specimens.loc[1, "critical_temp"])
 
 
 class TestPlotCurieEstimates:


### PR DESCRIPTION
## Summary

This PR adds multi-method Curie temperature estimation to `pmagpy/rockmag.py`, designed so that the method-dependent biases among estimators are explicit rather than hidden behind a single reported number. It builds on the initial Curie functionality from #776, which it refactors and supersedes.

Curie temperature estimates from thermomagnetic data are method- and data-type-dependent, with systematic offsets of several to tens of degrees documented on synthetic titanomagnetites ([Lattard et al., 2006](https://doi.org/10.1029/2006JB004591)). The Landau-theory analysis of [Fabian et al. (2013)](https://doi.org/10.1029/2012GC004440) shows that for in-field M(T) curves the Curie temperature corresponds to the inflection point (minimum of dM/dT), while the classical maximum-curvature (Ade-Hall et al., 1965) and two-tangent ([Grommé et al., 1969](https://doi.org/10.1029/JB074i022p05277)) estimates lie systematically above it; for low-field χ(T) curves the two-tangent construction is not physically justified and the Curie-Weiss extrapolation of 1/χ yields the paramagnetic Curie temperature θ ≥ Tc ([Petrovský & Kapička, 2006](https://doi.org/10.1029/2006JB004507)). The implementation attaches these caveats to its outputs.

## What's added

- `curie_temperature_estimates()` — main entry point: applies selected methods to the heating and cooling branches of a MagIC-formatted experiment and returns a tidy comparison table (one row per branch × method) with per-method caveat notes. A `data_type` parameter (`'susceptibility'`/`'magnetization'`, inferred from the column name by default) controls the default method set and caveats; `method_kwargs` keys are validated so typos raise rather than being silently ignored.
- Per-method estimators operating on plain temperature/magnetization arrays (so non-MagIC instrument exports can be analyzed directly):
  - `curie_derivative_estimates()` — inflection point and maximum-curvature estimates, with the curvature search restricted to the transition zone
  - `curie_two_tangent()` — intersecting tangents with auto or explicit windows; flags the case where no flat baseline exists (curve ending below Tc)
  - `curie_inverse_susceptibility()` — reproducible Curie-Weiss fit over a stated window with r², Curie constant, and propagated 1σ on θ; rejects non-positive slopes and warns when the window contains resolution-limited (repeated identical) susceptibility values, which bias θ low
  - `curie_landau_fit()` — fit of the in-field Landau equation of state m³ + τm = h (scipy-only; no new dependencies) with formal uncertainty; automatically flags Moskowitz (1981)-style extrapolation when data end below Tc, where the inflated uncertainty makes the non-identifiability explicit
- `landau_magnetization()` — closed-form (Cardano/trigonometric) solution of the Landau equation of state
- `plot_curie_estimates()` — multi-panel comparison figure (curve + per-method Tc lines + tangent/Landau constructions, derivative panel, 1/χ panel); consumes the same estimator results as the table (single computation, single source of truth)
- `interactive_curie_inverse_susceptibility()` — the draggable Bokeh Curie-Weiss fit, now a standalone `interactive_*` function
- `add_curie_estimates_to_specimens_table()` — writes `critical_temp` (in K) and `critical_temp_type` to a MagIC specimens table with the estimation method, branch, and uncertainty archived in `description`. Existing description content is preserved (dict literals updated, free text kept and appended to), and experiment matching is exact or colon-token based — never substring — so estimates cannot be written to the wrong specimen's rows.
- `prepare_thermomag_branches()` — shared preprocessing: branch splitting, optional holder correction, temperature-space smoothing, and duplicate-temperature averaging (repeated furnace-stabilization readings otherwise over-weight fits and produce zero-spacing derivatives).

## What's changed

- `split_warm_cool()` rewritten on numpy: filters non-finite rows, returns arrays, and handles cooling-only runs (the first point takes the direction of the first step instead of always being assigned to heating).
- `smooth_moving_avg()` no longer returns NaN when a tapered window degenerates to ≤2 points.
- `plot_X_T()` accepts Kelvin output, tolerates single-branch experiments, and averages duplicate temperatures before differencing (fixes inf/NaN derivative traces on real Kappabridge data).

## What's removed

- `estimate_curie_temperature()` (added in #776; no callers in this repo or in RockmagPy-notebooks). Its derivative-based estimates map onto the `inflection` and `max_curvature` methods of the new API. The legacy `ipmag.curie` second-derivative value corresponds to `max_curvature`: on `data_files/curie/curie_example.dat` with a 10-degree window, `ipmag.curie` gives 552°C and `max_curvature` gives 549°C (the small difference reflects the different smoothing kernels).

## Relationship to #856 / #802

This PR is complementary to the consolidation of rock magnetic analysis in `rockmag.py` (#856). Note that #856 currently rewrites `programs/curie.py` as a plot-only wrapper, dropping the CLI's quantitative Tc output; once this PR lands, `programs/curie.py` could wrap `curie_temperature_estimates()` (with `max_curvature` as the legacy-compatible default and a `--method` flag) to restore it.

## Testing

New `pmagpy/test/test_rockmag_curie.py` with 56 tests against synthetic curves with known analytical answers: exact recovery of Tc by the Landau fit and of θ by the Curie-Weiss fit; the documented bias ordering (two-tangent ≈ max curvature > inflection ≈ Tc) on in-field Landau curves; extrapolation-mode flagging and uncertainty inflation; resolution-limit detection; duplicate-temperature, heating-only, and holder-correction handling; MagIC specimens-table round-trips (Kelvin conversion, controlled vocabulary, description preservation, matching); and a regression lock against the legacy `ipmag.curie` value on `curie_example.dat`. Full suite: 452 passed.

Companion documentation (Jupyter Book notebook demonstrating all methods and caveats on Rock Magnetic Bestiary data, plus a written evaluation of the legacy Curie code) is in RockmagPy-notebooks.

## Notes for reviewers

- `remove_holder=True` (per-branch minimum subtraction) remains the default; the docstring documents that this assumes the run passes above Tc, and the notebooks demonstrate `remove_holder=False` for runs that end below it (e.g., MPMS M(T) curves).
- Derivative-based values differ slightly from legacy `ipmag.curie` by design (transition-zone restriction, interpolated zero crossings); see the mapping above.