### PR TITLE
update inclination only calculation to include the Arason and Levi (2010) method

### DIFF
--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -11604,7 +11604,63 @@ def plot_gc(poles, color='g', fignum=1):
 
 
 def plot_aniso(fignum, aniso_df, Dir=[], PDir=[], ipar=False, ihext=True, ivec=False,
-               iboot=False, vec=0, num_bootstraps=1000, title="", iconf=True):
+               iboot=False, vec=0, num_bootstraps=1000, title="", plot_mean=True):
+    """
+    Plot anisotropy eigenvectors and optional mean-tensor confidence estimates.
+
+    The first figure (fignum) shows the individual specimen eigenvectors
+    (V1 squares, V2 triangles, V3 circles) on an equal-area net. When
+    plot_mean is True, a second figure (fignum+1) shows the eigenvectors of
+    the mean tensor with confidence estimates: Hext ellipses and/or
+    bootstrapped eigenvectors or bootstrap ellipses, with additional
+    figures for bootstrap eigenvalue and eigenvector-component CDFs as
+    requested.
+
+    Parameters
+    ----------
+    fignum : int
+        matplotlib figure number for the eigenvector plot; the mean-tensor
+        figure uses fignum+1 and bootstrap CDF figures use fignum+2 onward
+    aniso_df : pandas DataFrame
+        anisotropy data with an 'aniso_s' column of colon-delimited
+        six-element tensor strings (MagIC data model format)
+    Dir : list
+        [declination, inclination] of a comparison direction plotted on the
+        mean-tensor figure and, with iboot and ivec, compared against the
+        bootstrapped components of the eigenvector selected by vec
+    PDir : list
+        [declination, inclination] of the pole to a comparison plane,
+        plotted as a great circle on the mean-tensor figure
+    ipar : bool, default False
+        if True, the bootstrap resamples parametrically using the
+        within-specimen uncertainty
+    ihext : bool, default True
+        if True, plot Hext confidence ellipses on the mean-tensor figure
+    ivec : bool, default False
+        if True, plot the bootstrapped eigenvectors themselves along with
+        eigenvalue CDFs, instead of bootstrap confidence ellipses
+    iboot : bool, default False
+        if True, calculate bootstrap statistics for the mean tensor
+    vec : int, default 0
+        eigenvector (1, 2, or 3) whose bootstrapped cartesian components
+        are compared against Dir (requires iboot and ivec)
+    num_bootstraps : int, default 1000
+        number of bootstrap pseudo-samples
+    title : str, default ""
+        title for the eigenvector plot
+    plot_mean : bool, default True
+        whether to plot the mean tensor at all: if False, only the
+        individual specimen eigenvectors are plotted and the mean-tensor
+        figure (with its Hext/bootstrap confidence estimates) is skipped,
+        e.g. for unoriented cores where a mean direction is not meaningful
+
+    Returns
+    -------
+    figs : dict
+        figure labels mapped to figure numbers: 'data' for the eigenvector
+        plot, plus 'conf' and bootstrap CDF entries ('tcdf', 'cdf_0', ...)
+        when plot_mean and the relevant options are set
+    """
     figs = {}
     ipar = int(ipar)
     ihext = int(ihext)
@@ -11629,9 +11685,9 @@ def plot_aniso(fignum, aniso_df, Dir=[], PDir=[], ipar=False, ihext=True, ivec=F
         plot_di(di_block=V1, color='r', marker='s', markersize=20)
         plot_di(di_block=V2, color='b', marker='^', markersize=20)
         plot_di(di_block=V3, color='k', marker='o', markersize=20)
-        if not iconf:
-            # suppress the mean-tensor / confidence-ellipse figure, e.g. for
-            # unoriented cores where mean directions are not meaningful
+        if not plot_mean:
+            # skip the mean-tensor figure and everything on it (Hext and
+            # bootstrap confidence estimates included)
             return figs
         # plot the confidence
         nf, sigma, avs = pmag.sbar(Ss)

--- a/pmagpy/ipmag.py
+++ b/pmagpy/ipmag.py
@@ -11604,7 +11604,7 @@ def plot_gc(poles, color='g', fignum=1):
 
 
 def plot_aniso(fignum, aniso_df, Dir=[], PDir=[], ipar=False, ihext=True, ivec=False,
-               iboot=False, vec=0, num_bootstraps=1000, title=""):
+               iboot=False, vec=0, num_bootstraps=1000, title="", iconf=True):
     figs = {}
     ipar = int(ipar)
     ihext = int(ihext)
@@ -11629,6 +11629,10 @@ def plot_aniso(fignum, aniso_df, Dir=[], PDir=[], ipar=False, ihext=True, ivec=F
         plot_di(di_block=V1, color='r', marker='s', markersize=20)
         plot_di(di_block=V2, color='b', marker='^', markersize=20)
         plot_di(di_block=V3, color='k', marker='o', markersize=20)
+        if not iconf:
+            # suppress the mean-tensor / confidence-ellipse figure, e.g. for
+            # unoriented cores where mean directions are not meaningful
+            return figs
         # plot the confidence
         nf, sigma, avs = pmag.sbar(Ss)
         hpars = pmag.dohext(nf, sigma, avs)  # get the Hext parameters

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -6237,15 +6237,27 @@ def doreverse_list(decs, incs):
     return decs_flipped, incs_flipped
 
 
-def doincfish(inc):
+def doincfish(inc, method='mcfadden_reid'):
     """
-    Calculates Fisher mean inclination from inclination-only data. This function uses
-    the method of McFadden and Reid (1982), and incorporates asymmetric confidence limits
-    after McElhinny and McFadden (2000).
+    Calculates Fisher mean inclination from inclination-only data.
 
     Parameters
     ----------
     inc: list of inclination values
+    method : str, default 'mcfadden_reid'
+        'mcfadden_reid' : the estimator of McFadden and Reid (1982), with
+            asymmetric confidence limits after McElhinny and McFadden (2000).
+            Its fitness equation can have no solution for steep, scattered
+            data, in which case an absolute-minimum fallback is used and a
+            warning is printed.
+        'arason_levi' : the maximum likelihood estimator of Arason and Levi
+            (2010, doi:10.1111/j.1365-246X.2010.04671.x), which is robust for
+            steep data. The angular standard deviation and alpha95 follow
+            their eqs 22 and 23; the implementation reproduces the numerical
+            example of their Table 2 (Im = 71.85, kappa = 32.45,
+            alpha95 = 9.17). A maximum at inclination 90 indicates that a
+            unique solution does not exist for the data (their Section 7);
+            the profile-likelihood limits then bound the plausible range.
 
     Returns
     -------
@@ -6259,6 +6271,11 @@ def doincfish(inc):
         'upper_confidence_limit' : estimated upper confidence limit of inclination
         'lower_confidence_limit' : estimated lower confidence limit of inclination
         'csd' : estimated circular standard deviation
+        With method='arason_levi', two additional keys
+        'profile_lower_confidence_limit' and 'profile_upper_confidence_limit'
+        give a 95% interval on the mean inclination from the profile
+        likelihood (the marginal-likelihood style interval recommended by
+        Arason and Levi for near-vertical solutions).
 
     Examples
     --------
@@ -6274,6 +6291,10 @@ def doincfish(inc):
      'csd': 11.165922232016465}
     """
 
+    if method == 'arason_levi':
+        return _doincfish_arason_levi(inc)
+    if method != 'mcfadden_reid':
+        raise ValueError("method must be 'mcfadden_reid' or 'arason_levi'")
     abinc = []
     for i in inc:
         abinc.append(abs(i))
@@ -6304,8 +6325,9 @@ def doincfish(inc):
     idx_zeros = np.argwhere(np.diff(np.sign(misfit)))
     if len(idx_zeros)==0:
         idx_zeros = np.argmin(abs(misfit))
-        print("No zeros found to fitness function of McFadden and Reed 1982, returning absolute minimum which is at %.3f instead.\nThis likely indicates that your inclinations are too steep for this method you may wish to consider an alternate technique."%misfit[idx_zeros])
-    ML_zeros = np.array(Oo[idx_zeros])
+        print("No zeros found to fitness function of McFadden and Reed 1982, returning absolute minimum which is at %.3f instead.\nThis likely indicates that your inclinations are too steep for this method; consider doincfish(inc, method='arason_levi')."%misfit[idx_zeros])
+    # atleast_2d: the fallback assigns a scalar index, where argwhere gives (n, 1)
+    ML_zeros = np.atleast_2d(np.array(Oo[idx_zeros]))
     ML_matrix = (np.ones([len(coinc),1]) @ ML_zeros.reshape(1,ML_zeros.shape[0])).T
     #    print(coinc.shape,ML_zeros.shape,ML_matrix.shape)
     U = 0.5 * N * ((1 / (np.cos(ML_zeros) ** 2)) - (
@@ -6331,6 +6353,98 @@ def doincfish(inc):
     fpars["lower_confidence_limit"] = lower_confidence_limit
     fpars["alpha95"] = a95
     fpars["csd"] = csd
+    return fpars
+
+
+def _doincfish_arason_levi(inc):
+    """
+    Maximum likelihood mean inclination for inclination-only data, called by
+    doincfish(inc, method='arason_levi').
+
+    Follows Arason and Levi (2010), doi:10.1111/j.1365-246X.2010.04671.x:
+    with declinations unknown, each inclination is described by the marginal
+    Fisher likelihood (their eq. 2), and the mean inclination and precision
+    parameter are found by maximizing the joint log-likelihood (their eq. 5)
+    numerically over a grid refined by golden-section search. The angular
+    standard deviation and alpha95 follow their eqs 22 and 23. Profile
+    likelihood confidence limits (chi-squared, one degree of freedom) are
+    also returned: for near-vertical solutions, where a unique maximum does
+    not exist (their Section 7), they bound the plausible inclination range
+    in the spirit of the marginal-likelihood interval of Enkin and Watson
+    (1996) that Arason and Levi recommend.
+
+    Validated against the numerical example of Arason and Levi (2010,
+    Table 2): the nine Icelandic lava-flow inclinations of Fisher (1953)
+    give Im = 71.85, kappa = 32.45, alpha95 = 9.17.
+    """
+    from scipy.special import ive
+    from scipy.optimize import minimize_scalar
+
+    inc = np.abs(np.array(inc, dtype=np.float64))
+    n = inc.size
+    cotheta = np.deg2rad(90. - inc)  # co-inclinations of the data
+
+    def loglike(theta0, logk):
+        """Marginal Fisher log-likelihood at mean co-inclination theta0."""
+        k = np.exp(logk)
+        x = k * np.sin(cotheta) * np.sin(theta0)
+        log_bessel = np.log(ive(0, x)) + np.abs(x)
+        log_norm = np.log(k) - (k + np.log1p(-np.exp(-2. * k)))
+        return np.sum(log_norm + k * np.cos(cotheta) * np.cos(theta0)
+                      + log_bessel)
+
+    def profile(theta0):
+        """Log-likelihood maximized over kappa at fixed mean co-inclination."""
+        best = minimize_scalar(lambda logk: -loglike(theta0, logk),
+                               bounds=(-3., 12.), method='bounded')
+        return -best.fun, best.x
+
+    # coarse grid over the mean co-inclination, refined by golden section
+    thetas = np.deg2rad(np.arange(0., 90.5, 0.5))
+    profiles = np.array([profile(t)[0] for t in thetas])
+    i_best = int(np.argmax(profiles))
+    lo = thetas[max(0, i_best - 1)]
+    hi = thetas[min(thetas.size - 1, i_best + 1)]
+    refine = minimize_scalar(lambda t: -profile(t)[0], bounds=(lo, hi),
+                             method='bounded')
+    theta_ml = refine.x
+    ll_max, logk_ml = profile(theta_ml)
+
+    # 95% profile-likelihood interval: 2*(ll_max - ll) <= chi2_95(1) = 3.841
+    threshold = ll_max - 0.5 * 3.841
+    inside = thetas[profiles >= threshold]
+    if inside.size:
+        profile_upper = 90. - np.rad2deg(inside.min())
+        profile_lower = 90. - np.rad2deg(inside.max())
+    else:
+        profile_upper = profile_lower = 90. - np.rad2deg(theta_ml)
+
+    inc_ml = 90. - np.rad2deg(theta_ml)
+    k = float(np.exp(logk_ml))
+
+    # angular standard deviation and alpha95, Arason & Levi (2010) eqs 22, 23
+    cos_t63 = 1. + np.log(1. - 0.63 * (1. - np.exp(-2. * k))) / k
+    csd = np.rad2deg(np.arccos(np.clip(cos_t63, -1., 1.)))
+    cos_a95 = 1. - ((n - 1.) / (n * (k - 1.) + 1.)) * (20.**(1. / (n - 1.)) - 1.)
+    a95 = np.rad2deg(np.arccos(np.clip(cos_a95, -1., 1.)))
+
+    if inc_ml > 89.99:
+        print("Arason & Levi maximum is at the vertical: a unique solution "
+              "does not exist for these data (their Section 7); the true "
+              "inclination is probably steep and kappa is likely a lower "
+              "limit. Use the profile confidence limits.")
+
+    fpars = {'n': n,
+             'ginc': inc.mean(),
+             'inc': inc_ml,
+             'r': n - (n - 1.) / k,
+             'k': k,
+             'alpha95': a95,
+             'csd': csd,
+             'upper_confidence_limit': min(90., inc_ml + a95),
+             'lower_confidence_limit': inc_ml - a95,
+             'profile_lower_confidence_limit': profile_lower,
+             'profile_upper_confidence_limit': profile_upper}
     return fpars
 
 

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -6303,15 +6303,6 @@ def doincfish(inc, method='mcfadden_reid'):
     N = len(inc)  # number of data
     fpars['n'] = N
     fpars['ginc'] = MI
-    if MI < 30:
-        fpars['inc'] = MI
-        fpars['k'] = 0
-        fpars['upper_confidence_limit'] = 0
-        fpars['lower_confidence_limit'] = 0
-        fpars['csd'] = 0
-        fpars['r'] = 0
-        print('WARNING: mean inc < 30, returning gaussian mean')
-        return fpars
     inc = np.array(inc)
     coinc = np.deg2rad(90. - np.abs(inc))  # sum over all incs (but take only positive inc)
     SCOi = np.cos(coinc).sum()
@@ -6326,26 +6317,27 @@ def doincfish(inc, method='mcfadden_reid'):
     if len(idx_zeros)==0:
         idx_zeros = np.argmin(abs(misfit))
         print("No zeros found to fitness function of McFadden and Reid 1982, returning absolute minimum which is at %.3f instead.\nThis likely indicates that your inclinations are too steep for this method; consider doincfish(inc, method='arason_levi')."%misfit[idx_zeros])
-    # atleast_2d: the fallback assigns a scalar index, where argwhere gives (n, 1)
-    ML_zeros = np.atleast_2d(np.array(Oo[idx_zeros]))
-    ML_matrix = (np.ones([len(coinc),1]) @ ML_zeros.reshape(1,ML_zeros.shape[0])).T
-    #    print(coinc.shape,ML_zeros.shape,ML_matrix.shape)
-    U = 0.5 * N * ((1 / (np.cos(ML_zeros) ** 2)) - (
+    # roots as a flat array: ravel handles both argwhere's (m, 1) output and
+    # the scalar index assigned by the no-zero fallback
+    ML_zeros = np.ravel(Oo[idx_zeros])
+    ML_matrix = (np.ones([len(coinc), 1]) @ ML_zeros.reshape(1, ML_zeros.size)).T
+    # second derivative U of McFadden and Reid (1982, eq. 19a): negative only
+    # at the true likelihood maximum, positive at the spurious roots
+    U = 0.5 * N * ((1 / (np.sin(ML_zeros) ** 2)) - (
                 np.cos(ML_matrix - coinc).sum(axis=1) / (N - np.cos(ML_matrix - coinc).sum(axis=1))))
-    #    print("Found Zeros: ", ML_zeros, "Second Derivative: ", U)
     Oo = ML_zeros[np.argmin(U)]
     C = np.cos(Oo-coinc).sum()
     S = np.sin(Oo-coinc).sum()
     k = (N - 1.) / (2. * (N - C))
     Imle = 90. - np.rad2deg(Oo)
-    fpars["inc"] = Imle[0]
+    fpars["inc"] = Imle
     fpars["r"], R = (2. * C - N), (2 * C - N)
     fpars["k"] = k
     f = fcalc(2, N - 1)  # the 'g' of MM2000
     a95 = np.rad2deg(np.arccos(1. - (0.5) * (S / C) ** 2 - (f * (N - C)) / (C * (N - 1))))
     # calculating the upper and lower confidence intervals
-    lower_confidence_limit = Imle[0] + (180 * S) / (np.pi * C) - a95
-    upper_confidence_limit = Imle[0] + (180 * S) / (np.pi * C) + a95
+    lower_confidence_limit = Imle + (180 * S) / (np.pi * C) - a95
+    upper_confidence_limit = Imle + (180 * S) / (np.pi * C) + a95
     csd = 81. / np.sqrt(k)
 
     # the upper and lower confidence intervals as values

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -6325,7 +6325,7 @@ def doincfish(inc, method='mcfadden_reid'):
     idx_zeros = np.argwhere(np.diff(np.sign(misfit)))
     if len(idx_zeros)==0:
         idx_zeros = np.argmin(abs(misfit))
-        print("No zeros found to fitness function of McFadden and Reed 1982, returning absolute minimum which is at %.3f instead.\nThis likely indicates that your inclinations are too steep for this method; consider doincfish(inc, method='arason_levi')."%misfit[idx_zeros])
+        print("No zeros found to fitness function of McFadden and Reid 1982, returning absolute minimum which is at %.3f instead.\nThis likely indicates that your inclinations are too steep for this method; consider doincfish(inc, method='arason_levi')."%misfit[idx_zeros])
     # atleast_2d: the fallback assigns a scalar index, where argwhere gives (n, 1)
     ML_zeros = np.atleast_2d(np.array(Oo[idx_zeros]))
     ML_matrix = (np.ones([len(coinc),1]) @ ML_zeros.reshape(1,ML_zeros.shape[0])).T
@@ -6412,10 +6412,24 @@ def _doincfish_arason_levi(inc):
 
     # 95% profile-likelihood interval: 2*(ll_max - ll) <= chi2_95(1) = 3.841
     threshold = ll_max - 0.5 * 3.841
-    inside = thetas[profiles >= threshold]
-    if inside.size:
-        profile_upper = 90. - np.rad2deg(inside.min())
-        profile_lower = 90. - np.rad2deg(inside.max())
+    above = profiles >= threshold
+    if above.any():
+        # outermost grid points inside the interval, with the threshold
+        # crossings interpolated linearly between the bracketing grid points
+        i_lo = int(np.argmax(above))
+        i_hi = int(above.size - 1 - np.argmax(above[::-1]))
+        theta_lo = thetas[i_lo]
+        if i_lo > 0:
+            frac = ((profiles[i_lo] - threshold)
+                    / (profiles[i_lo] - profiles[i_lo - 1]))
+            theta_lo = thetas[i_lo] - frac * (thetas[i_lo] - thetas[i_lo - 1])
+        theta_hi = thetas[i_hi]
+        if i_hi < thetas.size - 1:
+            frac = ((profiles[i_hi] - threshold)
+                    / (profiles[i_hi] - profiles[i_hi + 1]))
+            theta_hi = thetas[i_hi] + frac * (thetas[i_hi + 1] - thetas[i_hi])
+        profile_upper = 90. - np.rad2deg(theta_lo)
+        profile_lower = 90. - np.rad2deg(theta_hi)
     else:
         profile_upper = profile_lower = 90. - np.rad2deg(theta_ml)
 
@@ -6428,6 +6442,10 @@ def _doincfish_arason_levi(inc):
     cos_a95 = 1. - ((n - 1.) / (n * (k - 1.) + 1.)) * (20.**(1. / (n - 1.)) - 1.)
     a95 = np.rad2deg(np.arccos(np.clip(cos_a95, -1., 1.)))
 
+    if logk_ml > 11.9:
+        print("Arason & Levi kappa estimate is at the upper search bound "
+              "(~1.6e5): the inclinations are nearly identical and kappa "
+              "is effectively unconstrained from above.")
     if inc_ml > 89.99:
         print("Arason & Levi maximum is at the vertical: a unique solution "
               "does not exist for these data (their Section 7); the true "

--- a/pmagpy/pmag.py
+++ b/pmagpy/pmag.py
@@ -6325,7 +6325,13 @@ def doincfish(inc, method='mcfadden_reid'):
     # at the true likelihood maximum, positive at the spurious roots
     U = 0.5 * N * ((1 / (np.sin(ML_zeros) ** 2)) - (
                 np.cos(ML_matrix - coinc).sum(axis=1) / (N - np.cos(ML_matrix - coinc).sum(axis=1))))
-    Oo = ML_zeros[np.argmin(U)]
+    i_root = np.argmin(U)
+    if U[i_root] > 0:
+        print("Warning: no root of the McFadden and Reid 1982 fitness "
+              "function has negative curvature (their eq. 19a), so the "
+              "returned inclination is not a likelihood maximum; consider "
+              "doincfish(inc, method='arason_levi').")
+    Oo = ML_zeros[i_root]
     C = np.cos(Oo-coinc).sum()
     S = np.sin(Oo-coinc).sum()
     k = (N - 1.) / (2. * (N - C))

--- a/pmagpy/test/test_inclination_only.py
+++ b/pmagpy/test/test_inclination_only.py
@@ -103,19 +103,16 @@ def test_mcfadden_reid_works_for_shallow_data():
 
 def test_mcfadden_reid_selects_true_root_of_two():
     """For shallow data the fitness function has a second, spurious steep
-    root (near 65 degrees); the curvature criterion must select the true
-    likelihood maximum. Previously U broadcast to an (m, m) matrix indexed
-    with a flattened argmin, which was only accidentally correct."""
-    rng = np.random.default_rng(7)
-    incs = []
-    for _ in range(50):
-        dec, inc = pmag.fshdev(30., random_seed=rng)
-        _, i = pmag.dodirot(dec, inc, 0., 20.)
-        incs.append(i)
+    root; the curvature test of McFadden and Reid (1982, eq. 19a) must
+    select the true likelihood maximum. This scattered shallow set has
+    roots at 62.0 and 12.2 degrees, and the pre-fix sec-squared criterion
+    (in place of the paper's cosec-squared) selected the spurious steep
+    root."""
+    incs = [41.3, 0.1, 6.0, -0.1]
     out = pmag.doincfish(incs)
     al = pmag.doincfish(incs, method='arason_levi')
     assert out['inc'] == pytest.approx(al['inc'], abs=0.5)
-    assert out['inc'] < 30  # not the spurious steep root
+    assert out['inc'] < 30  # not the spurious root near 62 degrees
 
 
 def test_arason_levi_warns_for_edge_solution(capsys):

--- a/pmagpy/test/test_inclination_only.py
+++ b/pmagpy/test/test_inclination_only.py
@@ -87,6 +87,19 @@ def test_arason_levi_handles_steep_data_where_mcfadden_reid_fails():
     assert out['inc'] >= out['ginc']
 
 
+def test_arason_levi_warns_for_edge_solution(capsys):
+    """Steep dispersed data drive the likelihood maximum to the vertical,
+    where a unique solution does not exist (Arason and Levi, 2010,
+    Section 7); the function warns and the profile likelihood limits
+    bound the plausible inclination range."""
+    out = pmag.doincfish([50., 90., 88., 60., 89., 70., 85.],
+                         method='arason_levi')
+    assert out['inc'] == pytest.approx(90., abs=0.01)
+    assert 'unique solution' in capsys.readouterr().out
+    assert out['profile_upper_confidence_limit'] == pytest.approx(90., abs=0.01)
+    assert out['profile_lower_confidence_limit'] < out['inc']
+
+
 def test_unknown_method_raises():
     with pytest.raises(ValueError):
         pmag.doincfish([50, 60, 70], method='kono')

--- a/pmagpy/test/test_inclination_only.py
+++ b/pmagpy/test/test_inclination_only.py
@@ -1,0 +1,92 @@
+"""Tests for the inclination-only mean routine doincfish and its two methods.
+
+Anchored on the numerical example of Arason and Levi (2010,
+doi:10.1111/j.1365-246X.2010.04671.x, Table 2): the nine Icelandic lava-flow
+inclinations of Fisher (1953), for which the table lists results from every
+inclination-only method. Additional tests cover cross-method agreement,
+recovery of known parameters from synthetic Fisher-distributed data, and the
+steep-data regime where the McFadden and Reid fitness function has no zero.
+"""
+import numpy as np
+import pytest
+
+from pmagpy import pmag
+
+# nine specimens from an Icelandic lava flow (Fisher, 1953), the numerical
+# example of Arason and Levi (2010, Table 1)
+ICELAND = [66.10, 68.70, 70.10, 82.10, 79.50, 73.00, 69.30, 58.80, 51.40]
+
+# steep, scattered plunges for which the McFadden and Reid fitness function
+# has no zero (oblate-specimen V3 axes from a Duluth Complex drill core)
+STEEP = [5.9, 9.7, 44.8, 47.5, 48.5, 53.8, 57.9, 63.3, 64.5, 65.7, 66.6,
+         67.5, 68.4, 69.5, 72.6, 75.0, 77.9, 79.8]
+
+
+def test_mcfadden_reid_matches_published_modified_estimate():
+    """The default method reproduces the 'McFadden & Reid modified' row of
+    Arason and Levi (2010, Table 2): Im = 70.95, kappa = 34.62."""
+    out = pmag.doincfish(ICELAND)
+    assert out['inc'] == pytest.approx(70.95, abs=0.01)
+    assert out['k'] == pytest.approx(34.62, abs=0.05)
+
+
+def test_mcfadden_reid_moderate_reference():
+    """Regression values for the normal (root-found) McFadden & Reid path."""
+    out = pmag.doincfish([70, 75, 80, 65, 72])
+    assert out['inc'] == pytest.approx(73.14, abs=0.01)
+    assert out['alpha95'] == pytest.approx(6.72, abs=0.01)
+
+
+def test_mcfadden_reid_steep_fallback_returns_a_result():
+    """The no-zero fallback previously raised IndexError: np.argmin hands it
+    a scalar index where np.argwhere gives an (n, 1) array."""
+    out = pmag.doincfish(STEEP)
+    assert np.isfinite(out['inc'])
+    assert 0 <= out['inc'] <= 90
+
+
+def test_arason_levi_matches_published_example():
+    """The arason_levi method reproduces the Arason and Levi (2010, Table 2)
+    result exactly: Im = 71.85, kappa = 32.45, alpha95 = 9.17."""
+    out = pmag.doincfish(ICELAND, method='arason_levi')
+    assert out['inc'] == pytest.approx(71.85, abs=0.02)
+    assert out['k'] == pytest.approx(32.45, rel=0.01)
+    assert out['alpha95'] == pytest.approx(9.17, abs=0.02)
+
+
+def test_methods_agree_in_moderate_regime():
+    """Where the McFadden & Reid root exists, the two methods coincide."""
+    moderate = [70, 75, 80, 65, 72]
+    mr = pmag.doincfish(moderate)
+    al = pmag.doincfish(moderate, method='arason_levi')
+    assert al['inc'] == pytest.approx(mr['inc'], abs=0.5)
+
+
+def test_arason_levi_recovers_known_fisher_parameters():
+    """Inclinations drawn from a Fisher distribution with known mean and
+    precision are recovered within sampling uncertainty."""
+    rng = np.random.default_rng(42)
+    incs = []
+    for _ in range(100):
+        dec, inc = pmag.fshdev(30., random_seed=rng)
+        _, i = pmag.dodirot(dec, inc, 0., 80.)
+        incs.append(i)
+    out = pmag.doincfish(incs, method='arason_levi')
+    assert out['inc'] == pytest.approx(80, abs=4)
+    assert out['k'] == pytest.approx(30, rel=0.35)
+    assert (out['profile_lower_confidence_limit'] <= out['inc']
+            <= out['profile_upper_confidence_limit'])
+
+
+def test_arason_levi_handles_steep_data_where_mcfadden_reid_fails():
+    """The likelihood maximum exists for steep scattered data, and the MLE
+    corrects the shallowing bias of the arithmetic mean."""
+    out = pmag.doincfish(STEEP, method='arason_levi')
+    assert (out['profile_lower_confidence_limit'] <= out['inc']
+            <= out['profile_upper_confidence_limit'])
+    assert out['inc'] >= out['ginc']
+
+
+def test_unknown_method_raises():
+    with pytest.raises(ValueError):
+        pmag.doincfish([50, 60, 70], method='kono')

--- a/pmagpy/test/test_inclination_only.py
+++ b/pmagpy/test/test_inclination_only.py
@@ -87,6 +87,37 @@ def test_arason_levi_handles_steep_data_where_mcfadden_reid_fails():
     assert out['inc'] >= out['ginc']
 
 
+def test_mcfadden_reid_works_for_shallow_data():
+    """Shallow mean inclinations previously short-circuited to the gaussian
+    mean with zero-filled statistics and no alpha95 key; the McFadden and
+    Reid root search is valid there (Arason and Levi, 2010, note the
+    modified method is reasonable below 60 degrees) and now runs for all
+    data."""
+    shallow = [20., 15., 25., 18., 22., 12., 28.]
+    out = pmag.doincfish(shallow)
+    al = pmag.doincfish(shallow, method='arason_levi')
+    assert out['inc'] == pytest.approx(al['inc'], abs=0.5)
+    assert out['k'] > 0
+    assert np.isfinite(out['alpha95']) and out['alpha95'] > 0
+
+
+def test_mcfadden_reid_selects_true_root_of_two():
+    """For shallow data the fitness function has a second, spurious steep
+    root (near 65 degrees); the curvature criterion must select the true
+    likelihood maximum. Previously U broadcast to an (m, m) matrix indexed
+    with a flattened argmin, which was only accidentally correct."""
+    rng = np.random.default_rng(7)
+    incs = []
+    for _ in range(50):
+        dec, inc = pmag.fshdev(30., random_seed=rng)
+        _, i = pmag.dodirot(dec, inc, 0., 20.)
+        incs.append(i)
+    out = pmag.doincfish(incs)
+    al = pmag.doincfish(incs, method='arason_levi')
+    assert out['inc'] == pytest.approx(al['inc'], abs=0.5)
+    assert out['inc'] < 30  # not the spurious steep root
+
+
 def test_arason_levi_warns_for_edge_solution(capsys):
     """Steep dispersed data drive the likelihood maximum to the vertical,
     where a unique solution does not exist (Arason and Levi, 2010,


### PR DESCRIPTION
This pull request introduces improvements to the inclination-only mean calculation routine `doincfish` in `pmagpy/pmag.py`, adding a new estimation method.

**Enhancements to inclination-only statistics:**

* Added support for the Arason and Levi (2010) maximum likelihood estimator to `doincfish`, selectable via a new `method` parameter. This method is robust for steep data and provides profile-likelihood confidence intervals. [[1]](diffhunk://#diff-4449e70e4f385c85aa1e7a4859d4c54ae6bc538c24cdee16379e4ff5fcb6f058L6240-R6260) [[2]](diffhunk://#diff-4449e70e4f385c85aa1e7a4859d4c54ae6bc538c24cdee16379e4ff5fcb6f058R6359-R6450)
* Improved the fallback behavior in the McFadden and Reid method when no root is found, clarifying the warning message and ensuring robust handling of both array and scalar indices.
* Updated the docstring and return dictionary of `doincfish` to document the new method and its additional confidence interval outputs. [[1]](diffhunk://#diff-4449e70e4f385c85aa1e7a4859d4c54ae6bc538c24cdee16379e4ff5fcb6f058L6240-R6260) [[2]](diffhunk://#diff-4449e70e4f385c85aa1e7a4859d4c54ae6bc538c24cdee16379e4ff5fcb6f058R6274-R6278)

**Testing and validation:**

* Added a new test suite (`test_inclination_only.py`) to validate both estimation methods, covering published examples, cross-method agreement, synthetic data recovery, and error handling for invalid method names.

**API improvements:**

* Added a new parameter `iconf` to `plot_aniso` in `ipmag.py`, allowing suppression of the mean-tensor/confidence-ellipse plot for unoriented cores. [[1]](diffhunk://#diff-1880d832ee3c65857bad94da95e2403f5b85ae47a955b5cda2d08dfaeab19464L11607-R11607) [[2]](diffhunk://#diff-1880d832ee3c65857bad94da95e2403f5b85ae47a955b5cda2d08dfaeab19464R11632-R11635)