### PR TITLE
Defunct scipy replacement

### DIFF
--- a/pmagpy/convert_2_magic.py
+++ b/pmagpy/convert_2_magic.py
@@ -6,9 +6,7 @@ from functools import reduce
 import math
 import os
 import sys
-
 import pytz
-import scipy
 import numpy as np
 import pandas as pd
 import pmagpy.pmag as pmag
@@ -2133,10 +2131,10 @@ def generic(magfile="", dir_path=".", meas_file="measurements.txt",
                     cart_t = pmag.dir2cart([dec_t, inc_t, moment])
                     carts_t.append(cart_t)
         if len(carts_s) > 0:
-            carts = scipy.array(carts_s)
-            x_mean = scipy.mean(carts[:, 0])
-            y_mean = scipy.mean(carts[:, 1])
-            z_mean = scipy.mean(carts[:, 2])
+            carts = np.array(carts_s)
+            x_mean = np.mean(carts[:, 0])
+            y_mean = np.mean(carts[:, 1])
+            z_mean = np.mean(carts[:, 2])
             mean_dir = pmag.cart2dir([x_mean, y_mean, z_mean])
             mean_dec_s = "%.2f" % mean_dir[0]
             mean_inc_s = "%.2f" % mean_dir[1]
@@ -2144,10 +2142,10 @@ def generic(magfile="", dir_path=".", meas_file="measurements.txt",
         else:
             mean_dec_s, mean_inc_s = "", ""
         if len(carts_g) > 0:
-            carts = scipy.array(carts_g)
-            x_mean = scipy.mean(carts[:, 0])
-            y_mean = scipy.mean(carts[:, 1])
-            z_mean = scipy.mean(carts[:, 2])
+            carts = np.array(carts_g)
+            x_mean = np.mean(carts[:, 0])
+            y_mean = np.mean(carts[:, 1])
+            z_mean = np.mean(carts[:, 2])
             mean_dir = pmag.cart2dir([x_mean, y_mean, z_mean])
             mean_dec_g = "%.2f" % mean_dir[0]
             mean_inc_g = "%.2f" % mean_dir[1]
@@ -2156,10 +2154,10 @@ def generic(magfile="", dir_path=".", meas_file="measurements.txt",
             mean_dec_g, mean_inc_g = "", ""
 
         if len(carts_t) > 0:
-            carts = scipy.array(carts_t)
-            x_mean = scipy.mean(carts[:, 0])
-            y_mean = scipy.mean(carts[:, 1])
-            z_mean = scipy.mean(carts[:, 2])
+            carts = np.array(carts_t)
+            x_mean = np.mean(carts[:, 0])
+            y_mean = np.mean(carts[:, 1])
+            z_mean = np.mean(carts[:, 2])
             mean_dir = pmag.cart2dir([x_mean, y_mean, z_mean])
             mean_dec_t = "%.2f" % mean_dir[0]
             mean_inc_t = "%.2f" % mean_dir[1]

--- a/programs/conversion_scripts2/generic_magic2.py
+++ b/programs/conversion_scripts2/generic_magic2.py
@@ -2,9 +2,9 @@
 from builtins import str
 from builtins import range
 import sys
-import scipy
 import copy
 import os
+import numpy as np
 from pmagpy import pmag
 
 def main(command_line=True, **kwargs):
@@ -302,10 +302,10 @@ def main(command_line=True, **kwargs):
                     cart_t=pmag.dir2cart([dec_t,inc_t,moment])
                     carts_t.append(cart_t)
         if len(carts_s)>0:
-            carts=scipy.array(carts_s)
-            x_mean=scipy.mean(carts[:,0])
-            y_mean=scipy.mean(carts[:,1])
-            z_mean=scipy.mean(carts[:,2])
+            carts=np.array(carts_s)
+            x_mean=np.mean(carts[:,0])
+            y_mean=np.mean(carts[:,1])
+            z_mean=np.mean(carts[:,2])
             mean_dir=pmag.cart2dir([x_mean,y_mean,z_mean])
             mean_dec_s="%.2f"%mean_dir[0]
             mean_inc_s="%.2f"%mean_dir[1]
@@ -313,10 +313,10 @@ def main(command_line=True, **kwargs):
         else:
             mean_dec_s,mean_inc_s="",""
         if len(carts_g)>0:
-            carts=scipy.array(carts_g)
-            x_mean=scipy.mean(carts[:,0])
-            y_mean=scipy.mean(carts[:,1])
-            z_mean=scipy.mean(carts[:,2])
+            carts=np.array(carts_g)
+            x_mean=np.mean(carts[:,0])
+            y_mean=np.mean(carts[:,1])
+            z_mean=np.mean(carts[:,2])
             mean_dir=pmag.cart2dir([x_mean,y_mean,z_mean])
             mean_dec_g="%.2f"%mean_dir[0]
             mean_inc_g="%.2f"%mean_dir[1]
@@ -325,10 +325,10 @@ def main(command_line=True, **kwargs):
             mean_dec_g,mean_inc_g="",""
 
         if len(carts_t)>0:
-            carts=scipy.array(carts_t)
-            x_mean=scipy.mean(carts[:,0])
-            y_mean=scipy.mean(carts[:,1])
-            z_mean=scipy.mean(carts[:,2])
+            carts=np.array(carts_t)
+            x_mean=np.mean(carts[:,0])
+            y_mean=np.mean(carts[:,1])
+            z_mean=np.mean(carts[:,2])
             mean_dir=pmag.cart2dir([x_mean,y_mean,z_mean])
             mean_dec_t="%.2f"%mean_dir[0]
             mean_inc_t="%.2f"%mean_dir[1]


### PR DESCRIPTION
The functions `scipy.mean` and `scipy.array` have been moved over to numpy as of some time ago. These were lingering in the generic converter, which I ran into because I was trying to do some generic imports. 