### PR TITLE
develop merge_replicate_reversal_rows function

### DIFF
--- a/pmagpy/forc.py
+++ b/pmagpy/forc.py
@@ -2400,6 +2400,55 @@ def plot_forc_curves_hysteresis(
 # Phase 2: build grid + LOESS rho
 # ============================================================
 
+def merge_replicate_reversal_rows(
+    Ha_vals: np.ndarray,
+    M_grid: np.ndarray,
+    rel_tol: float = 0.25,
+) -> Tuple[np.ndarray, np.ndarray, int]:
+    """Average grid rows measured at repeated reversal fields.
+
+    Some measurement scripts end a FORC run with replicate curves at the
+    deepest reversal field. Repeated reversal fields would violate the
+    strictly increasing Ha axis the rho estimators require, so adjacent rows
+    whose reversal fields agree to within ``rel_tol`` of the median
+    reversal-field step are treated as replicates of one curve and combined
+    by a point-by-point mean that ignores missing values.
+
+    Args:
+        Ha_vals: Reversal fields of the rows in tesla, sorted ascending.
+        M_grid: Moment grid with one row per curve, aligned with Ha_vals.
+        rel_tol: Fraction of the median positive Ha step below which two
+            adjacent reversal fields count as the same curve.
+
+    Returns:
+        Tuple ``(Ha_merged, M_merged, n_replicates)`` where ``n_replicates``
+        is the number of rows that were folded into another row.
+    """
+    Ha = np.asarray(Ha_vals, dtype=np.float64)
+    M = np.asarray(M_grid, dtype=np.float64)
+    if Ha.size <= 1:
+        return Ha, M, 0
+
+    gaps = np.diff(Ha)
+    positive = gaps[gaps > 0]
+    tol = rel_tol * float(np.median(positive)) if positive.size else np.inf
+    group = np.concatenate([[0], np.cumsum(gaps > tol)])
+    n_groups = int(group[-1]) + 1
+    if n_groups == Ha.size:
+        return Ha, M, 0
+
+    Ha_merged = np.empty(n_groups, dtype=np.float64)
+    M_merged = np.full((n_groups, M.shape[1]), np.nan, dtype=np.float64)
+    for g in range(n_groups):
+        members = group == g
+        rows = M[members, :]
+        Ha_merged[g] = float(np.mean(Ha[members]))
+        counts = np.isfinite(rows).sum(axis=0)
+        sums = np.nansum(np.where(np.isfinite(rows), rows, 0.0), axis=0)
+        M_merged[g, :] = np.where(counts > 0, sums / np.maximum(counts, 1), np.nan)
+    return Ha_merged, M_merged, int(Ha.size - n_groups)
+
+
 def build_forc_grid(forcs: List[Segment], Hb_min=None, Hb_max=None, verbose: bool = True):
     """Build rectangular grid M(Ha,Hb). Returns Ha_vals, Hb_vals, M_grid, dHb, dHa."""
     good: List[Segment] = []
@@ -2454,13 +2503,6 @@ def build_forc_grid(forcs: List[Segment], Hb_min=None, Hb_max=None, verbose: boo
     Ha_vals = Ha_vals[order]
     good = [good[i] for i in order]
 
-    if len(Ha_vals) > 1:
-        dHa = float(np.median(np.diff(Ha_vals)))
-        if not np.isfinite(dHa) or dHa <= 0:
-            dHa = dHb
-    else:
-        dHa = dHb
-
     # Assigning each measurement to its nearest column is exact only when the
     # measured applied fields already lie on the common lattice. They do not
     # when the reversal-field increment is not a whole multiple of the
@@ -2491,7 +2533,19 @@ def build_forc_grid(forcs: List[Segment], Hb_min=None, Hb_max=None, verbose: boo
             row[(Hb_vals < Hf[0]) | (Hb_vals > Hf[-1]) | (Hb_vals < float(s.Ha))] = np.nan
             M_grid[i, :] = row
 
+    Ha_vals, M_grid, n_replicates = merge_replicate_reversal_rows(Ha_vals, M_grid)
+
+    if len(Ha_vals) > 1:
+        dHa = float(np.median(np.diff(Ha_vals)))
+        if not np.isfinite(dHa) or dHa <= 0:
+            dHa = dHb
+    else:
+        dHa = dHb
+
     if verbose:
+        if n_replicates:
+            print(f"Averaged {n_replicates} replicate curve(s) measured at "
+                  f"repeated reversal fields into their companions.")
         print(f"Inferred dHb ≈ {dHb:.6g} T, Hb: {Hb_vals[0]:.6g}→{Hb_vals[-1]:.6g} (n={len(Hb_vals)})")
         print(f"Inferred dHa ≈ {dHa:.6g} T, Ha: {Ha_vals[0]:.6g}→{Ha_vals[-1]:.6g} (n={len(Ha_vals)})")
         print(f"M_grid shape: {M_grid.shape}")
@@ -2584,6 +2638,12 @@ def build_forc_grid_regridded(
 
         Mi[~tri] = np.nan
         M_meas[i, :] = Mi
+
+    Ha_vals_meas, M_meas, n_replicates = merge_replicate_reversal_rows(
+        Ha_vals_meas, M_meas)
+    if verbose and n_replicates:
+        print(f"Averaged {n_replicates} replicate curve(s) measured at "
+              f"repeated reversal fields into their companions.")
 
     # infer Ha step if needed
     if Ha_step is None:

--- a/pmagpy/test/test_forc.py
+++ b/pmagpy/test/test_forc.py
@@ -36,7 +36,7 @@ def quadratic_grid(size=25):
 
 def write_micromag(path, n_forc=40, ha_min=-0.20, ha_max=0.02, h_max=0.25,
                    step=0.005, drift_amp=0.0, units="SI", eq_header=False,
-                   third_column=False, descending=True):
+                   third_column=False, descending=True, n_repeats_of_last_curve=0):
     """Write a synthetic MicroMag FORC export.
 
     Args:
@@ -52,6 +52,10 @@ def write_micromag(path, n_forc=40, ha_min=-0.20, ha_max=0.02, h_max=0.25,
         third_column: Append a temperature column to each data row.
         descending: Measure from the highest reversal field downwards, as
             MicroMag does.
+        n_repeats_of_last_curve: Number of times the final (deepest reversal
+            field) curve is measured again at the end of the run. The Lake
+            Shore 8600 FORC script does this, so a run can contain several
+            curves sharing one reversal field.
 
     Returns:
         The reversal fields written, in measurement order.
@@ -77,8 +81,10 @@ def write_micromag(path, n_forc=40, ha_min=-0.20, ha_max=0.02, h_max=0.25,
         lines += [sep("NData", 0), ""]
 
     Has = np.linspace(ha_max, ha_min, n_forc) if descending else np.linspace(ha_min, ha_max, n_forc)
+    if n_repeats_of_last_curve:
+        Has = np.concatenate([Has, np.full(n_repeats_of_last_curve, Has[-1])])
     for k, Ha in enumerate(Has):
-        drift = drift_amp * k / max(1, n_forc - 1)
+        drift = drift_amp * k / max(1, len(Has) - 1)
         cal_m = (1.0e-6 + drift) * ms
         tail = ",+2.947547E+02" if third_column else ""
         lines.append(f"{h_max * fs:.9g},{cal_m:.9g}{tail}")
@@ -251,6 +257,63 @@ def test_bc_and_bu_are_reported_in_the_rotated_literature_coordinates():
     # The upper triangle, where the applied field is below the reversal field,
     # is unphysical and carries negative Bc.
     assert Bc[2, 0] < 0
+
+
+# --------------------------------------------- replicate reversal curves
+
+def test_merge_replicate_reversal_rows_averages_nan_aware():
+    """Rows at a repeated Ha combine by a mean that ignores missing values."""
+    Ha = np.array([-0.02, -0.01, -0.01, 0.0])
+    M = np.array([
+        [1.0, 2.0, 3.0],
+        [2.0, np.nan, 4.0],
+        [4.0, np.nan, np.nan],
+        [5.0, 6.0, 7.0],
+    ])
+    Ha_merged, M_merged, n_replicates = forc.merge_replicate_reversal_rows(Ha, M)
+
+    assert n_replicates == 1
+    assert_allclose(Ha_merged, [-0.02, -0.01, 0.0])
+    assert_allclose(M_merged[0], M[0])
+    assert_allclose(M_merged[1], [3.0, np.nan, 4.0], equal_nan=True)
+    assert_allclose(M_merged[2], M[3])
+
+
+def test_merge_replicate_reversal_rows_leaves_distinct_curves_alone():
+    """Reversal fields a full step apart are not treated as replicates."""
+    Ha = np.array([-0.02, -0.01, 0.0])
+    M = np.arange(9, dtype=float).reshape(3, 3)
+    Ha_merged, M_merged, n_replicates = forc.merge_replicate_reversal_rows(Ha, M)
+
+    assert n_replicates == 0
+    assert_allclose(Ha_merged, Ha)
+    assert_allclose(M_merged, M)
+
+
+def test_repeated_final_curves_process_and_match_the_plain_run(tmp_path):
+    """A run whose last curve was measured repeatedly gives the same rho.
+
+    The Lake Shore 8600 FORC script re-measures the deepest-reversal-field
+    curve at the end of a run. Those repeats share one reversal field, which
+    violated the strictly increasing Ha axis and made processing fail; they
+    are now averaged into one grid row.
+    """
+    plain = tmp_path / "plain.txt"
+    replicated = tmp_path / "replicated.txt"
+    write_micromag(plain)
+    write_micromag(replicated, n_repeats_of_last_curve=2)
+
+    out_plain = forc.process_forc(mode="i", path=str(plain), plot_hyst=False,
+                                  plot_rho=False, verbose=False)
+    out_rep = forc.process_forc(mode="i", path=str(replicated), plot_hyst=False,
+                                plot_rho=False, verbose=False)
+
+    Ha = out_rep["Ha_vals_used"]
+    assert (np.diff(Ha) > 0).all()
+    assert Ha.size == out_plain["Ha_vals_used"].size
+    # The fixture's curves are noise-free, so averaging identical replicates
+    # must reproduce the plain run exactly.
+    assert_allclose(out_rep["rho"], out_plain["rho"], equal_nan=True)
 
 
 # ------------------------------------------------------- drift correction


### PR DESCRIPTION
This deals with the issue that Lakeshore routines can end a FORC run with replicate curves on the lower branch that need to be dealt with and averaged.

@maxwellbrown, I think that this approach to automatically take an average of the repeated lower branch measurements that are made on the Lakeshore makes sense. Let me know what you think. I want to test on some more Lakeshore files before merging in.
