### PR TITLE
Fix validate_upload3 crashes on empty cells (NaN)

### DIFF
--- a/pmagpy/validate_upload3.py
+++ b/pmagpy/validate_upload3.py
@@ -112,7 +112,8 @@ def isIn(row, col_name, arg, dm, df, con=None):
         possible_values = con.tables[table_name].df[table_col_name].unique()
         for value in cell_values:
             if value not in possible_values:
-                trunc_possible_values = [val.replace(' ', '') for val in possible_values if val]
+                trunc_possible_values = [str(val).replace(' ', '') for val in possible_values
+                             if val and not (isinstance(val, float) and math.isnan(val))]
                 trunc_cell_value = cell_value.replace(' ', '')
                 if trunc_cell_value not in trunc_possible_values:
                     if trunc_cell_value != value:
@@ -282,6 +283,8 @@ def test_type(value, value_type):
             flt = float(value)
         except ValueError:
             return '"{}" should be an integer'.format(str(value))
+        if math.isnan(flt):
+            return None          # an empty cell is not a type error
         if math.trunc(flt) == flt:
             return None
         return '"{}" should be an integer'.format(str(value))


### PR DESCRIPTION
Fixes #913.

Two one-line guards in `pmagpy/validate_upload3.py`:

- `test_type`: a blank cell in an Integer-typed column arrives as NaN and crashed `math.trunc` with `ValueError`; NaN is now treated as an empty cell (not a type error), matching how the other value types tolerate blanks.
- `isIn`: NaN entries in a referenced column's values crashed `val.replace` with `AttributeError`; they are now skipped (and values stringified) when building the space-stripped comparison list.

Verified by running `validate_upload3.validate_table` over all tables of `data_files/3_0/McMurdo` and `data_files/dmag_magic` exports: validation now completes and reports the genuine data problems instead of aborting.

Generated by Claude Fable 5 (Claude Code) on behalf of NSH