### PR TITLE
tolerate non-GUI backends in plot_init

### DIFF
--- a/pmagpy/pmagplotlib.py
+++ b/pmagpy/pmagplotlib.py
@@ -47,6 +47,7 @@ import os
 import matplotlib
 from matplotlib import cm as color_map
 from matplotlib import pyplot as plt
+from matplotlib.backend_bases import NonGuiException
 from pylab import meshgrid  # matplotlib's meshgrid function
 import matplotlib.ticker as mticker
 globals = 0
@@ -151,14 +152,19 @@ def plot_init(fignum, w, h):
     plt_num += 1
     fig = plt.figure(num=fignum, figsize=(w, h), dpi=dpi, clear=True)
     if (not isServer) and (not set_env.IS_NOTEBOOK):
-        plt.get_current_fig_manager().show()
-        # plt.get_current_fig_manager().window.wm_geometry('+%d+%d' %
-        # (fig_x_pos,fig_y_pos)) # this only works with matplotlib.use('TKAgg')
-        fig_x_pos = fig_x_pos + dpi * (w) + 25
-        if plt_num == 3:
-            plt_num = 0
-            fig_x_pos = 25
-            fig_y_pos = fig_y_pos + dpi * (h) + 25
+        try:
+            plt.get_current_fig_manager().show()
+            # plt.get_current_fig_manager().window.wm_geometry('+%d+%d' %
+            # (fig_x_pos,fig_y_pos)) # this only works with matplotlib.use('TKAgg')
+            fig_x_pos = fig_x_pos + dpi * (w) + 25
+            if plt_num == 3:
+                plt_num = 0
+                fig_x_pos = 25
+                fig_y_pos = fig_y_pos + dpi * (h) + 25
+        except NonGuiException:
+            # non-GUI backend (Agg, inline, the PDF/SVG writers): there is no
+            # window to raise or place, but the figure itself is fine (#781)
+            pass
         plt.figtext(.02, .01, version_num)
 # plt.connect('button_press_event',click)
 #

--- a/pmagpy/test/test_pmagplotlib_backend.py
+++ b/pmagpy/test/test_pmagplotlib_backend.py
@@ -1,0 +1,70 @@
+"""
+Tests for matplotlib backend handling in pmagplotlib.
+
+pmagplotlib.plot_init() raises a figure window when running outside a notebook
+and outside the server. On a non-GUI backend that call used to raise
+NonGuiException (issue #781), which broke plotting from plain scripts, from
+pytest, and from notebook front ends whose shell class was not recognized.
+"""
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.backend_bases import FigureManagerBase
+
+from pmag_env import set_env
+from pmagpy import ipmag, pmagplotlib
+
+
+class GuiManager(FigureManagerBase):
+    """Stand-in for a GUI backend's manager, which overrides show()."""
+
+    def __init__(self):
+        self.shown = False
+
+    def show(self):
+        self.shown = True
+
+
+class TestPlotInit:
+    """Tests for pmagplotlib.plot_init backend handling."""
+
+    @pytest.mark.parametrize("backend", ["Agg", "pdf", "svg"])
+    def test_no_exception_on_non_gui_backends(self, backend):
+        """plot_init does not raise on backends with no window (issue #781)."""
+        assert not set_env.IS_NOTEBOOK, "test assumes a non-notebook shell"
+        assert not pmagplotlib.isServer, "test assumes non-server mode"
+        original = matplotlib.get_backend()
+        try:
+            matplotlib.use(backend, force=True)
+            fig = pmagplotlib.plot_init(1, 5, 5)
+            assert fig is not None
+        finally:
+            plt.close("all")
+            matplotlib.use(original, force=True)
+
+    def test_version_stamp_still_applied(self):
+        """The version stamp is written even when no window can be shown."""
+        fig = pmagplotlib.plot_init(1, 5, 5)
+        texts = [t.get_text() for t in fig.texts]
+        assert any("pmagpy" in t for t in texts), texts
+        plt.close(fig)
+
+    def test_show_called_when_backend_is_interactive(self, monkeypatch):
+        """A GUI backend still gets its window raised -- no over-correction."""
+        manager = GuiManager()
+        monkeypatch.setattr(plt, "get_current_fig_manager", lambda: manager)
+        fig = pmagplotlib.plot_init(1, 5, 5)
+        assert manager.shown is True
+        plt.close(fig)
+
+
+class TestHistplotRegression:
+    """The exact call reported in issue #781."""
+
+    def test_histplot_runs_on_non_gui_backend(self):
+        """ipmag.histplot no longer raises NonGuiException on Agg."""
+        norm = np.random.default_rng(23).normal(size=100)
+        ipmag.histplot(data=norm, xlab='Gaussian Deviates',
+                       save_plots=False, norm=-1)
+        plt.close('all')


### PR DESCRIPTION
`plot_init` called `fig_manager.show()` whenever it was outside a notebook and outside the server. On a non-GUI backend that raises `NonGuiException`, so plotting broke in plain scripts, under pytest, and in some notebook environments. Closes #781