### PR TITLE
Versioning issue pmagpy vs pmagpy-cli

### DIFF
--- a/command_line_setup.py
+++ b/command_line_setup.py
@@ -2,8 +2,7 @@ from setuptools import setup, find_packages
 from pmagpy import version
 from programs_list import programs_list
 
-version_num = version.version.strip('pmagpy-')
-shared_version_requirement = f'pmagpy=={version_num}'
+version_num = version.version.removeprefix('pmagpy-')
 
 # skip the html header at the top of README.md
 with open('README.md', encoding='utf-8') as f:

--- a/command_line_setup.py
+++ b/command_line_setup.py
@@ -3,6 +3,7 @@ from pmagpy import version
 from programs_list import programs_list
 
 version_num = version.version.strip('pmagpy-')
+shared_version_requirement = f'pmagpy=={version_num}'
 
 # skip the html header at the top of README.md
 with open('README.md', encoding='utf-8') as f:
@@ -36,7 +37,7 @@ setup(
     python_requires='>=3.9',
 
     install_requires=[
-        'pmagpy',
+        shared_version_requirement,
         'wxPython',
         'PyQt5',
         'lmfit',

--- a/command_line_setup.py
+++ b/command_line_setup.py
@@ -3,6 +3,7 @@ from pmagpy import version
 from programs_list import programs_list
 
 version_num = version.version.removeprefix('pmagpy-')
+shared_version_requirement = f'pmagpy=={version_num}'
 
 # skip the html header at the top of README.md
 with open('README.md', encoding='utf-8') as f:

--- a/pmagpy/test/test_packaging.py
+++ b/pmagpy/test/test_packaging.py
@@ -12,12 +12,9 @@ def test_cli_package_requires_matching_pmagpy_version():
     assert version_value is not None, 'Could not determine shared version string'
 
     version_num = version_value.group(1).removeprefix('pmagpy-')
-    assert f"shared_version_requirement = f'pmagpy=={{version_num}}'" in setup_text, (
+    assert re.search(r"shared_version_requirement\s*=\s*f['\"]pmagpy==\{version_num\}['\"]", setup_text), (
         'pmagpy-cli should build an exact pmagpy version pin from the shared version string'
     )
     assert "shared_version_requirement," in setup_text, (
         'pmagpy-cli should include the computed pmagpy version pin in install_requires'
-    )
-    assert f"pmagpy=={version_num}" in setup_text, (
-        'pmagpy-cli should require the same version of pmagpy as the shared version string'
     )

--- a/pmagpy/test/test_packaging.py
+++ b/pmagpy/test/test_packaging.py
@@ -1,13 +1,18 @@
 import pathlib
 import re
+import pytest
 
 
 def test_cli_package_requires_matching_pmagpy_version():
     repo_root = pathlib.Path(__file__).resolve().parents[2]
 
-    setup_text = (repo_root / 'command_line_setup.py').read_text(encoding='utf-8')
-    version_text = (repo_root / 'pmagpy' / 'version.py').read_text(encoding='utf-8')
 
+    setup_path = repo_root / 'command_line_setup.py'
+    if not setup_path.exists():
+        pytest.skip('command_line_setup.py not found, test requires a source checkout')
+
+    setup_text = setup_path.read_text(encoding='utf-8')
+    version_text = (repo_root / 'pmagpy' / 'version.py').read_text(encoding='utf-8')
     version_value = re.search(r"version\s*=\s*['\"](pmagpy-[^'\"]+)['\"]", version_text)
     assert version_value is not None, 'Could not determine shared version string'
 

--- a/pmagpy/test/test_packaging.py
+++ b/pmagpy/test/test_packaging.py
@@ -1,0 +1,23 @@
+import pathlib
+import re
+
+
+def test_cli_package_requires_matching_pmagpy_version():
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+
+    setup_text = (repo_root / 'command_line_setup.py').read_text(encoding='utf-8')
+    version_text = (repo_root / 'pmagpy' / 'version.py').read_text(encoding='utf-8')
+
+    version_value = re.search(r"version\s*=\s*['\"](pmagpy-[^'\"]+)['\"]", version_text)
+    assert version_value is not None, 'Could not determine shared version string'
+
+    version_num = version_value.group(1).removeprefix('pmagpy-')
+    assert f"shared_version_requirement = f'pmagpy=={{version_num}}'" in setup_text, (
+        'pmagpy-cli should build an exact pmagpy version pin from the shared version string'
+    )
+    assert "shared_version_requirement," in setup_text, (
+        'pmagpy-cli should include the computed pmagpy version pin in install_requires'
+    )
+    assert f"pmagpy=={version_num}" in setup_text, (
+        'pmagpy-cli should require the same version of pmagpy as the shared version string'
+    )


### PR DESCRIPTION
# Summary
This PR fixes a packaging/versioning issue that leaves pmagpy-cli and pmagpy out of sync during installation. This, I believe, is what is causing the whack-a-mole problems in #769. The CLI package previously depended on pmagpy without pinning the exact matching version, which allowed pip to resolve a different compatible release and could lead to environments where the GUI/CLI entry points and the installed core library no longer matched. I spend some time running this through Copilot and here is what was come up with.

## What changed
- pmagpy-cli now requires the exact matching pmagpy version derived from the shared version string.

- A regression test was added to ensure this dependency contract remains in place.

## Steps to make the fix effective
To actually resolve the issue for users, pmagpy-cli needs to be re-released with this updated packaging metadata. In practice, the release flow should be:

- Publish or update pmagpy with the intended version.
- Publish pmagpy-cli from the same code state with the matching version pin.
- Ensure the two packages are released in sync so pip installs resolve the correct compatible pair.

## How to avoid this in the future
To prevent this from happening again, the release process should treat pmagpy and pmagpy-cli as coupled packages:

- release them together from the same tag or release commit,
- keep the versioning scheme aligned,
- and avoid loose dependency relationships between them.

## Long-term recommendation
The longer-term goal should be to simplify the packaging model by consolidating the core library and GUI/CLI entry points into a single installable package. If the split must remain, pmagpy-cli should continue to function as a thin wrapper released in lockstep with pmagpy and pinned to the exact matching version.