### PR TITLE
Fix matplotlib warnings in ipmag.fishqq

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -2113,7 +2113,11 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
         Dtit = 'Mode 1 ' + dec_label
         Itit = 'Mode 1 ' + inc_label
         if plot:
-            plt.figure(fignum,figsize=(6, 3))
+            # clear any existing figure with this number so that the figure
+            # size is applied and stale axes do not break tight_layout
+            fig = plt.figure(fignum)
+            fig.clear()
+            fig.set_size_inches(6, 3)
             fignum+=1
         else:
             tmp_fig = plt.figure(figsize=(6, 3))
@@ -2163,7 +2167,9 @@ def fishqq(lon=None, lat=None, di_block=None,plot=True,save=False,fmt='png',save
         if ppars['inc']<0:
             Irbar=-ppars['inc']
         if plot:
-            plt.figure(fignum,figsize=(6, 3))
+            fig = plt.figure(fignum)
+            fig.clear()
+            fig.set_size_inches(6, 3)
         else:
             tmp_fig = plt.figure(figsize=(6, 3))
         Mu_r, Mu_rcr = pmagplotlib.plot_qq_unf(

--- a/pmagpy/test/test_ipmag_plotting.py
+++ b/pmagpy/test/test_ipmag_plotting.py
@@ -4,6 +4,7 @@ Tests for plotting and output formatting functions in ipmag.py.
 Covers plot_net / plot_di (stereographic projection plotting),
 fishqq (Fisher QQ plot), and igrf_print (IGRF output formatting).
 """
+import warnings
 from contextlib import redirect_stdout
 from io import StringIO
 
@@ -276,6 +277,30 @@ class TestFishqq:
         titles = [ax.get_title() for ax in plt.gcf().get_axes()]
         assert 'Mode 1 Declinations' in titles
         assert 'Mode 1 Inclinations' in titles
+        plt.close('all')
+
+    def test_no_warnings_with_existing_figure(self):
+        """fishqq issues no matplotlib warnings when figure 1 already exists
+        with an incompatible layout (issue #824)."""
+        directions = ipmag.fishrot(k=40, n=20, dec=200, inc=50,
+                                   random_seed=33).tolist()
+        stale_fig = plt.figure(1, figsize=(5, 5))
+        stale_fig.add_subplot(111)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            ipmag.fishqq(di_block=directions, plot=True, save=False)
+        plt.close('all')
+
+    def test_figure_size_applied_with_existing_figure(self):
+        """fishqq applies its 6x3 figure size even when the figure number
+        already exists at a different size (issue #824)."""
+        directions = ipmag.fishrot(k=40, n=20, dec=200, inc=50,
+                                   random_seed=33).tolist()
+        plt.figure(1, figsize=(5, 5))
+        ipmag.fishqq(di_block=directions, plot=True, save=False)
+        width, height = plt.figure(1).get_size_inches()
+        assert abs(width - 6) < 1e-6
+        assert abs(height - 3) < 1e-6
         plt.close('all')
 
 


### PR DESCRIPTION
Clear any existing figure before drawing QQ subplots so the figure size is applied and stale axes don't break tight_layout. Closes #824